### PR TITLE
fix: audio seek sync and MIDI scheduling bugs

### DIFF
--- a/docs/2026-01-11-audio-seek-sync-fix.md
+++ b/docs/2026-01-11-audio-seek-sync-fix.md
@@ -1,0 +1,141 @@
+# Audio Seek & State Sync Fix
+
+**Date:** 2026-01-11
+**Status:** Planning
+
+## Framing
+
+**Tone.Transport is the source of truth** for playback state (playing/stopped/paused, position).
+
+`useTransport` is a **React subscriber** that reflects Transport state to UI. It doesn't "own" state - it just bridges Tone.js events to React state updates.
+
+The bug is: we're missing the timing/event to reflect position changes to React.
+
+---
+
+## Immediate Fix
+
+### Missing `"ticks"` Event
+
+Transport emits `"ticks"` when position changes while stopped. We weren't listening:
+
+```typescript
+// Add to useTransport
+transport.on("ticks", () => setPosition(transport.seconds));
+```
+
+This is a quick fix for the "playhead doesn't jump when paused" bug.
+
+### Remove `position` from `handlePlayPause` deps
+
+Get position from Transport directly to avoid stale state and 60fps callback recreation:
+
+```typescript
+const handlePlayPause = useCallback(() => {
+  if (!isPlaying) {
+    const currentPosition = Tone.getTransport().seconds;
+    audioManager.scheduleNotes(notes, currentPosition, tempo);
+    audioManager.play();
+  } else {
+    audioManager.pause();
+    audioManager.clearScheduledNotes();
+  }
+}, [isPlaying, notes, tempo]);
+```
+
+---
+
+## Open Questions (Follow-up)
+
+These need deeper investigation. Our current Tone.js usage might be subtly wrong.
+
+### 1. Position Change Detection
+
+Is relying on `"ticks"` + RAF the right pattern? Or is there a better Tone.js idiom?
+
+- `"ticks"` only fires when stopped
+- During playback we use RAF polling
+- Is there a more unified approach?
+
+### 2. Seek API
+
+We use `transport.seconds = x`. Is this the right API?
+
+- Does Tone.js have a dedicated seek method?
+- What's the expected behavior when seeking while playing vs stopped?
+
+### 3. Player Sync Pattern
+
+The pause→unsync→resync→resume dance in `setOffset()` feels fragile:
+
+```typescript
+if (wasPlaying) transport.pause();
+this.player.unsync();
+this.player.sync().start(0, this._offset);
+if (wasPlaying) transport.start();
+```
+
+Questions:
+- Is `player.seek()` more appropriate for offset changes?
+- Are there race conditions in this pattern?
+- How do other Tone.js apps handle audio alignment?
+
+### 4. Metronome Sequence Pattern
+
+Similar smell to player sync. The metronome uses `Tone.Sequence` with manual alignment:
+
+```typescript
+this.metronomeSeq = new Tone.Sequence(callback, [1, 0, 0, 0], "4n");
+
+// On enable, calculate next measure boundary
+const nextMeasure = Math.ceil(position / secondsPerMeasure) * secondsPerMeasure;
+this.metronomeSeq.start(nextMeasure);
+```
+
+Questions:
+- Is manual measure alignment the right pattern, or does Tone.js handle this?
+- Should we use `Tone.Loop` instead of `Tone.Sequence`?
+- The "lag" on metronome toggle - is this inherent to the pattern or fixable?
+- Hardcoded 4/4 time signature - how to handle other signatures?
+
+### 5. Reference Patterns
+
+We should look at:
+- Other Tone.js DAW/sequencer examples
+- How Signal (refs/signal) handles transport sync
+- Tone.js examples in refs/Tone.js
+
+---
+
+## Verified Patterns
+
+From Tone.js source research, these are confirmed correct:
+
+| Pattern | Status |
+|---------|--------|
+| `transport.seconds = x` for seeking | ✅ Standard |
+| `player.sync().start(time, offset)` | ✅ Idiomatic |
+| RAF for position during playback | ✅ No continuous event exists |
+
+---
+
+## Status
+
+### Immediate
+
+- [ ] Add `"ticks"` event listener to useTransport
+- [ ] Remove `position` from handlePlayPause deps
+- [ ] Test: seek while paused, seek while playing, MIDI scheduling
+
+### Follow-up (Separate Task)
+
+- [ ] Research position change patterns in Tone.js ecosystem
+- [ ] Evaluate player sync patterns (seek vs unsync/resync)
+- [ ] Evaluate metronome/sequence patterns (Loop vs Sequence, alignment)
+- [ ] Review reference projects for idioms we might be missing
+
+---
+
+## Feedback Log
+
+**2026-01-11:** Initial analysis framed useTransport as "owning" state - this was wrong. Reframed: Tone.Transport is source of truth, useTransport is subscriber. Immediate fix is adding `"ticks"` listener, but larger questions about Tone.js idioms remain open for follow-up.

--- a/docs/2026-01-11-audio-seek-sync-fix.md
+++ b/docs/2026-01-11-audio-seek-sync-fix.md
@@ -76,6 +76,7 @@ if (wasPlaying) transport.start();
 ```
 
 Questions:
+
 - Is `player.seek()` more appropriate for offset changes?
 - Are there race conditions in this pattern?
 - How do other Tone.js apps handle audio alignment?
@@ -93,6 +94,7 @@ this.metronomeSeq.start(nextMeasure);
 ```
 
 Questions:
+
 - Is manual measure alignment the right pattern, or does Tone.js handle this?
 - Should we use `Tone.Loop` instead of `Tone.Sequence`?
 - The "lag" on metronome toggle - is this inherent to the pattern or fixable?
