### PR TITLE
feat: add 'M' keyboard shortcut to toggle metronome

### DIFF
--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -327,7 +327,13 @@ export function Transport({
     ) {
       return;
     }
-    if (e.code === "KeyM" && !e.ctrlKey && !e.metaKey && !e.altKey && !e.repeat) {
+    if (
+      e.code === "KeyM" &&
+      !e.ctrlKey &&
+      !e.metaKey &&
+      !e.altKey &&
+      !e.repeat
+    ) {
       e.preventDefault();
       setMetronomeEnabled(!metronomeEnabled);
     }

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -319,13 +319,17 @@ export function Transport({
     clearAudioFile();
   };
 
-  // Keyboard shortcut: Ctrl+F=auto-scroll (Space is handled by PlayPauseButton)
+  // Keyboard shortcuts: M=metronome, Ctrl+F=auto-scroll (Space is handled by PlayPauseButton)
   useWindowEvent("keydown", (e) => {
     if (
       (e.target instanceof HTMLInputElement && e.target.type !== "range") ||
       e.target instanceof HTMLTextAreaElement
     ) {
       return;
+    }
+    if (e.code === "KeyM" && !e.ctrlKey && !e.metaKey && !e.altKey && !e.repeat) {
+      e.preventDefault();
+      setMetronomeEnabled(!metronomeEnabled);
     }
     if (e.code === "KeyF" && (e.ctrlKey || e.metaKey) && !e.repeat) {
       e.preventDefault();
@@ -449,7 +453,7 @@ export function Transport({
         onClick={() => setMetronomeEnabled(!metronomeEnabled)}
         variant={metronomeEnabled ? "default" : "ghost"}
         size="icon"
-        title="Toggle metronome"
+        title="Toggle metronome (M)"
         aria-pressed={metronomeEnabled}
       >
         <MetronomeIcon className="size-5" />

--- a/src/lib/keybindings.ts
+++ b/src/lib/keybindings.ts
@@ -21,6 +21,11 @@ export const KEYBOARD_SHORTCUTS: KeyBinding[] = [
     category: "playback",
   },
   {
+    key: "M",
+    description: "Toggle metronome",
+    category: "playback",
+  },
+  {
     key: "Ctrl+F",
     description: "Toggle auto-scroll",
     category: "playback",


### PR DESCRIPTION
## Summary
Adds a keyboard shortcut to quickly toggle the metronome on/off.

## Changes
- Press **M** to toggle metronome (works anywhere except when typing in text inputs)
- Button tooltip now shows the shortcut hint: "Toggle metronome (M)"
- Shortcut registered in keybindings for the help dialog

## Testing
1. Load a MIDI file
2. Press **M** — metronome should toggle
3. Press **?** to open help — should show 'M' shortcut listed