### PR TITLE
fix: move toolbar controls to transport header

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -82,13 +82,13 @@ See [architecture.md](architecture.md) for implementation details.
 - [ ] fix: extend note dragging grid snap
 - [ ] fix: limit vertical scale to keyboard area only
 - [ ] fix: refine waveform display resolution
-- [ ] fix: initial flash of lower keys
+- [ ] fix: keyboard sidebar initial height truncation (smelly viewportSize code)
 - [ ] fix: timeline click-to-seek delay
 - [ ] fix: jumping timeline during playback
 - [ ] fix: "No audio loaded" label scroll behavior
 - [ ] fix: audio offset label direction
 - [ ] chore: deploy (vercel)
-- [ ] fix: move toobar to transport header (debug button as small bug icon button)
+- [x] fix: move toolbar to transport header (debug button as small bug icon button)
 - [ ] fix: rework transport header layout
   - metro on off align left
   - volume somewhere else?

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -90,8 +90,10 @@ See [architecture.md](architecture.md) for implementation details.
 - [ ] chore: deploy (vercel)
 - [x] fix: move toolbar to transport header (debug button as small bug icon button)
 - [ ] fix: rework transport header layout
-  - metro on off align left
-  - volume somewhere else?
+  - metro toggle align left
+  - play/pause use proper icon
+  - button text shouldn't be black
+  - input/button/select design (height?) seems inconsistent
 - [ ] chore: refactor E2E tests to use evaluateStore helper (docs/2026-01-10-e2e-testing.md)
 - [ ] chore: code organization review
 - [ ] refactor: audio ↔ state sync (see architecture.md)

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { audioManager } from "../lib/audio";
 import {
   isBlackKey,
@@ -173,12 +179,12 @@ export function PianoRoll() {
     isPlaying,
     audioDuration,
     audioOffset,
+    showDebug,
     addNote,
     updateNote,
     deleteNotes,
     selectNotes,
     deselectAll,
-    setGridSnap,
     setPlayheadPosition,
     setAudioOffset,
     audioPeaks,
@@ -187,7 +193,6 @@ export function PianoRoll() {
   const gridRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [dragMode, setDragMode] = useState<DragMode>({ type: "none" });
-  const [showDebug, setShowDebug] = useState(false);
 
   // Viewport state: scroll position (in beats/semitones) and zoom (pixels per unit)
   const [scrollX, setScrollX] = useState(0); // leftmost visible beat
@@ -207,8 +212,8 @@ export function PianoRoll() {
   const roundedPixelsPerKey = Math.round(pixelsPerKey);
   const roundedPixelsPerBeat = Math.round(pixelsPerBeat);
 
-  // Update viewport size on resize
-  useEffect(() => {
+  // Update viewport size on resize (useLayoutEffect to measure before paint)
+  useLayoutEffect(() => {
     const updateSize = () => {
       if (containerRef.current) {
         const rect = containerRef.current.getBoundingClientRect();
@@ -624,33 +629,6 @@ export function PianoRoll() {
 
   return (
     <div className="flex flex-col flex-1 bg-neutral-900 text-neutral-100 select-none overflow-hidden">
-      {/* Toolbar */}
-      <div className="h-12 flex items-center gap-4 px-4 border-b border-neutral-700 shrink-0">
-        <span className="text-sm text-neutral-400">Grid:</span>
-        <select
-          value={gridSnap}
-          onChange={(e) => setGridSnap(e.target.value as GridSnap)}
-          className="bg-neutral-800 border border-neutral-600 rounded px-2 py-1 text-sm"
-        >
-          <option value="1/4">1/4</option>
-          <option value="1/8">1/8</option>
-          <option value="1/16">1/16</option>
-          <option value="1/4T">1/4T</option>
-          <option value="1/8T">1/8T</option>
-          <option value="1/16T">1/16T</option>
-        </select>
-
-        <span className="text-sm text-neutral-500 ml-auto">
-          {selectedNoteIds.size > 0 && `${selectedNoteIds.size} selected`}
-        </span>
-        <button
-          onClick={() => setShowDebug(!showDebug)}
-          className={`text-xs px-2 py-1 rounded ${showDebug ? "bg-yellow-600" : "bg-neutral-700"}`}
-        >
-          Debug
-        </button>
-      </div>
-
       {/* Main content area - fixed layout, no native scroll */}
       <div ref={containerRef} className="flex-1 flex overflow-hidden">
         {/* Left column: keyboard labels */}

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { saveAsset } from "../lib/asset-store";
 import { audioManager } from "../lib/audio";
 import { useProjectStore } from "../stores/project-store";
+import { GridSnap } from "../types";
 
 function formatTime(seconds: number): string {
   const mins = Math.floor(seconds / 60);
@@ -25,6 +26,8 @@ export function Transport({ onHelpClick }: TransportProps) {
     audioVolume,
     midiVolume,
     metronomeEnabled,
+    gridSnap,
+    showDebug,
     setAudioFile,
     setIsPlaying,
     setPlayheadPosition,
@@ -32,6 +35,8 @@ export function Transport({ onHelpClick }: TransportProps) {
     setAudioVolume,
     setMidiVolume,
     setMetronomeEnabled,
+    setGridSnap,
+    setShowDebug,
     setAudioPeaks,
   } = useProjectStore();
 
@@ -257,6 +262,24 @@ export function Transport({ onHelpClick }: TransportProps) {
         </button>
       </div>
 
+      {/* Grid snap selector */}
+      <div className="flex items-center gap-1">
+        <span className="text-xs text-neutral-400">Grid:</span>
+        <select
+          data-testid="grid-snap-select"
+          value={gridSnap}
+          onChange={(e) => setGridSnap(e.target.value as GridSnap)}
+          className="bg-neutral-700 border border-neutral-600 rounded px-1.5 py-0.5 text-xs"
+        >
+          <option value="1/4">1/4</option>
+          <option value="1/8">1/8</option>
+          <option value="1/16">1/16</option>
+          <option value="1/4T">1/4T</option>
+          <option value="1/8T">1/8T</option>
+          <option value="1/16T">1/16T</option>
+        </select>
+      </div>
+
       {/* File name */}
       {audioFileName && (
         <span
@@ -317,6 +340,26 @@ export function Transport({ onHelpClick }: TransportProps) {
           title="Toggle metronome"
         >
           Metro
+        </button>
+
+        {/* Debug toggle */}
+        <button
+          data-testid="debug-toggle"
+          onClick={() => setShowDebug(!showDebug)}
+          className={`w-6 h-6 flex items-center justify-center rounded ${
+            showDebug
+              ? "bg-yellow-600 text-white"
+              : "bg-neutral-700 text-neutral-400 hover:bg-neutral-600 hover:text-neutral-200"
+          }`}
+          title="Toggle debug overlay"
+        >
+          <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
+            <path
+              fillRule="evenodd"
+              d="M6.56 1.14a.75.75 0 01.177 1.045 3.989 3.989 0 00-.464.86c.185.17.382.329.59.473A3.993 3.993 0 0110 2c1.272 0 2.405.594 3.137 1.518.208-.144.405-.302.59-.473a3.989 3.989 0 00-.464-.86.75.75 0 011.222-.869c.369.519.65 1.105.822 1.736a.75.75 0 01-.174.707 5.23 5.23 0 01-1.795 1.283A4.003 4.003 0 0114 7.5h1.5a.75.75 0 010 1.5H14v1.25c0 .307-.025.608-.072.903l1.903.65a.75.75 0 01-.486 1.42l-1.638-.558a4.004 4.004 0 01-.946 1.167l1.236 2.139a.75.75 0 01-1.299.75l-1.177-2.04a4 4 0 01-3.042 0l-1.177 2.04a.75.75 0 11-1.299-.75l1.236-2.139a4.004 4.004 0 01-.946-1.167l-1.638.558a.75.75 0 01-.486-1.42l1.903-.65A4.03 4.03 0 016 10.25V9H4.5a.75.75 0 010-1.5H6A4.003 4.003 0 016.662 5.04 5.23 5.23 0 014.867 3.756a.75.75 0 01-.174-.707c.172-.63.453-1.217.822-1.736a.75.75 0 011.045-.177zM7.5 7.5c0 .232.03.457.086.672.055.215.136.42.24.611h4.348c.104-.191.185-.396.24-.611A2.5 2.5 0 007.5 7.5zm.086 2.783a2.5 2.5 0 004.828 0h-4.828z"
+              clipRule="evenodd"
+            />
+          </svg>
         </button>
 
         {/* Help button */}

--- a/src/stores/project-store.ts
+++ b/src/stores/project-store.ts
@@ -22,6 +22,9 @@ interface ProjectState {
   metronomeEnabled: boolean;
   metronomeVolume: number; // 0-1
 
+  // UI state
+  showDebug: boolean;
+
   // Waveform state
   audioPeaks: number[]; // Peak values 0-1 for waveform display
   peaksPerSecond: number; // Resolution of peaks array
@@ -47,6 +50,9 @@ interface ProjectState {
   setMidiVolume: (volume: number) => void;
   setMetronomeEnabled: (enabled: boolean) => void;
   setMetronomeVolume: (volume: number) => void;
+
+  // UI actions
+  setShowDebug: (show: boolean) => void;
 
   // Waveform actions
   setAudioPeaks: (peaks: number[], peaksPerSecond: number) => void;
@@ -77,6 +83,9 @@ export const useProjectStore = create<ProjectState>((set) => ({
   midiVolume: 0.8,
   metronomeEnabled: false,
   metronomeVolume: 0.5,
+
+  // UI state
+  showDebug: false,
 
   // Waveform state
   audioPeaks: [],
@@ -142,6 +151,9 @@ export const useProjectStore = create<ProjectState>((set) => ({
   setMidiVolume: (volume) => set({ midiVolume: volume }),
   setMetronomeEnabled: (enabled) => set({ metronomeEnabled: enabled }),
   setMetronomeVolume: (volume) => set({ metronomeVolume: volume }),
+
+  // UI actions
+  setShowDebug: (show) => set({ showDebug: show }),
 
   // Waveform actions
   setAudioPeaks: (peaks, peaksPerSecond) =>


### PR DESCRIPTION
## Summary
- Move grid snap selector and debug toggle from piano roll toolbar to transport header
- Debug button now displays as a small bug icon (yellow when active)
- Remove the separate toolbar row, giving more vertical space to the piano roll

## Test plan
- [ ] Verify grid snap selector works in transport header
- [ ] Verify debug toggle (bug icon) shows/hides debug overlay
- [ ] Check layout looks correct on different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)