### PR TITLE
feat: project settings dialog & startup screen improvements

### DIFF
--- a/e2e/multiple-projects.spec.ts
+++ b/e2e/multiple-projects.spec.ts
@@ -351,6 +351,9 @@ test.describe("Multiple Projects", () => {
 
     const projectId = await getLastProjectId(page);
 
+    // Verify initial document title
+    await expect(page).toHaveTitle("Untitled - Toy MIDI");
+
     // Open settings dropdown and click project settings
     await page.getByTestId("settings-button").click();
     await page.getByTestId("project-settings-button").click();
@@ -360,6 +363,9 @@ test.describe("Multiple Projects", () => {
     await expect(nameInput).toHaveValue("Untitled");
     await nameInput.fill("My Bass Track");
     await nameInput.press("Enter");
+
+    // Verify document title updated
+    await expect(page).toHaveTitle("My Bass Track - Toy MIDI");
 
     // Verify the name was changed by going to startup screen
     await page.reload();

--- a/e2e/multiple-projects.spec.ts
+++ b/e2e/multiple-projects.spec.ts
@@ -351,17 +351,15 @@ test.describe("Multiple Projects", () => {
 
     const projectId = await getLastProjectId(page);
 
-    // Open settings dropdown and click rename
+    // Open settings dropdown and click project settings
     await page.getByTestId("settings-button").click();
+    await page.getByTestId("project-settings-button").click();
 
-    // Set up prompt dialog handler
-    page.once("dialog", async (dialog) => {
-      expect(dialog.message()).toContain("Rename project");
-      expect(dialog.defaultValue()).toBe("Untitled");
-      await dialog.accept("My Bass Track");
-    });
-
-    await page.getByTestId("rename-project-button").click();
+    // Fill in the new name in the dialog
+    const nameInput = page.getByTestId("project-name-input");
+    await expect(nameInput).toHaveValue("Untitled");
+    await nameInput.fill("My Bass Track");
+    await nameInput.press("Enter");
 
     // Verify the name was changed by going to startup screen
     await page.reload();

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap"
       rel="stylesheet"
     />
-    <title>toy-midi</title>
+    <title>Toy MIDI</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -258,146 +258,162 @@ function ProjectListView({
   return (
     <div
       data-testid="startup-screen"
-      className="fixed inset-0 bg-neutral-900 flex items-center justify-center z-50"
+      className="fixed inset-0 bg-neutral-900 flex items-center justify-center z-50 overflow-hidden"
     >
-      <div className="flex flex-col items-center gap-6 max-w-2xl w-full px-4">
-        <h1 className="text-2xl font-semibold text-neutral-200">Toy MIDI</h1>
+      {/* Gradient glow */}
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_80%_50%_at_center,#10b98125_0%,transparent_70%)] pointer-events-none" />
 
-        {hasProjects && (
-          <div className="w-full max-h-96 overflow-y-auto bg-neutral-800 rounded-lg p-4">
-            <h2 className="text-lg font-medium text-neutral-300 mb-3">
-              Recent Projects
-            </h2>
-            <div className="space-y-2">
-              {projects.map((project) => {
-                const isLastProject = project.id === lastProjectId;
-                return (
-                  <div
-                    key={project.id}
-                    data-testid={`project-card-${project.id}`}
-                    aria-current={isLastProject ? "true" : undefined}
-                    className={`w-full px-4 py-3 rounded-lg transition-colors ${
-                      isLastProject
-                        ? "bg-emerald-900/30 hover:bg-emerald-900/40 border-2 border-emerald-700/50"
-                        : "bg-neutral-700 hover:bg-neutral-600"
-                    }`}
-                  >
-                    {renamingProjectId === project.id ? (
-                      <div className="flex items-center gap-2">
-                        <input
-                          data-testid={`rename-input-${project.id}`}
-                          type="text"
-                          value={renameValue}
-                          onChange={(e) => setRenameValue(e.target.value)}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter") {
-                              handleRenameSubmit(project.id);
-                            } else if (e.key === "Escape") {
-                              handleRenameCancel();
-                            }
-                          }}
-                          className="flex-1 px-2 py-1 bg-neutral-800 border border-neutral-600 rounded text-neutral-200 text-sm focus:outline-none focus:border-neutral-500"
-                          onFocus={(e) => e.target.select()}
-                        />
-                        <button
-                          type="button"
-                          onClick={() => handleRenameSubmit(project.id)}
-                          className="px-2 py-1 bg-emerald-600 hover:bg-emerald-500 text-white rounded text-sm"
-                        >
-                          Save
-                        </button>
-                        <button
-                          type="button"
-                          onClick={handleRenameCancel}
-                          className="px-2 py-1 bg-neutral-600 hover:bg-neutral-500 text-neutral-200 rounded text-sm"
-                        >
-                          Cancel
-                        </button>
-                      </div>
-                    ) : (
-                      <div className="flex justify-between items-start">
-                        <button
-                          type="button"
-                          onClick={() => onSelectProject(project.id)}
-                          className="flex-1 text-left"
-                        >
-                          <div className="text-neutral-200 font-medium">
-                            {project.name}
-                          </div>
-                          <div className="text-neutral-500 text-sm">
-                            {new Date(project.updatedAt).toLocaleDateString()}{" "}
-                            {new Date(project.updatedAt).toLocaleTimeString(
-                              [],
-                              {
-                                hour: "2-digit",
-                                minute: "2-digit",
-                              },
-                            )}
-                          </div>
-                        </button>
-                        <div className="flex items-center gap-1">
+      <div className="flex flex-col items-center gap-8 w-full px-6 relative">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold text-neutral-100 tracking-tight">
+            Toy MIDI
+          </h1>
+          <p className="text-neutral-500 mt-2">A simple piano roll editor</p>
+        </div>
+
+        {hasProjects ? (
+          <>
+            <div className="w-full max-w-lg">
+              <h2 className="text-sm font-medium text-neutral-400 uppercase tracking-wider mb-4">
+                Your Projects
+              </h2>
+              <div className="space-y-3 max-h-80 overflow-y-auto">
+                {projects.map((project) => {
+                  const isLastProject = project.id === lastProjectId;
+                  return (
+                    <div
+                      key={project.id}
+                      data-testid={`project-card-${project.id}`}
+                      aria-current={isLastProject ? "true" : undefined}
+                      className={`group w-full h-20 px-5 rounded-xl border transition-colors flex items-center ${
+                        isLastProject
+                          ? "bg-emerald-900/25 hover:bg-emerald-900/35 border-emerald-700/50"
+                          : "bg-neutral-800/60 hover:bg-neutral-800 border-neutral-700/50"
+                      }`}
+                    >
+                      {renamingProjectId === project.id ? (
+                        <div className="flex items-center gap-3 flex-1">
+                          <input
+                            data-testid={`rename-input-${project.id}`}
+                            type="text"
+                            value={renameValue}
+                            onChange={(e) => setRenameValue(e.target.value)}
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter") {
+                                handleRenameSubmit(project.id);
+                              } else if (e.key === "Escape") {
+                                handleRenameCancel();
+                              }
+                            }}
+                            className="flex-1 px-3 py-1.5 bg-neutral-900 border border-neutral-600 rounded-lg text-neutral-200 text-lg focus:outline-none focus:border-emerald-500"
+                            onFocus={(e) => e.target.select()}
+                          />
                           <button
                             type="button"
-                            data-testid={`rename-button-${project.id}`}
-                            onClick={(e) =>
-                              handleRenameStart(e, project.id, project.name)
-                            }
-                            className="p-1.5 hover:bg-neutral-500 rounded transition-colors"
-                            title="Rename project"
+                            onClick={() => handleRenameSubmit(project.id)}
+                            className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 text-white rounded-lg text-sm font-medium"
                           >
-                            <Pencil className="size-4 text-neutral-300" />
+                            Save
                           </button>
                           <button
                             type="button"
-                            data-testid={`delete-button-${project.id}`}
-                            onClick={(e) => handleDelete(e, project.id)}
-                            className="p-1.5 hover:bg-red-600 rounded transition-colors"
-                            title="Delete project"
+                            onClick={handleRenameCancel}
+                            className="px-3 py-1.5 bg-neutral-700 hover:bg-neutral-600 text-neutral-300 rounded-lg text-sm"
                           >
-                            <Trash2 className="size-4 text-neutral-300" />
+                            Cancel
                           </button>
                         </div>
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
+                      ) : (
+                        <div className="flex justify-between items-center flex-1">
+                          <button
+                            type="button"
+                            onClick={() => onSelectProject(project.id)}
+                            className="flex-1 text-left"
+                          >
+                            <div className="text-neutral-100 font-medium text-lg">
+                              {project.name}
+                            </div>
+                            <div className="text-neutral-500 text-sm mt-1">
+                              Last edited{" "}
+                              {new Date(project.updatedAt).toLocaleDateString(
+                                undefined,
+                                {
+                                  month: "short",
+                                  day: "numeric",
+                                  year: "numeric",
+                                },
+                              )}
+                            </div>
+                          </button>
+                          <div className="flex items-center gap-1">
+                            <button
+                              type="button"
+                              data-testid={`rename-button-${project.id}`}
+                              onClick={(e) =>
+                                handleRenameStart(e, project.id, project.name)
+                              }
+                              className="p-2 hover:bg-neutral-600/50 rounded-lg transition-colors"
+                              title="Rename"
+                            >
+                              <Pencil className="size-4 text-neutral-400" />
+                            </button>
+                            <button
+                              type="button"
+                              data-testid={`delete-button-${project.id}`}
+                              onClick={(e) => handleDelete(e, project.id)}
+                              className="p-2 hover:bg-red-600/30 rounded-lg transition-colors"
+                              title="Delete"
+                            >
+                              <Trash2 className="size-4 text-neutral-400" />
+                            </button>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
             </div>
-          </div>
-        )}
 
-        <div className="flex gap-3">
-          {hasProjects && (
-            <button
-              type="button"
-              data-testid="continue-button"
-              onClick={() => lastProjectId && onSelectProject(lastProjectId)}
-              className="px-6 py-3 bg-emerald-600 hover:bg-emerald-500 text-white rounded-lg font-medium"
-            >
-              Continue Last
-            </button>
-          )}
+            <div className="flex flex-col items-center gap-4">
+              <div className="flex gap-4">
+                <button
+                  type="button"
+                  data-testid="continue-button"
+                  onClick={() =>
+                    lastProjectId && onSelectProject(lastProjectId)
+                  }
+                  className="px-8 py-3 bg-emerald-600 hover:bg-emerald-500 text-white rounded-xl font-medium text-lg shadow-lg shadow-emerald-900/30"
+                >
+                  Continue
+                </button>
+                <button
+                  type="button"
+                  data-testid="new-project-button"
+                  onClick={onNewProject}
+                  className="px-8 py-3 bg-neutral-800 hover:bg-neutral-700 text-neutral-200 rounded-xl font-medium text-lg"
+                >
+                  New Project
+                </button>
+              </div>
+              <p className="text-neutral-600 text-sm">
+                Press{" "}
+                <kbd className="px-2 py-1 bg-neutral-800 rounded text-neutral-400 font-mono text-xs">
+                  Space
+                </kbd>{" "}
+                to continue
+              </p>
+            </div>
+          </>
+        ) : (
           <button
             type="button"
             data-testid="new-project-button"
             onClick={onNewProject}
-            className={`px-6 py-3 rounded-lg font-medium ${
-              hasProjects
-                ? "bg-neutral-700 hover:bg-neutral-600 text-neutral-200"
-                : "bg-emerald-600 hover:bg-emerald-500 text-white"
-            }`}
+            className="px-10 py-4 bg-emerald-600 hover:bg-emerald-500 text-white rounded-xl font-medium text-lg shadow-lg shadow-emerald-900/30"
           >
-            New Project
+            Create Your First Project
           </button>
-        </div>
-        {hasProjects && (
-          <div className="text-neutral-500 text-sm">
-            Press{" "}
-            <kbd className="px-2 py-1 bg-neutral-800 rounded text-neutral-400 font-mono text-xs border border-neutral-700">
-              Space
-            </kbd>{" "}
-            to continue
-          </div>
         )}
       </div>
     </div>

--- a/src/components/project-settings-dialog.tsx
+++ b/src/components/project-settings-dialog.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useRef, useState } from "react";
+import { Button } from "./ui/button";
+
+type ProjectSettingsDialogProps = {
+  isOpen: boolean;
+  projectName: string;
+  onSave: (name: string) => void;
+  onClose: () => void;
+};
+
+export function ProjectSettingsDialog({
+  isOpen,
+  projectName,
+  onSave,
+  onClose,
+}: ProjectSettingsDialogProps) {
+  const [name, setName] = useState(projectName);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Reset form when opening
+  useEffect(() => {
+    if (isOpen) {
+      setName(projectName);
+      // Focus and select on next frame
+      requestAnimationFrame(() => inputRef.current?.select());
+    }
+  }, [isOpen, projectName]);
+
+  if (!isOpen) return null;
+
+  const handleSave = () => {
+    const trimmed = name.trim();
+    if (trimmed && trimmed !== projectName) {
+      onSave(trimmed);
+    }
+    onClose();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSave();
+    }
+  };
+
+  return (
+    <div
+      data-testid="project-settings-dialog"
+      className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-neutral-800 rounded-lg shadow-2xl w-full max-w-md"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="border-b border-neutral-700 px-6 py-4 flex justify-between items-center">
+          <h2 className="text-lg font-semibold text-neutral-100">
+            Project Settings
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-neutral-400 hover:text-neutral-200 text-2xl leading-none"
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-6 space-y-4">
+          <div>
+            <label
+              htmlFor="project-name"
+              className="block text-sm font-medium text-neutral-300 mb-2"
+            >
+              Project Name
+            </label>
+            <input
+              ref={inputRef}
+              id="project-name"
+              data-testid="project-name-input"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={handleKeyDown}
+              className="w-full h-10 px-3 text-sm bg-neutral-900 border border-neutral-600 rounded text-neutral-100 focus:outline-none focus:border-neutral-500"
+              placeholder="Enter project name"
+            />
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-neutral-700 px-6 py-4 flex justify-end gap-3">
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave}>Save</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -6,7 +6,6 @@ import {
   FolderIcon,
   MusicIcon,
   PauseIcon,
-  PencilIcon,
   PlayIcon,
   SettingsIcon,
   Trash2Icon,
@@ -144,15 +143,15 @@ function PlayPauseButton() {
 }
 
 type TransportProps = {
+  onProjectSettingsClick: () => void;
   onHelpClick: () => void;
   onProjectsClick: () => void;
-  onRenameProject: () => void;
 };
 
 export function Transport({
+  onProjectSettingsClick,
   onHelpClick,
   onProjectsClick,
-  onRenameProject,
 }: TransportProps) {
   const {
     audioFileName,
@@ -690,13 +689,13 @@ export function Transport({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-48">
-          {/* Rename Project */}
+          {/* Project Settings */}
           <DropdownMenuItem
-            data-testid="rename-project-button"
-            onClick={onRenameProject}
+            data-testid="project-settings-button"
+            onClick={onProjectSettingsClick}
           >
-            <PencilIcon className="size-4" />
-            Rename Project
+            <SettingsIcon className="size-4" />
+            Project Settings
           </DropdownMenuItem>
 
           {/* Projects */}


### PR DESCRIPTION
## Summary

- Add project settings dialog accessible from transport bar
- Redesign startup screen with improved visual design:
  - Subtle emerald gradient glow background
  - Better project card layout with borders and fixed height
  - Friendlier date format and tagline
  - Better empty state for new users

## Test plan

- [ ] Open app with no projects - see "Create Your First Project" CTA
- [ ] Open app with existing projects - verify project list displays correctly
- [ ] Rename a project inline - card height should not change
- [ ] Click project settings in transport - dialog opens
- [ ] Verify Space shortcut still works to continue last project

🤖 Generated with [Claude Code](https://claude.com/claude-code)