### PR TITLE
feat: add ability to remove audio track

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -114,6 +114,7 @@ _Audio/Playback_
 
 - [ ] fix: drag timeline (currently cannot even move timeline bar at exact zero)
 - [x] feat: remove audio track (menu + select + Delete key)
+- [ ] feat: undo/redo audio track operations (move, remove)
 - [ ] feat: trim audio track length (start and end)
 - [ ] feat: higher resolution waveform at zoom (canvas instead of svg?)
 - [ ] follow up docs/2026-01-11-audio-seek-sync-fix.md, docs/2026-01-10-audio-state-sync-refactor.md

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -113,7 +113,7 @@ _Timeline/Viewport_
 _Audio/Playback_
 
 - [ ] fix: drag timeline (currently cannot even move timeline bar at exact zero)
-- [ ] feat: remove audio track
+- [x] feat: remove audio track (menu + select + Delete key)
 - [ ] feat: trim audio track length (start and end)
 - [ ] feat: higher resolution waveform at zoom (canvas instead of svg?)
 - [ ] follow up docs/2026-01-11-audio-seek-sync-fix.md, docs/2026-01-10-audio-state-sync-refactor.md
@@ -160,6 +160,10 @@ _Chores/Refactoring_
   - `src/components/piano-roll.tsx:315` - `screenToGrid`
   - `src/components/piano-roll.tsx:333` - `gridToScreen`
 - [ ] chore: refactor E2E tests to use evaluateStore helper (docs/2026-01-10-e2e-testing.md)
+- [ ] chore: consolidate E2E tests into user flows (reduce setup overhead)
+  - locators.spec.ts: 10 tests → ~4 (combine add/select/delete/deselect)
+  - undo-redo.spec.ts: 9 tests → ~4 (combine create/delete/move/resize undo+redo)
+  - copy-paste.spec.ts: 8 tests → ~4 (combine paste/snap/preserve/selection)
 - [ ] chore: code organization review
 - [ ] test: test audio context playback (docs/2026-01-11-e2e-audio-context-testing.md)
 - [ ] refactor: refactor debug panel

