### PR TITLE
refactor: make auto-save debounce configurable for faster E2E tests

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -414,7 +414,7 @@ App mounts → loadProject() from localStorage
 ### Save Flow
 
 ```
-Any state change → debounced 500ms → saveProject() to localStorage
+Any state change → debounced (default 500ms, configurable via VITE_AUTO_SAVE_DEBOUNCE_MS) → saveProject() to localStorage
 Audio loaded → saveAsset() to IndexedDB (once per file)
 ```
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -143,7 +143,7 @@ _Chores/Refactoring_
 - [ ] refactor: use UI library for common components
 - [ ] refactor: don't swallow error. use toast with log.
 - [ ] refactor: simplify pixelsPerBeat/pixelsPerKey to discrete integer levels (e.g. 1,2,3,4,6,8,12,16,24,32,48,64,96,128,192) for simpler state and guaranteed zoom roundtrip
-- [ ] refactor: reduce auto-save debounce timeout (currently 500ms) to speed up E2E tests that still need waitForTimeout after state changes
+- [x] refactor: reduce auto-save debounce timeout (currently 500ms) to speed up E2E tests that still need waitForTimeout after state changes
 
 ### Backlog
 

--- a/e2e/multiple-projects.spec.ts
+++ b/e2e/multiple-projects.spec.ts
@@ -35,7 +35,7 @@ test.describe("Multiple Projects", () => {
     });
 
     // Wait for auto-save
-    await page.waitForTimeout(600);
+    await page.waitForTimeout(100);
 
     // Get first project ID
     const project1Id = await getLastProjectId(page);

--- a/e2e/persistence.spec.ts
+++ b/e2e/persistence.spec.ts
@@ -32,8 +32,8 @@ test.describe("Project Persistence", () => {
     const note = page.locator("[data-testid^='note-']");
     await expect(note).toHaveCount(1);
 
-    // Wait for auto-save (debounced at 500ms)
-    await page.waitForTimeout(600);
+    // Wait for auto-save
+    await page.waitForTimeout(100);
 
     // Reload the page and click Continue to restore
     await page.reload();
@@ -93,7 +93,7 @@ test.describe("Project Persistence", () => {
     await expect(page.locator("[data-testid^='note-']")).toHaveCount(3);
 
     // Wait for auto-save
-    await page.waitForTimeout(600);
+    await page.waitForTimeout(100);
 
     // Reload and click Continue to restore
     await page.reload();
@@ -117,7 +117,7 @@ test.describe("Project Persistence", () => {
     await page.waitForTimeout(500);
 
     // Wait for auto-save
-    await page.waitForTimeout(600);
+    await page.waitForTimeout(100);
 
     // Reload and click Continue to restore
     await page.reload();
@@ -153,7 +153,7 @@ test.describe("Project Persistence", () => {
     await expect(metronomeToggle).toHaveAttribute("aria-pressed", "true");
 
     // Wait for auto-save
-    await page.waitForTimeout(600);
+    await page.waitForTimeout(100);
 
     // Reload and click Continue to restore
     await page.reload();
@@ -200,7 +200,7 @@ test.describe("Project Persistence", () => {
     if (!movedBox) throw new Error("Note not found after move");
 
     // Wait for auto-save
-    await page.waitForTimeout(600);
+    await page.waitForTimeout(100);
 
     // Reload and click Continue to restore
     await page.reload();
@@ -253,7 +253,7 @@ test.describe("Project Persistence", () => {
     await expect(page.locator("[data-testid^='note-']")).toHaveCount(1);
 
     // Wait for auto-save
-    await page.waitForTimeout(600);
+    await page.waitForTimeout(100);
 
     // Reload and click Continue to restore
     await page.reload();
@@ -280,7 +280,7 @@ test.describe("Project Persistence", () => {
     await expect(note).toHaveAttribute("data-selected", "true");
 
     // Wait for auto-save
-    await page.waitForTimeout(600);
+    await page.waitForTimeout(100);
 
     // Reload and click Continue to restore
     await page.reload();
@@ -318,7 +318,7 @@ test.describe("Project Persistence", () => {
     expect(changedScrollX).toBe(25);
 
     // Wait for auto-save
-    await page.waitForTimeout(600);
+    await page.waitForTimeout(100);
 
     // Reload and click Continue to restore
     await page.reload();

--- a/e2e/startup-screen.spec.ts
+++ b/e2e/startup-screen.spec.ts
@@ -57,7 +57,7 @@ test.describe("Startup Screen", () => {
     });
 
     // Wait for auto-save
-    await page.waitForTimeout(600);
+    await page.waitForTimeout(100);
 
     // Reload - continue button should now be visible
     await page.reload();

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./e2e",
   webServer: {
-    command: "npm run dev",
+    command: "VITE_AUTO_SAVE_DEBOUNCE_MS=50 npm run dev",
     url: "http://localhost:5173",
     reuseExistingServer: !process.env.CI,
   },

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -80,7 +80,9 @@ export function App() {
 
       // Setup auto-save on state changes (debounced)
       // projectId is captured in closure - no need for Zustand
-      // TODO: reduce timeout on E2E to reduce lengthy watiForTimeout
+      const autoSaveDebounceMs = Number(
+        import.meta.env.VITE_AUTO_SAVE_DEBOUNCE_MS ?? 500,
+      );
       let saveTimeout: number;
       useProjectStore.subscribe(() => {
         clearTimeout(saveTimeout);
@@ -94,7 +96,7 @@ export function App() {
             console.error("Failed to save project:", e);
             toast.error("Failed to save project. Changes may be lost.");
           }
-        }, 500);
+        }, autoSaveDebounceMs);
       });
 
       return { projectId };


### PR DESCRIPTION
## Summary

- Add `VITE_AUTO_SAVE_DEBOUNCE_MS` env var to configure auto-save debounce (defaults to 500ms)
- Set 50ms debounce in `playwright.config.ts` for E2E tests
- Update all E2E `waitForTimeout` from 600ms to 100ms

## Benchmark

| Branch | Time |
|--------|------|
| main (before) | 14.7s |
| feature (after) | 14.1s |

~0.6s improvement (tests run in parallel so gains are less than the sum of individual savings)

---

*Generated with [OpenCode](https://opencode.ai) using Claude Sonnet 4*