### PR TITLE
feat: add useDraftInput hook for commit-on-enter inputs

### DIFF
--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -16,6 +16,7 @@ import {
 import { useRef } from "react";
 import { toast } from "sonner";
 import * as Tone from "tone";
+import { useDraftInput } from "../hooks/use-draft-input";
 import { useTransport } from "../hooks/use-transport";
 import { useWindowEvent } from "../hooks/use-window-event";
 import {
@@ -186,6 +187,13 @@ export function Transport({
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const tapTimesRef = useRef<number[]>([]);
+
+  const tempoInput = useDraftInput({
+    value: tempo,
+    onCommit: setTempo,
+    min: 30,
+    max: 300,
+  });
 
   const loadAudioMutation = useMutation({
     mutationFn: async (file: File) => {
@@ -377,22 +385,9 @@ export function Transport({
         <span className="text-muted-foreground">BPM:</span>
         <input
           data-testid="tempo-input"
-          type="number"
-          min={30}
-          max={300}
-          value={tempo}
-          onChange={(e) => {
-            const value = Number.parseInt(e.target.value, 10);
-            if (!Number.isNaN(value)) {
-              setTempo(value);
-            }
-          }}
-          onBlur={(e) => {
-            const value = Number.parseInt(e.target.value, 10);
-            if (!Number.isNaN(value)) {
-              setTempo(Math.min(300, Math.max(30, value)));
-            }
-          }}
+          type="text"
+          inputMode="numeric"
+          {...tempoInput.props}
           className="w-14 h-8 px-1 text-sm font-mono bg-input border border-border rounded text-center text-foreground"
         />
         <Button

--- a/src/hooks/use-draft-input.ts
+++ b/src/hooks/use-draft-input.ts
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+
+type UseDraftInputOptions = {
+  value: number;
+  onCommit: (value: number) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+};
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Hook for numeric inputs that only commit on Enter or blur.
+ * Supports arrow keys and increment/decrement for fine control.
+ *
+ * @example
+ * ```tsx
+ * const bpmInput = useDraftInput({
+ *   value: tempo,
+ *   onCommit: setTempo,
+ *   min: 30,
+ *   max: 300,
+ *   step: 1,
+ * });
+ *
+ * <input type="text" inputMode="numeric" {...bpmInput.props} />
+ * ```
+ */
+export function useDraftInput({
+  value,
+  onCommit,
+  min = -Infinity,
+  max = Infinity,
+  step = 1,
+}: UseDraftInputOptions) {
+  const [draft, setDraft] = useState(String(value));
+
+  useEffect(() => {
+    setDraft(String(value));
+  }, [value]);
+
+  const commit = () => {
+    const n = Number.parseInt(draft, 10);
+    if (!Number.isNaN(n)) {
+      onCommit(clamp(n, min, max));
+    } else {
+      setDraft(String(value)); // Reset on invalid input
+    }
+  };
+
+  const reset = () => setDraft(String(value));
+
+  const increment = () => onCommit(clamp(value + step, min, max));
+  const decrement = () => onCommit(clamp(value - step, min, max));
+
+  return {
+    draft,
+    setDraft,
+    commit,
+    reset,
+    increment,
+    decrement,
+    props: {
+      value: draft,
+      onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+        setDraft(e.target.value),
+      onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter") {
+          commit();
+          e.currentTarget.blur();
+        } else if (e.key === "Escape") {
+          reset();
+          e.currentTarget.blur();
+        } else if (e.key === "ArrowUp") {
+          e.preventDefault();
+          increment();
+        } else if (e.key === "ArrowDown") {
+          e.preventDefault();
+          decrement();
+        }
+      },
+      onBlur: commit,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Add `useDraftInput` hook for numeric inputs that only commit on Enter/blur
- Replace fully reactive BPM input with draft-based approach
- Support arrow up/down keys for increment/decrement

## Test plan
- [ ] Type in BPM field - value should not change until Enter or blur
- [ ] Press Escape - value should reset to original
- [ ] Press Arrow Up/Down - value should increment/decrement immediately
- [ ] Tap tempo still works and updates the input

🤖 Generated with [Claude Code](https://claude.com/claude-code)