--- a/e2e/transport.spec.ts
+++ b/e2e/transport.spec.ts
@@ -256,18 +256,23 @@ test.describe("Audio Track", () => {
   }
 
   test("remove audio via settings menu", async ({ page }) => {
+    // Remove button should be disabled when no audio loaded
+    await page.getByTestId("settings-button").click();
+    const removeButton = page.getByTestId("remove-audio-button");
+    await expect(removeButton).toBeDisabled();
+    await page.keyboard.press("Escape");
+
     // Load audio file
     await loadAudioFile(page);
 
-    // Verify waveform is visible (audio region exists)
+    // Verify waveform is visible
     const audioRegion = page
       .locator(".bg-emerald-700, .bg-emerald-600")
       .first();
     await expect(audioRegion).toBeVisible();
 
-    // Open settings and click Remove Audio
+    // Remove button should now be enabled
     await page.getByTestId("settings-button").click();
-    const removeButton = page.getByTestId("remove-audio-button");
     await expect(removeButton).toBeEnabled();
     await removeButton.click();
 
@@ -275,79 +280,36 @@ test.describe("Audio Track", () => {
     await expect(audioRegion).not.toBeVisible();
   });
 
-  test("remove audio button is disabled when no audio loaded", async ({
-    page,
-  }) => {
-    await page.getByTestId("settings-button").click();
-    const removeButton = page.getByTestId("remove-audio-button");
-    await expect(removeButton).toBeDisabled();
-  });
-
-  test("select audio track by clicking", async ({ page }) => {
+  test("select, deselect, and delete audio track", async ({ page }) => {
     await loadAudioFile(page);
 
-    // Click on the audio region to select it
     const audioRegion = page
       .locator(".bg-emerald-700, .bg-emerald-600")
       .first();
-    await audioRegion.click();
-
-    // Should have ring-2 class when selected
-    await expect(audioRegion).toHaveClass(/ring-2/);
-  });
-
-  test("delete selected audio track with Delete key", async ({ page }) => {
-    await loadAudioFile(page);
-
-    // Click on the audio region to select it
-    const audioRegion = page
-      .locator(".bg-emerald-700, .bg-emerald-600")
-      .first();
-    await audioRegion.click();
-    await expect(audioRegion).toHaveClass(/ring-2/);
-
-    // Press Delete to remove the audio
-    await page.keyboard.press("Delete");
-
-    // Verify audio region is gone
-    await expect(audioRegion).not.toBeVisible();
-  });
-
-  test("deselect audio track with Escape key", async ({ page }) => {
-    await loadAudioFile(page);
-
-    // Click on the audio region to select it
-    const audioRegion = page
-      .locator(".bg-emerald-700, .bg-emerald-600")
-      .first();
-    await audioRegion.click();
-    await expect(audioRegion).toHaveClass(/ring-2/);
-
-    // Press Escape to deselect
-    await page.keyboard.press("Escape");
-
-    // Should no longer have ring-2 class
-    await expect(audioRegion).not.toHaveClass(/ring-2/);
-    // Audio should still be there (opacity-85 instead of ring-2)
-    await expect(audioRegion).toBeVisible();
-  });
-
-  test("clicking piano roll grid deselects audio track", async ({ page }) => {
-    await loadAudioFile(page);
-
-    // Click on the audio region to select it
-    const audioRegion = page
-      .locator(".bg-emerald-700, .bg-emerald-600")
-      .first();
-    await audioRegion.click();
-    await expect(audioRegion).toHaveClass(/ring-2/);
-
-    // Click on the piano roll grid
     const pianoRoll = page.getByTestId("piano-roll-grid");
-    await pianoRoll.click({ position: { x: 200, y: 100 } });
 
-    // Audio track should be deselected
+    // Click to select - should show ring
+    await audioRegion.click();
+    await expect(audioRegion).toHaveClass(/ring-2/);
+
+    // Escape to deselect - ring gone but audio still there
+    await page.keyboard.press("Escape");
     await expect(audioRegion).not.toHaveClass(/ring-2/);
+    await expect(audioRegion).toBeVisible();
+
+    // Click to select again
+    await audioRegion.click();
+    await expect(audioRegion).toHaveClass(/ring-2/);
+
+    // Click grid to deselect
+    await pianoRoll.click({ position: { x: 200, y: 100 } });
+    await expect(audioRegion).not.toHaveClass(/ring-2/);
+
+    // Click to select and delete with Delete key
+    await audioRegion.click();
+    await expect(audioRegion).toHaveClass(/ring-2/);
+    await page.keyboard.press("Delete");
+    await expect(audioRegion).not.toBeVisible();
   });
 });
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,9 +3,12 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./e2e",
   webServer: {
-    command: "VITE_AUTO_SAVE_DEBOUNCE_MS=50 pnpm dev --port 5183",
+    command: "pnpm dev --port 5183",
     url: "http://localhost:5183",
     reuseExistingServer: false,
+    env: {
+      VITE_AUTO_SAVE_DEBOUNCE_MS: "50",
+    },
   },
   use: {
     baseURL: "http://localhost:5183",

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -246,6 +246,7 @@ export function PianoRoll() {
     audioDuration,
     audioOffset,
     audioFileName,
+    isAudioTrackSelected,
     showDebug,
     autoScrollEnabled,
     addNote,
@@ -254,6 +255,8 @@ export function PianoRoll() {
     selectNotes,
     deselectAll,
     setAudioOffset,
+    setAudioTrackSelected,
+    clearAudioFile,
     audioPeaks,
     undo,
     redo,
@@ -386,10 +389,13 @@ export function PianoRoll() {
         deleteNotes(Array.from(selectedNoteIds));
       } else if (selectedLocatorId) {
         deleteLocator(selectedLocatorId);
+      } else if (isAudioTrackSelected) {
+        clearAudioFile();
       }
     } else if (e.key === "Escape") {
       deselectAll();
       selectLocator(null);
+      setAudioTrackSelected(false);
     } else if (e.key === "c" && (e.ctrlKey || e.metaKey)) {
       // Ctrl+C or Cmd+C: Copy
       e.preventDefault();
@@ -510,6 +516,7 @@ export function PianoRoll() {
   const handleGridMouseDown = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       if (e.button !== 0) return;
+      setAudioTrackSelected(false);
       const { beat, pitch } = screenToGrid(e.clientX, e.clientY);
       const snappedBeat = snapToGrid(beat, gridSnapValue);
       const rect = gridRef.current!.getBoundingClientRect();
@@ -680,6 +687,7 @@ export function PianoRoll() {
       gridToScreen,
       selectNotes,
       deselectAll,
+      setAudioTrackSelected,
     ],
   );
 
@@ -1053,8 +1061,14 @@ export function PianoRoll() {
             audioPeaks={audioPeaks}
             height={waveformHeight}
             beatsPerBar={beatsPerBar}
+            isSelected={isAudioTrackSelected}
             onOffsetChange={setAudioOffset}
             onHeightChange={setWaveformHeight}
+            onSelect={() => {
+              deselectAll();
+              selectLocator(null);
+              setAudioTrackSelected(true);
+            }}
           />
           {/* Note grid with CSS background */}
           <div
@@ -1597,8 +1611,10 @@ function WaveformArea({
   audioPeaks,
   height,
   beatsPerBar,
+  isSelected,
   onOffsetChange,
   onHeightChange,
+  onSelect,
 }: {
   pixelsPerBeat: number;
   gridSnap: GridSnap;
@@ -1612,8 +1628,10 @@ function WaveformArea({
   audioPeaks: number[];
   height: number;
   beatsPerBar: number;
+  isSelected: boolean;
   onOffsetChange: (offset: number) => void;
   onHeightChange: (height: number) => void;
+  onSelect: () => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isDragging, setIsDragging] = useState(false);
@@ -1655,6 +1673,7 @@ function WaveformArea({
 
   const handleMouseDown = (e: React.MouseEvent) => {
     if (audioDuration === 0) return;
+    onSelect();
     setIsDragging(true);
     dragStartRef.current = { x: e.clientX, startOffset: audioOffset };
   };
@@ -1713,11 +1732,11 @@ function WaveformArea({
       {/* Audio region block */}
       {audioDuration > 0 && (
         <div
-          className={`absolute top-1 bottom-1 rounded cursor-ew-resize overflow-hidden opacity-85 ${
+          className={`absolute top-1 bottom-1 rounded cursor-ew-resize overflow-hidden ${
             isDragging
               ? "bg-emerald-600"
               : "bg-emerald-700 hover:bg-emerald-600"
-          }`}
+          } ${isSelected ? "ring-2 ring-sky-400" : "opacity-85"}`}
           style={{
             left: audioStartX,
             width: Math.max(audioWidth, 4),

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -9,6 +9,7 @@ import {
   PencilIcon,
   PlayIcon,
   SettingsIcon,
+  Trash2Icon,
   UploadIcon,
   Volume2Icon,
 } from "lucide-react";
@@ -21,7 +22,7 @@ import {
   downloadABCFile,
   exportABC,
 } from "../lib/abc-export";
-import { saveAsset } from "../lib/asset-store";
+import { deleteAsset, saveAsset } from "../lib/asset-store";
 import { audioManager, GM_PROGRAMS, loadAudioFile } from "../lib/audio";
 import { downloadMidiFile, exportMidi } from "../lib/midi-export";
 import { useProjectStore } from "../stores/project-store";
@@ -98,6 +99,7 @@ export function Transport({
 }: TransportProps) {
   const {
     audioFileName,
+    audioAssetKey,
     tempo,
     timeSignature,
     notes,
@@ -122,6 +124,7 @@ export function Transport({
     setAudioFile,
     setAudioOffset,
     setAudioPeaks,
+    clearAudioFile,
   } = useProjectStore();
 
   // Transport state from hook (source of truth: Tone.js Transport)
@@ -157,6 +160,17 @@ export function Transport({
     }
     // Reset input so same file can be selected again
     e.target.value = "";
+  };
+
+  const handleRemoveAudio = async () => {
+    // Delete from IndexedDB if we have a key
+    if (audioAssetKey) {
+      await deleteAsset(audioAssetKey);
+    }
+    // Clear the audio buffer in the player
+    audioManager.clearAudioBuffer();
+    // Clear store state
+    clearAudioFile();
   };
 
   const handlePlayPause = useCallback(() => {
@@ -684,6 +698,16 @@ export function Transport({
           >
             <UploadIcon className="size-4" />
             {loadAudioMutation.isPending ? "Loading..." : "Load Audio"}
+          </DropdownMenuItem>
+
+          {/* Remove Audio */}
+          <DropdownMenuItem
+            data-testid="remove-audio-button"
+            onClick={handleRemoveAudio}
+            disabled={!audioFileName}
+          >
+            <Trash2Icon className="size-4" />
+            Remove Audio
           </DropdownMenuItem>
 
           {/* Export MIDI */}

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -294,6 +294,12 @@ class AudioManager {
     this.player.sync().start(offset);
   }
 
+  clearAudioBuffer(): void {
+    this.player.stop();
+    this.player.unsync();
+    this.player.buffer = new Tone.ToneAudioBuffer();
+  }
+
   // TODO: incremental add / remove
   setNotes(notes: Note[]): void {
     this.midiPart.clear();

--- a/src/stores/project-store.ts
+++ b/src/stores/project-store.ts
@@ -85,6 +85,7 @@ export interface ProjectState {
   // Audio actions
   setAudioFile: (fileName: string, duration: number, assetKey: string) => void;
   setAudioOffset: (offset: number) => void;
+  clearAudioFile: () => void;
 
   // Mixer actions
   setAudioVolume: (volume: number) => void;
@@ -309,6 +310,15 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     }),
 
   setAudioOffset: (offset) => set({ audioOffset: offset }),
+
+  clearAudioFile: () =>
+    set({
+      audioFileName: null,
+      audioAssetKey: null,
+      audioDuration: 0,
+      audioOffset: 0,
+      audioPeaks: [],
+    }),
 
   // Mixer actions
   setAudioVolume: (volume) => set({ audioVolume: volume }),

--- a/src/stores/project-store.ts
+++ b/src/stores/project-store.ts
@@ -25,6 +25,7 @@ export interface ProjectState {
   audioAssetKey: string | null; // Reference to IndexedDB asset
   audioDuration: number; // in seconds
   audioOffset: number; // in seconds - timeline position where audio starts (>= 0)
+  isAudioTrackSelected: boolean;
 
   // Mixer state
   audioVolume: number; // 0-1
@@ -86,6 +87,7 @@ export interface ProjectState {
   setAudioFile: (fileName: string, duration: number, assetKey: string) => void;
   setAudioOffset: (offset: number) => void;
   clearAudioFile: () => void;
+  setAudioTrackSelected: (selected: boolean) => void;
 
   // Mixer actions
   setAudioVolume: (volume: number) => void;
@@ -137,6 +139,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   audioAssetKey: null,
   audioDuration: 0,
   audioOffset: 0,
+  isAudioTrackSelected: false,
 
   // Mixer state
   audioVolume: 0.8,
@@ -318,7 +321,10 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       audioDuration: 0,
       audioOffset: 0,
       audioPeaks: [],
+      isAudioTrackSelected: false,
     }),
+
+  setAudioTrackSelected: (selected) => set({ isAudioTrackSelected: selected }),
 
   // Mixer actions
   setAudioVolume: (volume) => set({ audioVolume: volume }),


### PR DESCRIPTION
## Summary
- Add "Remove Audio" menu item in Settings dropdown
- Clears audio from IndexedDB, Tone.js player buffer, and project store
- Option is disabled when no audio track is loaded

## Test plan
- [ ] Load an audio file
- [ ] Verify "Remove Audio" menu item becomes enabled
- [ ] Click "Remove Audio"
- [ ] Verify waveform disappears and audio stops playing
- [ ] Verify the option becomes disabled again

🤖 Generated with [Claude Code](https://claude.com/claude-code)