### PR TITLE
feat: add searchable instrument selector

### DIFF
--- a/e2e/transport.spec.ts
+++ b/e2e/transport.spec.ts
@@ -133,7 +133,7 @@ test.describe("Transport Controls", () => {
 
     // Open and select a different instrument
     await instrumentSelect.click();
-    await page.getByRole("option", { name: /24:.*Acoustic Guitar/ }).click();
+    await page.locator('[data-slot="command-item"]', { hasText: "24: Acoustic Guitar" }).click();
 
     // Should show new instrument
     await expect(instrumentSelect).toContainText("Acoustic Guitar");
@@ -144,6 +144,34 @@ test.describe("Transport Controls", () => {
     await expect(page.getByTestId("instrument-select")).toContainText(
       "Acoustic Guitar",
     );
+  });
+
+  test("instrument selector search", async ({ page }) => {
+    const instrumentSelect = page.getByTestId("instrument-select");
+
+    // Open selector
+    await instrumentSelect.click();
+
+    // Type to search
+    const searchInput = page.locator('[data-slot="command-input"]');
+    await searchInput.fill("violin");
+
+    // Should filter to show only violin
+    const items = page.locator('[data-slot="command-item"]');
+    await expect(items).toHaveCount(1);
+    await expect(items.first()).toContainText("Violin");
+
+    // Select it
+    await items.first().click();
+    await expect(instrumentSelect).toContainText("Violin");
+
+    // Open again and search for something else
+    await instrumentSelect.click();
+    await searchInput.fill("synth");
+
+    // Should show multiple synth instruments
+    const synthItems = page.locator('[data-slot="command-item"]');
+    expect(await synthItems.count()).toBeGreaterThan(5);
   });
 
   test("export MIDI workflow", async ({ page }) => {

--- a/e2e/transport.spec.ts
+++ b/e2e/transport.spec.ts
@@ -133,7 +133,9 @@ test.describe("Transport Controls", () => {
 
     // Open and select a different instrument
     await instrumentSelect.click();
-    await page.locator('[data-slot="command-item"]', { hasText: "24: Acoustic Guitar" }).click();
+    await page
+      .locator('[data-slot="command-item"]', { hasText: "24: Acoustic Guitar" })
+      .click();
 
     // Should show new instrument
     await expect(instrumentSelect).toContainText("Acoustic Guitar");

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.4",
@@ -22,6 +23,7 @@
     "@tonejs/midi": "^2.0.28",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "lucide-react": "^0.562.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.16
         version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-popover':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -35,6 +38,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.3)
@@ -462,6 +468,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-direction@1.1.1':
     resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
     peerDependencies:
@@ -530,6 +549,19 @@ packages:
 
   '@radix-ui/react-menu@2.1.16':
     resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.15':
+    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1096,6 +1128,12 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1883,6 +1921,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.7)(react@19.2.3)
+      aria-hidden: 1.2.6
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-remove-scroll: 2.7.2(@types/react@19.2.7)(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
   '@radix-ui/react-direction@1.1.1(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       react: 19.2.3
@@ -1959,6 +2019,29 @@ snapshots:
       '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.7)(react@19.2.3)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      aria-hidden: 1.2.6
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-remove-scroll: 2.7.2(@types/react@19.2.7)(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.7)(react@19.2.3)
       aria-hidden: 1.2.6
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
@@ -2466,6 +2549,18 @@ snapshots:
       clsx: 2.1.1
 
   clsx@2.1.1: {}
+
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   convert-source-map@2.0.0: {}
 

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -179,10 +179,11 @@ function InstrumentCombobox({
       <PopoverTrigger asChild>
         <Button
           data-testid="instrument-select"
-          variant="outline"
+          variant="ghost"
+          size="sm"
           role="combobox"
           aria-expanded={open}
-          className="h-8 w-44 justify-between text-xs font-normal"
+          className="w-44 justify-between font-normal"
         >
           <span className="truncate">
             {value}: {GM_PROGRAMS[value]}

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -1,5 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import {
+  CheckIcon,
+  ChevronsUpDownIcon,
   CircleHelpIcon,
   ClipboardIcon,
   DownloadIcon,
@@ -13,7 +15,7 @@ import {
   UploadIcon,
   Volume2Icon,
 } from "lucide-react";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 import * as Tone from "tone";
 import { useTransport } from "../hooks/use-transport";
@@ -30,6 +32,14 @@ import { useProjectStore } from "../stores/project-store";
 import { COMMON_TIME_SIGNATURES, type GridSnap } from "../types";
 import { Button } from "./ui/button";
 import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "./ui/command";
+import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
@@ -40,15 +50,7 @@ import {
   DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectTrigger,
-  SelectValue,
-} from "./ui/select";
+import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { Slider } from "./ui/slider";
 
 function MetronomeIcon({ className }: { className?: string }) {
@@ -140,6 +142,88 @@ function PlayPauseButton() {
         <PlayIcon data-testid="play-icon" className="size-5" />
       )}
     </Button>
+  );
+}
+
+// GM instrument groups for organized display
+const INSTRUMENT_GROUPS = [
+  { label: "Piano", start: 0, end: 8 },
+  { label: "Chromatic Percussion", start: 8, end: 16 },
+  { label: "Organ", start: 16, end: 24 },
+  { label: "Guitar", start: 24, end: 32 },
+  { label: "Bass", start: 32, end: 40 },
+  { label: "Strings", start: 40, end: 48 },
+  { label: "Ensemble", start: 48, end: 56 },
+  { label: "Brass", start: 56, end: 64 },
+  { label: "Reed", start: 64, end: 72 },
+  { label: "Pipe", start: 72, end: 80 },
+  { label: "Synth Lead", start: 80, end: 88 },
+  { label: "Synth Pad", start: 88, end: 96 },
+  { label: "Synth Effects", start: 96, end: 104 },
+  { label: "Ethnic", start: 104, end: 112 },
+  { label: "Percussive", start: 112, end: 120 },
+  { label: "Sound Effects", start: 120, end: 128 },
+] as const;
+
+function InstrumentCombobox({
+  value,
+  onValueChange,
+}: {
+  value: number;
+  onValueChange: (value: number) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          data-testid="instrument-select"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="h-8 w-44 justify-between text-xs font-normal"
+        >
+          <span className="truncate">
+            {value}: {GM_PROGRAMS[value]}
+          </span>
+          <ChevronsUpDownIcon className="ml-1 size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64 p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search instruments..." />
+          <CommandList>
+            <CommandEmpty>No instrument found.</CommandEmpty>
+            {INSTRUMENT_GROUPS.map((group) => (
+              <CommandGroup key={group.label} heading={group.label}>
+                {GM_PROGRAMS.slice(group.start, group.end).map((name, i) => {
+                  const program = group.start + i;
+                  return (
+                    <CommandItem
+                      key={program}
+                      value={`${program}: ${name}`}
+                      onSelect={() => {
+                        onValueChange(program);
+                        setOpen(false);
+                      }}
+                      className="text-xs"
+                    >
+                      <CheckIcon
+                        className={`mr-2 size-4 ${
+                          value === program ? "opacity-100" : "opacity-0"
+                        }`}
+                      />
+                      {program}: {name}
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            ))}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -473,206 +557,7 @@ export function Transport({
       <div className="w-px h-5 bg-border" />
 
       {/* Instrument selector */}
-      <Select
-        value={String(midiProgram)}
-        onValueChange={(v) => setMidiProgram(Number(v))}
-      >
-        <SelectTrigger
-          data-testid="instrument-select"
-          className="h-8 w-44 text-xs"
-        >
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent
-          position="popper"
-          className="max-h-64 [&>[data-slot=select-scroll-up-button]]:hidden [&>[data-slot=select-scroll-down-button]]:hidden"
-        >
-          <SelectGroup>
-            <SelectLabel>Piano</SelectLabel>
-            {GM_PROGRAMS.slice(0, 8).map((name, i) => (
-              <SelectItem key={i} value={String(i)} className="text-xs">
-                {i}: {name}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-          <SelectGroup>
-            <SelectLabel>Chromatic Percussion</SelectLabel>
-            {GM_PROGRAMS.slice(8, 16).map((name, i) => (
-              <SelectItem key={i + 8} value={String(i + 8)} className="text-xs">
-                {i + 8}: {name}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-          <SelectGroup>
-            <SelectLabel>Organ</SelectLabel>
-            {GM_PROGRAMS.slice(16, 24).map((name, i) => (
-              <SelectItem
-                key={i + 16}
-                value={String(i + 16)}
-                className="text-xs"
-              >
-                {i + 16}: {name}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-          <SelectGroup>
-            <SelectLabel>Guitar</SelectLabel>
-            {GM_PROGRAMS.slice(24, 32).map((name, i) => (
-              <SelectItem
-                key={i + 24}
-                value={String(i + 24)}
-                className="text-xs"
-              >
-                {i + 24}: {name}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-          <SelectGroup>
-            <SelectLabel>Bass</SelectLabel>
-            {GM_PROGRAMS.slice(32, 40).map((name, i) => (
-              <SelectItem
-                key={i + 32}
-                value={String(i + 32)}
-                className="text-xs"
-              >
-                {i + 32}: {name}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-          <SelectGroup>
-            <SelectLabel>Strings</SelectLabel>
-            {GM_PROGRAMS.slice(40, 48).map((name, i) => (
-              <SelectItem
-                key={i + 40}
-                value={String(i + 40)}
-                className="text-xs"
-              >
-                {i + 40}: {name}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-          <SelectGroup>
-            <SelectLabel>Ensemble</SelectLabel>
-            {GM_PROGRAMS.slice(48, 56).map((name, i) => (
-              <SelectItem
-                key={i + 48}
-                value={String(i + 48)}
-                className="text-xs"
-              >
-                {i + 48}: {name}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-          <SelectGroup>
-            <SelectLabel>Brass</SelectLabel>
-            {GM_PROGRAMS.slice(56, 64).map((name, i) => (
-              <SelectItem
-                key={i + 56}
-                value={String(i + 56)}
-                className="text-xs"
-              >
-                {i + 56}: {name}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-          <SelectGroup>
-            <SelectLabel>Reed</SelectLabel>
-            {GM_PROGRAMS.slice(64, 72).map((name, i) => (
-              <SelectItem
-                key={i + 64}
-                value={String(i + 64)}
-                className="text-xs"
-              >
-                {i + 64}: {name}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-          <SelectGroup>
-            <SelectLabel>Pipe</SelectLabel>
-            {GM_PROGRAMS.slice(72, 80).map((name, i) => (
-              <SelectItem
-                key={i + 72}
-                value={String(i + 72)}
-                className="text-xs"
-              >
-                {i + 72}: {name}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-          <SelectGroup>
-            <SelectLabel>Synth Lead</SelectLabel>
-            {GM_PROGRAMS.slice(80, 88).map((name, i) => (
-              <SelectItem
-                key={i + 80}
-                value={String(i + 80)}
-                className="text-xs"
-              >
-                {i + 80}: {name}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-          <SelectGroup>
-            <SelectLabel>Synth Pad</SelectLabel>
-            {GM_PROGRAMS.slice(88, 96).map((name, i) => (
-              <SelectItem
-                key={i + 88}
-                value={String(i + 88)}
-                className="text-xs"
-              >
-                {i + 88}: {name}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-          <SelectGroup>
-            <SelectLabel>Synth Effects</SelectLabel>
-            {GM_PROGRAMS.slice(96, 104).map((name, i) => (
-              <SelectItem
-                key={i + 96}
-                value={String(i + 96)}
-                className="text-xs"
-              >
-                {i + 96}: {name}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-          <SelectGroup>
-            <SelectLabel>Ethnic</SelectLabel>
-            {GM_PROGRAMS.slice(104, 112).map((name, i) => (
-              <SelectItem
-                key={i + 104}
-                value={String(i + 104)}
-                className="text-xs"
-              >
-                {i + 104}: {name}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-          <SelectGroup>
-            <SelectLabel>Percussive</SelectLabel>
-            {GM_PROGRAMS.slice(112, 120).map((name, i) => (
-              <SelectItem
-                key={i + 112}
-                value={String(i + 112)}
-                className="text-xs"
-              >
-                {i + 112}: {name}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-          <SelectGroup>
-            <SelectLabel>Sound Effects</SelectLabel>
-            {GM_PROGRAMS.slice(120, 128).map((name, i) => (
-              <SelectItem
-                key={i + 120}
-                value={String(i + 120)}
-                className="text-xs"
-              >
-                {i + 120}: {name}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-        </SelectContent>
-      </Select>
+      <InstrumentCombobox value={midiProgram} onValueChange={setMidiProgram} />
 
       {/* Spacer */}
       <div className="flex-1" />

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { Command as CommandPrimitive } from "cmdk";
+import { SearchIcon } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  );
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "text-foreground [&_[data-slot=command-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[data-slot=command-group-heading]]:px-2 [&_[data-slot=command-group-heading]]:py-1.5 [&_[data-slot=command-group-heading]]:text-xs [&_[data-slot=command-group-heading]]:font-medium",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("bg-border -mx-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+};

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+}
+
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger };


### PR DESCRIPTION
## Summary
- Replace Radix Select with Popover + Command (cmdk) for the instrument selector
- Users can now type to search/filter through 128 GM MIDI programs
- Preserves instrument groups (Piano, Strings, Brass, etc.) with keyboard navigation

## Test plan
- [ ] Open instrument selector dropdown
- [ ] Type to filter (e.g., "piano", "violin", "synth")
- [ ] Use arrow keys to navigate, Enter to select
- [ ] Verify checkmark shows current selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)