### PR TITLE
feat: add project settings dialog with document.title sync

### DIFF
--- a/e2e/multiple-projects.spec.ts
+++ b/e2e/multiple-projects.spec.ts
@@ -351,6 +351,9 @@ test.describe("Multiple Projects", () => {
 
     const projectId = await getLastProjectId(page);
 
+    // Verify initial document title
+    await expect(page).toHaveTitle("Untitled - Toy MIDI");
+
     // Open settings dropdown and click project settings
     await page.getByTestId("settings-button").click();
     await page.getByTestId("project-settings-button").click();
@@ -360,6 +363,9 @@ test.describe("Multiple Projects", () => {
     await expect(nameInput).toHaveValue("Untitled");
     await nameInput.fill("My Bass Track");
     await nameInput.press("Enter");
+
+    // Verify document title updated
+    await expect(page).toHaveTitle("My Bass Track - Toy MIDI");
 
     // Verify the name was changed by going to startup screen
     await page.reload();

--- a/e2e/multiple-projects.spec.ts
+++ b/e2e/multiple-projects.spec.ts
@@ -351,17 +351,15 @@ test.describe("Multiple Projects", () => {
 
     const projectId = await getLastProjectId(page);
 
-    // Open settings dropdown and click rename
+    // Open settings dropdown and click project settings
     await page.getByTestId("settings-button").click();
+    await page.getByTestId("project-settings-button").click();
 
-    // Set up prompt dialog handler
-    page.once("dialog", async (dialog) => {
-      expect(dialog.message()).toContain("Rename project");
-      expect(dialog.defaultValue()).toBe("Untitled");
-      await dialog.accept("My Bass Track");
-    });
-
-    await page.getByTestId("rename-project-button").click();
+    // Fill in the new name in the dialog
+    const nameInput = page.getByTestId("project-name-input");
+    await expect(nameInput).toHaveValue("Untitled");
+    await nameInput.fill("My Bass Track");
+    await nameInput.press("Enter");
 
     // Verify the name was changed by going to startup screen
     await page.reload();

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap"
       rel="stylesheet"
     />
-    <title>toy-midi</title>
+    <title>Toy MIDI</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/project-settings-dialog.tsx
+++ b/src/components/project-settings-dialog.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useRef, useState } from "react";
+import { Button } from "./ui/button";
+
+type ProjectSettingsDialogProps = {
+  isOpen: boolean;
+  projectName: string;
+  onSave: (name: string) => void;
+  onClose: () => void;
+};
+
+export function ProjectSettingsDialog({
+  isOpen,
+  projectName,
+  onSave,
+  onClose,
+}: ProjectSettingsDialogProps) {
+  const [name, setName] = useState(projectName);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Reset form when opening
+  useEffect(() => {
+    if (isOpen) {
+      setName(projectName);
+      // Focus and select on next frame
+      requestAnimationFrame(() => inputRef.current?.select());
+    }
+  }, [isOpen, projectName]);
+
+  if (!isOpen) return null;
+
+  const handleSave = () => {
+    const trimmed = name.trim();
+    if (trimmed && trimmed !== projectName) {
+      onSave(trimmed);
+    }
+    onClose();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSave();
+    }
+  };
+
+  return (
+    <div
+      data-testid="project-settings-dialog"
+      className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-neutral-800 rounded-lg shadow-2xl w-full max-w-md"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="border-b border-neutral-700 px-6 py-4 flex justify-between items-center">
+          <h2 className="text-lg font-semibold text-neutral-100">
+            Project Settings
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-neutral-400 hover:text-neutral-200 text-2xl leading-none"
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-6 space-y-4">
+          <div>
+            <label
+              htmlFor="project-name"
+              className="block text-sm font-medium text-neutral-300 mb-2"
+            >
+              Project Name
+            </label>
+            <input
+              ref={inputRef}
+              id="project-name"
+              data-testid="project-name-input"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={handleKeyDown}
+              className="w-full h-10 px-3 text-sm bg-neutral-900 border border-neutral-600 rounded text-neutral-100 focus:outline-none focus:border-neutral-500"
+              placeholder="Enter project name"
+            />
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-neutral-700 px-6 py-4 flex justify-end gap-3">
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave}>Save</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -6,7 +6,6 @@ import {
   FolderIcon,
   MusicIcon,
   PauseIcon,
-  PencilIcon,
   PlayIcon,
   SettingsIcon,
   Trash2Icon,
@@ -144,15 +143,15 @@ function PlayPauseButton() {
 }
 
 type TransportProps = {
+  onProjectSettingsClick: () => void;
   onHelpClick: () => void;
   onProjectsClick: () => void;
-  onRenameProject: () => void;
 };
 
 export function Transport({
+  onProjectSettingsClick,
   onHelpClick,
   onProjectsClick,
-  onRenameProject,
 }: TransportProps) {
   const {
     audioFileName,
@@ -690,13 +689,13 @@ export function Transport({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-48">
-          {/* Rename Project */}
+          {/* Project Settings */}
           <DropdownMenuItem
-            data-testid="rename-project-button"
-            onClick={onRenameProject}
+            data-testid="project-settings-button"
+            onClick={onProjectSettingsClick}
           >
-            <PencilIcon className="size-4" />
-            Rename Project
+            <SettingsIcon className="size-4" />
+            Project Settings
           </DropdownMenuItem>
 
           {/* Projects */}


### PR DESCRIPTION
## Summary
- Add `ProjectSettingsDialog` component for editing project name
- Show project name in `document.title` (browser tab shows "ProjectName - Toy MIDI")
- Move project settings to Settings dropdown menu
- Standardize app title to "Toy MIDI" across codebase

## Test plan
- [ ] Open Settings dropdown → click "Project Settings"
- [ ] Edit project name in dialog, press Enter or click Save
- [ ] Verify browser tab title updates to "NewName - Toy MIDI"
- [ ] Press Escape or click outside to cancel without saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)