### PR TITLE
fix: keyboard preview note follows mouse down/up

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -125,7 +125,7 @@ _Audio/Playback_
   - eliminates subscription/sync complexity
   - enables incremental updates (addNote adds to Part, not rebuild all)
   - may not need zustand - could be simpler custom store
-- [ ] preview note on/off should follow mouse down/up
+- [x] preview note on/off should follow mouse down/up
 
 _Project management_
 
@@ -144,11 +144,11 @@ _UI polish_
 
 - [ ] fix: keyboard sidebar initial height truncation (smelly viewportSize code)
 - [x] fix: "No audio loaded" label scroll behavior
-- [ ] fix: press "Space" to continue on startup screen isntead of "Enter"
+- [x] fix: press "Space" to continue on startup screen isntead of "Enter"
 
 _Misc_
 
-- [ ] feat: export ABC notation (file export + clipbaord for quick LLM usage)
+- [x] feat: export ABC notation (file export + clipbaord for quick LLM usage)
 - [ ] feat: support fret position annotation metadata
 - [x] feat: full review quick reference and what's missing
 

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -1320,14 +1320,20 @@ function Keyboard({
   const lastPlayedPitch = useRef<number | null>(null);
 
   useWindowEvent("mouseup", () => {
+    if (lastPlayedPitch.current !== null) {
+      audioManager.noteOff(lastPlayedPitch.current);
+    }
     setIsDragging(false);
     lastPlayedPitch.current = null;
   });
 
   const playPitch = useCallback((pitch: number) => {
     if (lastPlayedPitch.current !== pitch) {
+      if (lastPlayedPitch.current !== null) {
+        audioManager.noteOff(lastPlayedPitch.current);
+      }
       lastPlayedPitch.current = pitch;
-      audioManager.playNote(pitch);
+      audioManager.noteOn(pitch);
     }
   }, []);
 

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -317,6 +317,15 @@ class AudioManager {
     this.midiSynth.triggerAttackRelease(pitch, duration, 100);
   }
 
+  // Note preview with manual control (for keyboard interaction)
+  noteOn(pitch: number): void {
+    this.midiSynth.noteOn(pitch, 100);
+  }
+
+  noteOff(pitch: number): void {
+    this.midiSynth.noteOff(pitch);
+  }
+
   // Volume controls (0-1)
   setAudioVolume(volume: number): void {
     this.audioChannel.volume.rampTo(


### PR DESCRIPTION
## Summary

- Keyboard preview note now sustains while mouse button is held down
- Note stops when mouse button is released
- Properly handles sliding between keys (stops previous note, starts new one)

Previously, clicking a keyboard key played a fixed 0.5s note. Now it provides a more natural piano-like feel where you control the duration.

## Test plan

- [ ] Click and hold a keyboard key - note should sustain
- [ ] Release mouse button - note should stop
- [ ] Click and drag across multiple keys - each key should sound as you slide over it

🤖 Generated with [Claude Code](https://claude.com/claude-code)