### PR TITLE
chore: refactor persistence E2E tests to use evaluateStore helper

### DIFF
--- a/docs/2026-01-10-e2e-testing.md
+++ b/docs/2026-01-10-e2e-testing.md
@@ -221,12 +221,18 @@ await page.reload();
 - [x] Create `evaluateStore(page, fn)` helper in `e2e/helpers.ts`
 - [x] Delete `audio.spec.ts` (redundant with transport tests)
 - [x] Fix failing tests (metronome aria-pressed, play button icons, tempo clamping)
+- [x] Refactor 9 persistence tests to use `evaluateStore` (all passing)
+
+### In Progress
+
+**Phase 2: Test refactoring**
+
+- [ ] Refactor 3 piano-roll keyboard tests to use `evaluateStore`
+  - Issue: Notes added via `evaluateStore` don't trigger React re-renders
+  - Store state IS updated (verified), but DOM doesn't update
+  - Needs investigation: Zustand subscription not firing from page.evaluate context?
 
 ### Remaining
-
-**Phase 2: Test refactoring (optional - infrastructure is in place)**
-
-- [ ] Refactor 12 tests per "Test Refactoring Plan" above to use `evaluateStore`
 
 **Phase 3: Additional test coverage (optional)**
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6,6 +6,20 @@ Focused tasks for next few sessions. See `prd.md` for full roadmap.
 
 See `docs/2026-01-10-startup-screen.md` for implementation and follow-up items.
 
+## E2E Test Refactoring (In Progress)
+
+**Goal:** Refactor tests to use `evaluateStore` helper for more robust state setup/verification.
+
+**Doc:** See `docs/2026-01-10-e2e-testing.md`
+
+**Status:**
+- [x] Refactored 9 persistence tests to use `evaluateStore` (PR #3)
+- [ ] 3 piano-roll keyboard tests blocked - store updates via `page.evaluate` don't trigger React re-renders
+
+**Remaining (optional):**
+- [ ] Investigate React re-render issue with external store mutations
+- [ ] Additional test coverage (audio offset, volume sliders, zoom/pan)
+
 ## Audio ↔ State Sync Refactor
 
 **Goal:** Single source of truth, eliminate sync bugs.


### PR DESCRIPTION
## Summary

- Refactored 9 persistence tests to use `evaluateStore` helper for state setup/verification
- Tests are now more robust (no pixel position dependencies) and concise (direct state access)
- Updated task doc with current status

## Test plan

- [x] All 37 E2E tests pass
- [x] TypeScript and lint checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)