@@ -101,6 +103,7 @@ Questions:
 ### 5. Reference Patterns
 
 We should look at:
+
 - Other Tone.js DAW/sequencer examples
 - How Signal (refs/signal) handles transport sync
 - Tone.js examples in refs/Tone.js
@@ -111,11 +114,11 @@ We should look at:
 
 From Tone.js source research, these are confirmed correct:
 
-| Pattern | Status |
-|---------|--------|
-| `transport.seconds = x` for seeking | ✅ Standard |
-| `player.sync().start(time, offset)` | ✅ Idiomatic |
-| RAF for position during playback | ✅ No continuous event exists |
+| Pattern                             | Status                        |
+| ----------------------------------- | ----------------------------- |
+| `transport.seconds = x` for seeking | ✅ Standard                   |
+| `player.sync().start(time, offset)` | ✅ Idiomatic                  |
+| RAF for position during playback    | ✅ No continuous event exists |
 
 ---
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -87,6 +87,10 @@ See [architecture.md](architecture.md) for implementation details.
   - [ ] fix: remove unnecessary null checks in AudioManager
   - [ ] fix: metronome toggle is laggy
   - [ ] feat: persist lastPlayheadPosition
+  - [ ] fix: `transport.bpm` source of truth instead of `store.tempo`
+  - [ ] fix: playback scheduling shouldn't be driven directly by UI effect
+  - [ ] refactor: align naming with Tone.js (e.g. position -> seconds, etc.)
+    - reduce trivial re-expose Tone.js from audioManager
 - [ ] fix: extend note dragging grid snap
 - [ ] fix: limit vertical scale to keyboard area only
 - [ ] fix: keyboard sidebar initial height truncation (smelly viewportSize code)
@@ -95,8 +99,6 @@ See [architecture.md](architecture.md) for implementation details.
 - [ ] chore: deploy (vercel)
 - [ ] chore: refactor E2E tests to use evaluateStore helper (docs/2026-01-10-e2e-testing.md)
 - [ ] chore: code organization review
-- [ ] refactor: align naming with Tone.js (e.g. position -> seconds, etc.)
-  - reduce trivial re-expose Tone.js from audioManager
 - [ ] test: test audio context playback
   - no need to test what users hear, but can we test transport state?
 - [ ] refactor: refactor debug panel

--- a/e2e/transport.spec.ts
+++ b/e2e/transport.spec.ts
@@ -133,7 +133,7 @@ test.describe("Transport Controls", () => {
   });
 });
 
-test.describe.skip("Timeline Seek", () => {
+test.describe("Timeline Seek", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
     await clickNewProject(page);

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -1055,6 +1055,7 @@ function Timeline({
 
   return (
     <div
+      data-testid="timeline"
       className="relative shrink-0 bg-neutral-850 border-b border-neutral-700 cursor-pointer"
       style={{ height: TIMELINE_HEIGHT }}
       onClick={handleClick}
@@ -1063,6 +1064,7 @@ function Timeline({
       {/* Playhead indicator */}
       {showPlayhead && (
         <div
+          data-testid="timeline-playhead"
           className="absolute top-0 bottom-0 w-px bg-sky-400 pointer-events-none"
           style={{ left: playheadX }}
         />

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -62,6 +62,12 @@ export function Transport({ onHelpClick }: TransportProps) {
     audioManager.setMetronomeVolume(metronomeVolume);
   }, [metronomeVolume]);
 
+  // TODO: playback scheduling shouldn't be driven directly by UI effect.
+  // instead, we should do:
+  // - store -> UI
+  // - UI event -> store update
+  // - Tone.transport event + store event -> AudioManager schedule notes
+  // == stale comment ==
   // Dynamically update scheduled notes when notes or tempo change during playback
   // Note: Don't depend on `position` - it updates at 60fps during playback!
   // Get current position from Transport directly when needed.

--- a/src/hooks/use-transport.ts
+++ b/src/hooks/use-transport.ts
@@ -46,14 +46,21 @@ export function useTransport() {
       setPosition(Tone.getTransport().seconds);
     };
 
+    // Position changed while stopped (e.g., timeline click to seek)
+    const handleTicks = () => {
+      setPosition(Tone.getTransport().seconds);
+    };
+
     transport.on("start", handleStart);
     transport.on("stop", handleStop);
     transport.on("pause", handlePause);
+    transport.on("ticks", handleTicks);
 
     return () => {
       transport.off("start", handleStart);
       transport.off("stop", handleStop);
       transport.off("pause", handlePause);
+      transport.off("ticks", handleTicks);
       cancelAnimationFrame(rafRef.current);
     };
   }, []);

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -148,11 +148,6 @@ class AudioManager {
     Tone.getTransport().pause();
   }
 
-  stop(): void {
-    Tone.getTransport().stop();
-    Tone.getTransport().seconds = 0;
-  }
-
   seek(seconds: number): void {
     const transport = Tone.getTransport();
     const wasPlaying = transport.state === "started";


### PR DESCRIPTION
## Summary

- Fixes playhead not jumping when clicking timeline while paused
- Fixes MIDI playback broken after moving playhead
- Documents Tone.js pattern questions for follow-up

## Root Cause

`useTransport` wasn't listening to Transport's `"ticks"` event, which fires when position changes while stopped.

## Plan

See `docs/2026-01-11-audio-seek-sync-fix.md` for full analysis.

**Immediate fixes:**
- [ ] Add `"ticks"` event listener to useTransport
- [ ] Remove `position` from handlePlayPause deps
- [ ] E2E tests for seek behavior

**Follow-up (separate task):**
- Evaluate player sync patterns
- Evaluate metronome sequence patterns
- Research Tone.js idioms

🤖 Generated with [Claude Code](https://claude.com/claude-code)