### PR TITLE
fix: selective subscription for setNotes and syncAudioTrack

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -104,7 +104,7 @@ _Audio/Playback_
   - [ ] refactor: align naming with Tone.js (e.g. position -> seconds, etc.)
     - reduce trivial re-expose Tone.js from audioManager
 - [ ] follow up docs/2026-01-11-state-management-principles.md
-  - [ ] fix: selective subscription for setNotes and syncAudioTrack
+  - [x] fix: selective subscription for setNotes and syncAudioTrack
     - currently any zustand update triggers applyState() which resets internal state
     - setNotes() clears all notes and re-adds them (causes MIDI glitch)
     - syncAudioTrack() unsync/resync player (causes audio glitch)

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -52,8 +52,8 @@ export function App() {
       }
 
       audioManager.applyState(useProjectStore.getState());
-      useProjectStore.subscribe((state) => {
-        audioManager.applyState(state);
+      useProjectStore.subscribe((state, prevState) => {
+        audioManager.applyState(state, prevState);
       });
 
       // Setup auto-save on state changes (debounced)


### PR DESCRIPTION
## Summary

- Use `prevState` from Zustand `subscribe()` to avoid expensive operations on unrelated state changes
- `setNotes()` only called when `notes` changes (avoids clearing/rebuilding MIDI Part)
- `syncAudioTrack()` only called when `audioOffset` changes (avoids unsync/resync glitch)
- Added `player.loaded` guard to prevent errors when no audio is loaded

## Test plan

- [ ] Manual test: create notes, change volume - verify no audio glitch
- [ ] Manual test: drag audio waveform offset - verify sync still works
- [ ] Existing E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)