### PR TITLE
chore: consolidate E2E tests into user flows

### DIFF
--- a/e2e/locators.spec.ts
+++ b/e2e/locators.spec.ts
@@ -7,123 +7,24 @@ test.describe("Locators", () => {
     await clickNewProject(page);
   });
 
-  test("add locator with L key", async ({ page }) => {
-    // Press L to add locator at playhead (starts at beat 0)
-    await page.keyboard.press("l");
-
-    // Check that locator was created
-    const locator = page.locator("[data-testid^='locator-']");
-    await expect(locator).toHaveCount(1);
-
-    // Check that label is visible
-    await expect(locator.getByText("Section 1")).toBeVisible();
-  });
-
-  test("add multiple locators", async ({ page }) => {
+  test("add, select, delete, and deselect locators", async ({ page }) => {
     const timeline = page.getByTestId("timeline");
     const timelineBox = await timeline.boundingBox();
     if (!timelineBox) throw new Error("Timeline not found");
-
-    // Add first locator at beat 0
-    await page.keyboard.press("l");
-
-    // Seek to beat 4 and add second locator
-    await page.mouse.click(
-      timelineBox.x + 320,
-      timelineBox.y + timelineBox.height / 2,
-    );
-    await page.keyboard.press("l");
-
-    // Check that both locators exist
     const locators = page.locator("[data-testid^='locator-']");
-    await expect(locators).toHaveCount(2);
 
-    // Check labels
+    // Add first locator at beat 0 (auto-selected)
+    await page.keyboard.press("l");
+    await expect(locators).toHaveCount(1);
     await expect(page.getByText("Section 1")).toBeVisible();
-    await expect(page.getByText("Section 2")).toBeVisible();
-  });
 
-  test("select locator", async ({ page }) => {
-    // Add a locator
-    await page.keyboard.press("l");
-
-    const locator = page.locator("[data-testid^='locator-']").first();
-    await expect(locator).toBeVisible();
-
-    // Locator is auto-selected after creation, verify it's highlighted
-    const triangleDiv = locator.locator("div").first();
-    await expect(triangleDiv).toHaveClass(/border-t-amber-400/);
-  });
-
-  test("delete locator with Delete key", async ({ page }) => {
-    // Add a locator (auto-selected)
-    await page.keyboard.press("l");
-
-    const locator = page.locator("[data-testid^='locator-']");
-    await expect(locator).toHaveCount(1);
-
-    // Press Delete key
-    await page.keyboard.press("Delete");
-
-    // Locator should be deleted
-    await expect(locator).toHaveCount(0);
-  });
-
-  test("delete locator with Backspace key", async ({ page }) => {
-    // Add a locator (auto-selected)
-    await page.keyboard.press("l");
-
-    const locator = page.locator("[data-testid^='locator-']");
-    await expect(locator).toHaveCount(1);
-
-    // Press Backspace key
-    await page.keyboard.press("Backspace");
-
-    // Locator should be deleted
-    await expect(locator).toHaveCount(0);
-  });
-
-  test("deselect locator with Escape key", async ({ page }) => {
-    // Add a locator (auto-selected)
-    await page.keyboard.press("l");
-
-    const locator = page.locator("[data-testid^='locator-']").first();
-
-    // Verify selected (amber color)
-    const triangleDiv = locator.locator("div").first();
+    // Verify auto-selected (amber color)
+    const triangleDiv = locators.first().locator("div").first();
     await expect(triangleDiv).toHaveClass(/border-t-amber-400/);
 
-    // Press Escape
+    // Deselect with Escape
     await page.keyboard.press("Escape");
-
-    // Verify deselected (neutral color)
     await expect(triangleDiv).toHaveClass(/border-neutral-500/);
-  });
-
-  test("locators persist across zoom", async ({ page }) => {
-    // Add a locator
-    await page.keyboard.press("l");
-    await expect(page.getByText("Section 1")).toBeVisible();
-
-    // Zoom in (Ctrl+Wheel)
-    const grid = page.getByTestId("piano-roll-grid");
-    const gridBox = await grid.boundingBox();
-    if (!gridBox) throw new Error("Grid not found");
-
-    await page.mouse.move(gridBox.x + 100, gridBox.y + 100);
-    await page.mouse.wheel(0, -100);
-
-    // Locator should still be visible
-    await expect(page.getByText("Section 1")).toBeVisible();
-  });
-
-  test("locators persist after page reload", async ({ page }) => {
-    const timeline = page.getByTestId("timeline");
-    const timelineBox = await timeline.boundingBox();
-    if (!timelineBox) throw new Error("Timeline not found");
-
-    // Add first locator at beat 0
-    await page.keyboard.press("l");
 
     // Seek to beat 4 and add second locator
     await page.mouse.click(
@@ -131,24 +32,19 @@ test.describe("Locators", () => {
       timelineBox.y + timelineBox.height / 2,
     );
     await page.keyboard.press("l");
-
-    // Wait for auto-save
-    await page.waitForTimeout(1000);
-
-    // Verify locators exist
-    await expect(page.getByText("Section 1")).toBeVisible();
+    await expect(locators).toHaveCount(2);
     await expect(page.getByText("Section 2")).toBeVisible();
 
-    // Reload page
-    await page.reload();
+    // Delete second locator with Delete key (it's auto-selected)
+    await page.keyboard.press("Delete");
+    await expect(locators).toHaveCount(1);
+    await expect(page.getByText("Section 2")).not.toBeVisible();
 
-    // Click "Continue" to restore project
-    await page.getByTestId("continue-button").click();
-    await page.getByTestId("transport").waitFor({ state: "visible" });
-
-    // Verify locators persisted
-    await expect(page.getByText("Section 1")).toBeVisible();
-    await expect(page.getByText("Section 2")).toBeVisible();
+    // Re-add and delete with Backspace
+    await page.keyboard.press("l");
+    await expect(locators).toHaveCount(2);
+    await page.keyboard.press("Backspace");
+    await expect(locators).toHaveCount(1);
   });
 
   test("rename locator via double-click", async ({ page }) => {
@@ -171,5 +67,46 @@ test.describe("Locators", () => {
     // Verify label changed
     await expect(page.getByText("Intro")).toBeVisible();
     await expect(page.getByText("Section 1")).not.toBeVisible();
+  });
+
+  test("locators persist across zoom and reload", async ({ page }) => {
+    const timeline = page.getByTestId("timeline");
+    const timelineBox = await timeline.boundingBox();
+    if (!timelineBox) throw new Error("Timeline not found");
+
+    // Add first locator at beat 0
+    await page.keyboard.press("l");
+    await expect(page.getByText("Section 1")).toBeVisible();
+
+    // Seek to beat 4 and add second locator
+    await page.mouse.click(
+      timelineBox.x + 320,
+      timelineBox.y + timelineBox.height / 2,
+    );
+    await page.keyboard.press("l");
+    await expect(page.getByText("Section 2")).toBeVisible();
+
+    // Zoom in (Ctrl+Wheel) - verify locators persist
+    const grid = page.getByTestId("piano-roll-grid");
+    const gridBox = await grid.boundingBox();
+    if (!gridBox) throw new Error("Grid not found");
+    await page.mouse.move(gridBox.x + 100, gridBox.y + 100);
+    await page.mouse.wheel(0, -100);
+    await expect(page.getByText("Section 1")).toBeVisible();
+    await expect(page.getByText("Section 2")).toBeVisible();
+
+    // Wait for auto-save
+    await page.waitForTimeout(1000);
+
+    // Reload page
+    await page.reload();
+
+    // Click "Continue" to restore project
+    await page.getByTestId("continue-button").click();
+    await page.getByTestId("transport").waitFor({ state: "visible" });
+
+    // Verify locators persisted after reload
+    await expect(page.getByText("Section 1")).toBeVisible();
+    await expect(page.getByText("Section 2")).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- Consolidate related E2E tests to reduce setup overhead
- locators.spec.ts: 10 → 3 tests (combine add/select/delete/deselect)
- undo-redo.spec.ts: 9 → 4 tests (combine create/delete, move/resize, multi-ops)
- copy-paste.spec.ts: 8 → 4 tests (combine paste/snap, multi-note, edge cases)
- Total reduction: 27 → 11 tests (59% fewer test setups)

## Test plan
- [x] All 11 consolidated tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)