### PR TITLE
fix: render audio track wave form in adoptive resolution

### DIFF
--- a/docs/2026-01-31-high-res-waveform-v2.md
+++ b/docs/2026-01-31-high-res-waveform-v2.md
@@ -72,67 +72,74 @@ At 1920px viewport, 500 peaks is marginal for full-song view and terrible for zo
 
 ---
 
-## Current Implementation
+## Ideal Data Flow
 
-### Data Flow
+### Core Question
+
+Given visible time range and pixel width, what peaks do we need?
+
+### Flow
 
 ```
-File Load                              Render
-─────────                              ──────
-AudioBuffer (48kHz)                    peaks[] + viewport params
-    │                                       │
-    ▼                                       ▼
-getAudioBufferPeaks()                  downsample to 500 points (BUG)
-    │ 480 samples/peak                      │
-    ▼                                       ▼
-peaks[] (100/sec)                      SVG/Canvas (renderer-agnostic)
-    │
-    ▼
-stored in project-store
+Render time inputs:
+  - visibleStart (seconds)
+  - visibleEnd (seconds)
+  - pixelWidth (pixels)
+
+          ↓
+
+getPeaksForViewport(audioData, visibleStart, visibleEnd, pixelWidth)
+
+          ↓
+
+peaks[] with length ≈ pixelWidth (1-2 peaks per pixel)
+
+          ↓
+
+Renderer (SVG, Canvas, etc.)
 ```
 
-### The Bug
+### Where Does `audioData` Come From?
 
-Current downsampling happens at render time with no viewport awareness:
+Two options:
+
+**A. Raw AudioBuffer**
+
+- Compute peaks on-demand from samples
+- Pro: Maximum flexibility, no pre-computation
+- Con: CPU-intensive on every render
+
+**B. Pre-computed peaks at fixed resolution**
+
+- Extract once at load time (e.g., 100 peaks/sec)
+- Slice + downsample at render time
+- Pro: Fast render, small storage
+- Con: Can't exceed pre-computed resolution when zoomed in
+
+**Recommendation:** Option B for now. 100 peaks/sec = 15 peaks per 16th note at 100 BPM, which is plenty for most zoom levels.
+
+### Processing Function
 
 ```typescript
-// Current: always 500 points regardless of visible range
-const maxPoints = 500;
-const step = Math.max(1, Math.floor(peaks.length / maxPoints));
-```
-
-### Fix: Pure Data Processing Function
-
-Extract a viewport-aware culling function (renderer-agnostic):
-
-```typescript
-function getVisiblePeaks(
+function getPeaksForViewport(
   peaks: number[],
   peaksPerSecond: number,
-  // Viewport params (in seconds, not beats - keep it audio-domain)
   visibleStart: number, // seconds
   visibleEnd: number, // seconds
-  targetWidth: number, // pixels - determines output resolution
+  pixelWidth: number, // target output length
 ): number[] {
-  // 1. Calculate peak indices for visible range
-  const startIndex = Math.floor(visibleStart * peaksPerSecond);
-  const endIndex = Math.ceil(visibleEnd * peaksPerSecond);
+  // Slice to visible range
+  const startIdx = Math.floor(visibleStart * peaksPerSecond);
+  const endIdx = Math.ceil(visibleEnd * peaksPerSecond);
+  const visible = peaks.slice(startIdx, endIdx);
 
-  // 2. Slice to visible range
-  const visiblePeaks = peaks.slice(startIndex, endIndex);
-
-  // 3. Downsample to ~1 peak per pixel (if needed)
-  const targetPeaks = Math.min(visiblePeaks.length, targetWidth);
-  return downsample(visiblePeaks, targetPeaks);
+  // Downsample if more peaks than pixels, otherwise return as-is
+  if (visible.length <= pixelWidth) return visible;
+  return downsample(visible, pixelWidth);
 }
 ```
 
-**Key design decisions:**
-
-- Input viewport in **seconds** (audio domain), not beats (music domain)
-- Caller converts beats→seconds before calling
-- Output resolution based on **pixel width**, not arbitrary constant
-- Returns array ready for any renderer (SVG, Canvas, etc.)
+**Key:** Output length ≈ pixelWidth, not arbitrary constant.
 
 ---
 

--- a/docs/2026-01-31-high-res-waveform-v2.md
+++ b/docs/2026-01-31-high-res-waveform-v2.md
@@ -77,89 +77,62 @@ At 1920px viewport, 500 peaks is marginal for full-song view and terrible for zo
 ### Data Flow
 
 ```
-┌─────────────────────────────────────────────────────────────────────────┐
-│  File Load (src/lib/audio.ts)                                           │
-│                                                                         │
-│  loadAudioFile(file)                                                    │
-│    └─> getAudioBufferPeaks(buffer, 100)    ← Stage 1: 480 samples/peak │
-│          └─> peaks[] stored in project-store                            │
-└─────────────────────────────────────────────────────────────────────────┘
-                                │
-                                ▼
-┌─────────────────────────────────────────────────────────────────────────┐
-│  Render (src/components/piano-roll.tsx)                                 │
-│                                                                         │
-│  WaveformArea                                                           │
-│    ├─ receives: audioPeaks[], scrollX, pixelsPerBeat                    │
-│    ├─ positions audio block based on offset/duration                    │
-│    └─> Waveform component                                               │
-│          └─> Downsample to 500 points      ← Stage 2: THE BUG          │
-│          └─> SVG <path> with viewBox 0-1000                             │
-│          └─> CSS stretches to container width                           │
-└─────────────────────────────────────────────────────────────────────────┘
+File Load                              Render
+─────────                              ──────
+AudioBuffer (48kHz)                    peaks[] + viewport params
+    │                                       │
+    ▼                                       ▼
+getAudioBufferPeaks()                  downsample to 500 points (BUG)
+    │ 480 samples/peak                      │
+    ▼                                       ▼
+peaks[] (100/sec)                      SVG/Canvas (renderer-agnostic)
+    │
+    ▼
+stored in project-store
 ```
 
-### Key Code Locations
+### The Bug
 
-| File                                 | Function                | What it does                            |
-| ------------------------------------ | ----------------------- | --------------------------------------- |
-| `src/lib/audio.ts:390`               | `getAudioBufferPeaks()` | Stage 1: Extract peaks at 100/sec       |
-| `src/lib/audio.ts:415`               | `loadAudioFile()`       | Orchestrates load + peak extraction     |
-| `src/components/piano-roll.tsx:1786` | `Waveform()`            | Stage 2: Downsample to 500 + render SVG |
-| `src/components/piano-roll.tsx:1607` | `WaveformArea()`        | Container, positions waveform block     |
-
-### Current Waveform Component (the bug)
+Current downsampling happens at render time with no viewport awareness:
 
 ```typescript
-function Waveform({ peaks, height }) {
-  // BUG: Fixed 500 points regardless of audio length or zoom
-  const maxPoints = 500;
-  const step = Math.max(1, Math.floor(peaks.length / maxPoints));
+// Current: always 500 points regardless of visible range
+const maxPoints = 500;
+const step = Math.max(1, Math.floor(peaks.length / maxPoints));
+```
 
-  // Downsample by taking max of each chunk
-  for (let i = 0; i < peaks.length; i += step) { ... }
+### Fix: Pure Data Processing Function
 
-  // Render to fixed viewBox, CSS stretches to fit
-  <svg viewBox="0 0 1000 {height}" preserveAspectRatio="none">
-    <path d={pathData} />
-  </svg>
+Extract a viewport-aware culling function (renderer-agnostic):
+
+```typescript
+function getVisiblePeaks(
+  peaks: number[],
+  peaksPerSecond: number,
+  // Viewport params (in seconds, not beats - keep it audio-domain)
+  visibleStart: number, // seconds
+  visibleEnd: number, // seconds
+  targetWidth: number, // pixels - determines output resolution
+): number[] {
+  // 1. Calculate peak indices for visible range
+  const startIndex = Math.floor(visibleStart * peaksPerSecond);
+  const endIndex = Math.ceil(visibleEnd * peaksPerSecond);
+
+  // 2. Slice to visible range
+  const visiblePeaks = peaks.slice(startIndex, endIndex);
+
+  // 3. Downsample to ~1 peak per pixel (if needed)
+  const targetPeaks = Math.min(visiblePeaks.length, targetWidth);
+  return downsample(visiblePeaks, targetPeaks);
 }
 ```
 
-**Problems:**
+**Key design decisions:**
 
-1. `peaks.length / 500` = more aggressive downsampling for longer audio
-2. No awareness of `scrollX` or visible viewport
-3. SVG covers entire audio duration, CSS scales it
-
-### What WaveformArea Already Has
-
-The parent component `WaveformArea` receives:
-
-- `scrollX` - current horizontal scroll position (in beats)
-- `pixelsPerBeat` - current zoom level
-- `viewportWidth` - visible area width
-- `audioPeaks` - full peaks array
-- `audioOffset` / `audioDuration` - timing info
-
-**It already calculates visible region** for positioning the audio block:
-
-```typescript
-const audioStartX = (audioOffsetBeats - scrollX) * pixelsPerBeat;
-```
-
-But it passes the **entire** `audioPeaks` array to `Waveform`, which then:
-
-1. Downsamples to 500 points (losing detail)
-2. Renders all of it (even off-screen parts)
-
-### Fix Strategy
-
-Pass viewport info to `Waveform`, so it can:
-
-1. Calculate which peaks are visible based on `scrollX` and `viewportWidth`
-2. Slice `peaks[]` to visible range only
-3. Remove or adjust the 500-point limit (may not be needed for visible-only data)
+- Input viewport in **seconds** (audio domain), not beats (music domain)
+- Caller converts beats→seconds before calling
+- Output resolution based on **pixel width**, not arbitrary constant
+- Returns array ready for any renderer (SVG, Canvas, etc.)
 
 ---
 

--- a/docs/2026-01-31-high-res-waveform-v2.md
+++ b/docs/2026-01-31-high-res-waveform-v2.md
@@ -72,7 +72,29 @@ At 1920px viewport, 500 peaks is marginal for full-song view and terrible for zo
 
 ---
 
-## Ideal Data Flow
+## Data Flow
+
+### Current (broken)
+
+```
+Load time:
+  AudioBuffer → peaks[] at 100/sec (entire file)
+
+Render time:
+  peaks[] (entire file)
+      ↓
+  downsample to 500 points (fixed, regardless of viewport)
+      ↓
+  Renderer
+```
+
+**Problems:**
+
+- No viewport awareness - processes entire file
+- Fixed 500 output - longer files get worse quality
+- Output resolution unrelated to display pixels
+
+### Ideal
 
 ### Core Question
 

--- a/docs/2026-01-31-high-res-waveform-v2.md
+++ b/docs/2026-01-31-high-res-waveform-v2.md
@@ -72,6 +72,51 @@ At 1920px viewport, 500 peaks is marginal for full-song view and terrible for zo
 
 ---
 
+## Computation Analysis
+
+### Raw Numbers (3 min, 48kHz, mono)
+
+| Data              | Size                      |
+| ----------------- | ------------------------- |
+| Raw samples       | 8,640,000 floats (~35 MB) |
+| Viewport (1920px) | 1,920 output peaks needed |
+
+### Peak Extraction Cost
+
+For each output peak: scan N samples, find max.
+
+| Zoom Level | Visible Duration | Samples | Samples/Peak | Total Comparisons |
+| ---------- | ---------------- | ------- | ------------ | ----------------- |
+| Full song  | 180 sec          | 8.6M    | 4,500        | 8.6M              |
+| 24 beats   | 14.4 sec         | 691K    | 360          | 691K              |
+| 4 beats    | 2.4 sec          | 115K    | 60           | 115K              |
+
+**Is this expensive?**
+
+- JavaScript: tens of millions of simple ops/sec
+- 8.6M comparisons ≈ 10-50ms (acceptable)
+- 115K comparisons < 1ms (trivial)
+
+### Ideal Robust System
+
+For very long audio (hours), you'd want:
+
+1. **Background processing** (Web Worker) - don't block UI
+2. **Multi-resolution cache** (mipmap) - pre-compute at 2x, 4x, 8x... downsampling
+3. **Chunked processing** - process in segments, parallelize
+
+### Practical Heuristic (≤10 min audio)
+
+For typical use case (3-min song):
+
+- Raw sample scan is fast enough (<50ms worst case)
+- Could compute on-demand from raw buffer
+- Or pre-compute once at load, slice at render (current approach, just fix the bug)
+
+**Simplest fix:** Keep pre-computed peaks, just add viewport slicing. No architectural changes needed.
+
+---
+
 ## Data Flow
 
 ### Current (broken)

--- a/docs/2026-01-31-high-res-waveform-v2.md
+++ b/docs/2026-01-31-high-res-waveform-v2.md
@@ -107,20 +107,34 @@ At 1920px viewport, 500 peaks is marginal for full-song view and terrible for zo
 
 All cheap. Even 800/sec is < 1 MB.
 
-### Extraction Cost (one-time at load)
+### Why Pre-compute? Render Cost Comparison
 
-From 8.6M samples to N peaks = 8.6M comparisons regardless of N.
+**Without pre-compute (scan raw samples per render):**
 
-- JavaScript: ~10-50ms
-- Acceptable for one-time load
+| Zoom      | Samples to Scan | Cost      |
+| --------- | --------------- | --------- |
+| Full song | 8.6M            | 10-50ms ✗ |
+| 32 beats  | 921K            | 5-10ms ✗  |
+| 4 beats   | 115K            | <1ms ✓    |
 
-### Render Cost (per frame)
+Zoomed-out views would cost 10-50ms **per frame** - unacceptable for 60fps.
 
-With pre-computed peaks + viewport slicing:
+**With pre-compute (scan once at load, slice at render):**
 
-- Slice array: O(1)
-- Downsample visible peaks to pixels: O(visible_peaks)
-- At 800/sec, 4-beat view: 800 × 2.4 = 1,920 peaks → trivial
+| Step                                | When        | Cost             |
+| ----------------------------------- | ----------- | ---------------- |
+| Extract 8.6M → 144K peaks (800/sec) | Load (once) | 10-50ms          |
+| Slice to visible range              | Render      | O(1)             |
+| Downsample to pixels                | Render      | O(visible_peaks) |
+
+At 800/sec, worst case render (full song):
+
+- Slice: O(1)
+- Downsample 144K → 1920: ~144K comparisons → <1ms ✓
+
+**Pre-compute buys:** Move 8.6M-sample scan from render-time to load-time.
+
+Without it, zoomed-out renders would block UI. With it, all renders are <1ms.
 
 ### Ideal Robust System (for hours of audio)
 

--- a/docs/2026-01-31-high-res-waveform-v2.md
+++ b/docs/2026-01-31-high-res-waveform-v2.md
@@ -74,46 +74,69 @@ At 1920px viewport, 500 peaks is marginal for full-song view and terrible for zo
 
 ## Computation Analysis
 
-### Raw Numbers (3 min, 48kHz, mono)
+### What Pre-compute Resolution Do We Need?
 
-| Data              | Size                      |
-| ----------------- | ------------------------- |
-| Raw samples       | 8,640,000 floats (~35 MB) |
-| Viewport (1920px) | 1,920 output peaks needed |
+**Constraint:** Pre-computed resolution limits max zoom quality. Can't show more detail than we have.
 
-### Peak Extraction Cost
+**Goal:** 1-2 peaks per pixel for smooth waveform.
 
-For each output peak: scan N samples, find max.
+**Derive from zoom levels** (100 BPM, 1920px viewport):
 
-| Zoom Level | Visible Duration | Samples | Samples/Peak | Total Comparisons |
-| ---------- | ---------------- | ------- | ------------ | ----------------- |
-| Full song  | 180 sec          | 8.6M    | 4,500        | 8.6M              |
-| 24 beats   | 14.4 sec         | 691K    | 360          | 691K              |
-| 4 beats    | 2.4 sec          | 115K    | 60           | 115K              |
+| Zoom Level        | Beats Visible | Duration | Peaks/sec for 1 peak/px |
+| ----------------- | ------------- | -------- | ----------------------- |
+| Full song         | 300           | 180 sec  | 11                      |
+| 32 beats (8 bars) | 32            | 19.2 sec | 100                     |
+| 8 beats (2 bars)  | 8             | 4.8 sec  | 400                     |
+| 4 beats (1 bar)   | 4             | 2.4 sec  | 800                     |
+| 1 beat            | 1             | 0.6 sec  | 3,200                   |
 
-**Is this expensive?**
+**Current 100 peaks/sec:**
 
-- JavaScript: tens of millions of simple ops/sec
-- 8.6M comparisons ≈ 10-50ms (acceptable)
-- 115K comparisons < 1ms (trivial)
+- Good for ≥32 beats visible
+- At 4 beats zoom: 100 × 2.4 = 240 peaks for 1920 pixels = 0.125 peaks/pixel (blocky)
 
-### Ideal Robust System
+**If we want smooth waveform at 4-beat zoom:** need ~800 peaks/sec
 
-For very long audio (hours), you'd want:
+### Storage Cost (3-min song)
 
-1. **Background processing** (Web Worker) - don't block UI
-2. **Multi-resolution cache** (mipmap) - pre-compute at 2x, 4x, 8x... downsampling
-3. **Chunked processing** - process in segments, parallelize
+| Resolution | Total Peaks | Size (Float32) |
+| ---------- | ----------- | -------------- |
+| 100/sec    | 18,000      | 72 KB          |
+| 400/sec    | 72,000      | 288 KB         |
+| 800/sec    | 144,000     | 576 KB         |
 
-### Practical Heuristic (≤10 min audio)
+All cheap. Even 800/sec is < 1 MB.
 
-For typical use case (3-min song):
+### Extraction Cost (one-time at load)
 
-- Raw sample scan is fast enough (<50ms worst case)
-- Could compute on-demand from raw buffer
-- Or pre-compute once at load, slice at render (current approach, just fix the bug)
+From 8.6M samples to N peaks = 8.6M comparisons regardless of N.
 
-**Simplest fix:** Keep pre-computed peaks, just add viewport slicing. No architectural changes needed.
+- JavaScript: ~10-50ms
+- Acceptable for one-time load
+
+### Render Cost (per frame)
+
+With pre-computed peaks + viewport slicing:
+
+- Slice array: O(1)
+- Downsample visible peaks to pixels: O(visible_peaks)
+- At 800/sec, 4-beat view: 800 × 2.4 = 1,920 peaks → trivial
+
+### Ideal Robust System (for hours of audio)
+
+1. **Background processing** (Web Worker) - don't block UI during load
+2. **Multi-resolution cache** (mipmap) - store at multiple resolutions
+3. **Chunked processing** - for progress indication on very long files
+
+### Practical Decision
+
+For ≤10 min audio with max zoom of 4 beats:
+
+- Pre-compute at **800 peaks/sec** (or 1000 for round number)
+- One-time cost: ~50ms + 0.5 MB
+- Render: slice + optional downsample, trivial
+
+**Current 100/sec is too low** for zoomed-in views. Should increase to 800-1000.
 
 ---
 

--- a/docs/2026-01-31-high-res-waveform-v2.md
+++ b/docs/2026-01-31-high-res-waveform-v2.md
@@ -72,6 +72,97 @@ At 1920px viewport, 500 peaks is marginal for full-song view and terrible for zo
 
 ---
 
+## Current Implementation
+
+### Data Flow
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  File Load (src/lib/audio.ts)                                           │
+│                                                                         │
+│  loadAudioFile(file)                                                    │
+│    └─> getAudioBufferPeaks(buffer, 100)    ← Stage 1: 480 samples/peak │
+│          └─> peaks[] stored in project-store                            │
+└─────────────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Render (src/components/piano-roll.tsx)                                 │
+│                                                                         │
+│  WaveformArea                                                           │
+│    ├─ receives: audioPeaks[], scrollX, pixelsPerBeat                    │
+│    ├─ positions audio block based on offset/duration                    │
+│    └─> Waveform component                                               │
+│          └─> Downsample to 500 points      ← Stage 2: THE BUG          │
+│          └─> SVG <path> with viewBox 0-1000                             │
+│          └─> CSS stretches to container width                           │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### Key Code Locations
+
+| File                                 | Function                | What it does                            |
+| ------------------------------------ | ----------------------- | --------------------------------------- |
+| `src/lib/audio.ts:390`               | `getAudioBufferPeaks()` | Stage 1: Extract peaks at 100/sec       |
+| `src/lib/audio.ts:415`               | `loadAudioFile()`       | Orchestrates load + peak extraction     |
+| `src/components/piano-roll.tsx:1786` | `Waveform()`            | Stage 2: Downsample to 500 + render SVG |
+| `src/components/piano-roll.tsx:1607` | `WaveformArea()`        | Container, positions waveform block     |
+
+### Current Waveform Component (the bug)
+
+```typescript
+function Waveform({ peaks, height }) {
+  // BUG: Fixed 500 points regardless of audio length or zoom
+  const maxPoints = 500;
+  const step = Math.max(1, Math.floor(peaks.length / maxPoints));
+
+  // Downsample by taking max of each chunk
+  for (let i = 0; i < peaks.length; i += step) { ... }
+
+  // Render to fixed viewBox, CSS stretches to fit
+  <svg viewBox="0 0 1000 {height}" preserveAspectRatio="none">
+    <path d={pathData} />
+  </svg>
+}
+```
+
+**Problems:**
+
+1. `peaks.length / 500` = more aggressive downsampling for longer audio
+2. No awareness of `scrollX` or visible viewport
+3. SVG covers entire audio duration, CSS scales it
+
+### What WaveformArea Already Has
+
+The parent component `WaveformArea` receives:
+
+- `scrollX` - current horizontal scroll position (in beats)
+- `pixelsPerBeat` - current zoom level
+- `viewportWidth` - visible area width
+- `audioPeaks` - full peaks array
+- `audioOffset` / `audioDuration` - timing info
+
+**It already calculates visible region** for positioning the audio block:
+
+```typescript
+const audioStartX = (audioOffsetBeats - scrollX) * pixelsPerBeat;
+```
+
+But it passes the **entire** `audioPeaks` array to `Waveform`, which then:
+
+1. Downsamples to 500 points (losing detail)
+2. Renders all of it (even off-screen parts)
+
+### Fix Strategy
+
+Pass viewport info to `Waveform`, so it can:
+
+1. Calculate which peaks are visible based on `scrollX` and `viewportWidth`
+2. Slice `peaks[]` to visible range only
+3. Remove or adjust the 500-point limit (may not be needed for visible-only data)
+
+---
+
 ## Problem
 
 The waveform has two separate issues:

--- a/docs/2026-01-31-high-res-waveform-v2.md
+++ b/docs/2026-01-31-high-res-waveform-v2.md
@@ -1,0 +1,159 @@
+# Higher Resolution Waveform at Zoom
+
+## First Principles: Downsampling Limits
+
+**Baseline:** 100 BPM, 3 min song, 48 kHz
+
+| Unit      | Duration | Samples   |
+| --------- | -------- | --------- |
+| 16th note | 0.15 sec | 7,200     |
+| 8th note  | 0.3 sec  | 14,400    |
+| Beat      | 0.6 sec  | 28,800    |
+| Bar       | 2.4 sec  | 115,200   |
+| Full song | 180 sec  | 8,640,000 |
+
+Song = 75 bars = 300 beats = 1,200 16th notes
+
+### How much can we downsample?
+
+**Core question:** How many samples can we collapse into one peak before losing musical detail?
+
+A 16th note = 7,200 samples. To see it as a distinct transient (not merged with neighbors), we need at least 2-4 peaks to represent it.
+
+| Samples/Peak | Peaks per 16th | Can distinguish 16th notes? |
+| ------------ | -------------- | --------------------------- |
+| 7,200        | 1              | No - merged with neighbors  |
+| 3,600        | 2              | Barely                      |
+| 1,800        | 4              | Yes                         |
+| 900          | 8              | Clear                       |
+
+**Max useful downsampling:** ~1,800 samples/peak (gives 4 peaks per 16th note)
+
+### Current Implementation (Two-Stage)
+
+**Stage 1 - Peak extraction:** 100 peaks/sec
+
+- At 48kHz: 480 samples/peak
+- = 15 peaks per 16th note ✓ (plenty of detail)
+
+**Stage 2 - SVG rendering:** Fixed 500 points for entire song
+
+For 3-min song:
+
+- 8,640,000 samples → 500 points = **17,280 samples/peak**
+- = 0.4 peaks per 16th note ✗
+
+We can't even see individual beats, let alone 16th notes.
+
+### The Bug
+
+Stage 1 extracts enough detail. Stage 2 throws it all away.
+
+The 500-point limit makes quality dependent on total audio length:
+
+| Audio Length | Stage 1 Peaks | Stage 2 Output | Samples/Point |
+| ------------ | ------------- | -------------- | ------------- |
+| 1 min        | 6,000         | 500            | 5,760         |
+| 3 min        | 18,000        | 500            | 17,280        |
+| 10 min       | 60,000        | 500            | 57,600        |
+
+Longer songs get worse quality. This is backwards.
+
+### Display: Peaks to Pixels
+
+Once we have peaks, mapping to screen:
+
+| Situation               | Result                                |
+| ----------------------- | ------------------------------------- |
+| More peaks than pixels  | Downsample for display (fine)         |
+| Fewer peaks than pixels | Stretchy/blocky (can't invent detail) |
+
+At 1920px viewport, 500 peaks is marginal for full-song view and terrible for zoomed views.
+
+---
+
+## Problem
+
+The waveform has two separate issues:
+
+### Issue 1: Audio-length-dependent quality (bug)
+
+Current implementation downsamples to fixed 500 SVG points regardless of audio length:
+
+| Audio Length | Peaks (100/sec) | Downsampling | Result     |
+| ------------ | --------------- | ------------ | ---------- |
+| 5 minutes    | 30,000          | 60:1         | Acceptable |
+| 30 minutes   | 180,000         | 360:1        | 6x worse   |
+
+**Longer files look progressively worse.** This is backwards.
+
+### Issue 2: No zoom detail (limitation)
+
+Waveform is extracted at fixed 100 peaks/second. Zooming in just stretches the same data - it becomes blocky instead of revealing more detail.
+
+## Root Cause
+
+The current approach renders the **entire audio file** with no awareness of:
+
+- **Viewport**: What's actually visible on screen
+- **Zoom level**: How much detail is appropriate
+
+## Orthogonal Concerns
+
+Three independent dimensions to consider:
+
+| Concern            | Options                         | Notes                                       |
+| ------------------ | ------------------------------- | ------------------------------------------- |
+| **What to render** | Entire file vs visible viewport | Viewport culling fixes Issue 1              |
+| **Resolution**     | Fixed vs adaptive to zoom       | Adaptive fixes Issue 2                      |
+| **Rendering tech** | SVG vs Canvas                   | Performance optimization, separate decision |
+
+These can be addressed independently.
+
+## Solutions
+
+### Fix 1: Viewport Culling
+
+- Calculate visible time range from scroll position
+- Pass only visible peaks to renderer
+- Keep 100 peaks/sec resolution
+
+**Fixes:** Issue 1 (audio-length bug)
+**Effort:** Low (1-2 hours)
+
+### Fix 2: Adaptive Resolution
+
+- Calculate target resolution based on zoom (e.g., 2 peaks/pixel)
+- Extract peaks on-demand from audio buffer
+
+**Fixes:** Issue 2 (zoom detail)
+**Effort:** Medium (3-4 hours, requires Fix 1 first)
+
+### Optional: Switch to Canvas
+
+Canvas is **not a fix** - it's a performance optimization for rendering.
+
+Only consider if SVG proves slow at higher peak counts after implementing Fix 1 or Fix 2. The current 500-point limit may be overly conservative for 2026 browsers.
+
+## Recommendation
+
+1. **Implement Fix 1** (viewport culling)
+   - Fixes the critical bug
+   - Minimal effort, low risk
+
+2. **Implement Fix 2 if needed** (adaptive resolution)
+   - Only if users want better zoom detail
+   - Depends on Fix 1
+
+3. **Switch to Canvas only if SVG is slow**
+   - Measure first, don't assume
+   - Orthogonal to both fixes
+
+## Status
+
+**Created:** 2026-01-31
+**Status:** Ready for review
+
+## Feedback Log
+
+_(Append feedback here)_

--- a/docs/2026-01-31-high-res-waveform.md
+++ b/docs/2026-01-31-high-res-waveform.md
@@ -1,0 +1,2369 @@
+# Higher Resolution Waveform at Zoom
+
+Research and implementation strategy for improving waveform detail when zoomed in.
+
+## Executive Summary
+
+**Problem:** Waveform appears blocky at high zoom levels (defeats "infinite zoom" feature).
+
+**Solution:** Replace SVG with Canvas + adaptive peak generation (industry standard approach).
+
+**Impact:**
+
+- ✅ 10-20x more waveform detail at high zoom
+- ✅ Better audio-to-note alignment precision
+- ✅ Smooth 60fps performance
+- ✅ Minimal memory overhead (< 5MB)
+
+**Effort:** 7-10 hours over 3 phases (each phase ships independently)
+
+**Based On:**
+
+- 🔍 BBC Peaks.js (production-grade multi-resolution waveforms)
+- 🔍 WaveSurfer.js (adaptive peak generation algorithm)
+- 🔍 Signal piano roll (viewport culling, coordinate transforms)
+- 🔍 Doist Ramble (modern Canvas implementation, Jan 2026)
+
+---
+
+## Problem
+
+**Two Separate Issues Identified:**
+
+### Issue 1: Audio-Length-Dependent Quality (Critical Bug 🐛)
+
+- SVG downsamples to fixed 500 points **based on total audio length**
+- 5-minute song: 30,000 peaks → 500 points (60:1 downsampling)
+- 30-minute song: 180,000 peaks → 500 points (360:1 downsampling - 6× worse!)
+- **Result:** Longer audio files show progressively worse waveform detail
+
+### Issue 2: No Zoom Detail (Feature Request)
+
+- Waveform is rendered from a fixed-resolution peak array (100 peaks/second)
+- At high zoom levels (e.g., 1 beat = 200+ pixels), waveform appears blocky/pixelated
+- Waveform doesn't take advantage of zoom to show more audio detail
+- Defeats the purpose of "infinite zoom in" feature (line 73 in prd.md)
+
+**User Impact:**
+
+- ❌ Longer audio files look worse (bug!)
+- ❌ Hard to precisely align notes with audio transients when zoomed in
+- ❌ Visual feedback doesn't match the level of detail available in the zoom
+
+**These are separate problems requiring different solutions:**
+
+1. Issue 1 can be fixed with viewport culling (render only visible region)
+2. Issue 2 requires adaptive peak resolution (more peaks at higher zoom)
+
+## Key Concepts Explained
+
+### Three Orthogonal Concerns
+
+The waveform rendering problem has **three independent dimensions**:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ 1. DATA OPTIMIZATION (What peaks to generate)          │
+│    - Viewport Culling: Only visible region             │
+│    - Adaptive Resolution: More peaks at high zoom      │
+│                                                         │
+│ 2. RENDERING TECHNOLOGY (How to display peaks)         │
+│    - SVG: <path d="..."/>                              │
+│    - Canvas: ctx.lineTo(x, y)                          │
+│                                                         │
+│ 3. PERFORMANCE (Does it run at 60fps?)                 │
+│    - Depends on: Peak count × Rendering technology     │
+│    - Needs: Actual testing, not hand-waving            │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Important:** Data optimization and rendering technology are **completely orthogonal**. You can combine them independently.
+
+---
+
+### 1. Data Optimization
+
+#### Viewport Culling
+
+**What it does:** Only generate peaks for the visible time range.
+
+**Example:**
+
+```
+Audio file: 5 minutes (300 seconds)
+Viewport:   Shows 24 beats = 14.4 seconds @ 100 BPM
+
+WITHOUT culling:
+  Generate: 30,000 peaks (entire file)
+  Pass to renderer: 30,000 peaks
+
+WITH culling:
+  Generate: 1,440 peaks (visible 14.4s × 100/sec)
+  Pass to renderer: 1,440 peaks
+```
+
+**Benefits:**
+
+- ✅ Fixes audio-length bug (quality independent of duration)
+- ✅ Less data to process
+- ✅ Constant peak count regardless of audio length
+
+**Orthogonal to:** SVG or Canvas (works with either)
+
+---
+
+#### Adaptive Resolution
+
+**What it does:** Generate more/fewer peaks based on zoom level.
+
+**Example:**
+
+```
+Audio viewport: 14.4 seconds visible
+
+Zoomed OUT (20 px/beat):
+  Target resolution: 100 peaks/sec
+  Generate: 1,440 peaks
+
+Zoomed IN (200 px/beat):
+  Target resolution: 800 peaks/sec
+  Generate: 11,520 peaks
+```
+
+**Benefits:**
+
+- ✅ More detail when zoomed in
+- ✅ Less data when zoomed out
+- ✅ Smooth zoom experience
+
+**Orthogonal to:** SVG or Canvas (works with either)
+
+---
+
+### 2. Rendering Technology
+
+Once you have an array of peaks (e.g., `Float32Array(5000)`), you can render it with either technology:
+
+#### SVG Rendering
+
+```typescript
+function renderSVG(peaks: number[], height: number) {
+  const points: string[] = [];
+
+  for (let i = 0; i < peaks.length; i++) {
+    const x = (i / peaks.length) * width;
+    const y = centerY - peaks[i] * amplitude;
+    points.push(`${x},${y}`);
+  }
+
+  const pathData = `M ${points.join(' L ')}`;
+  return <path d={pathData} />;
+}
+```
+
+**Characteristics:**
+
+- DOM-based (one `<path>` element)
+- Text-based path definition
+- Browser handles rendering
+
+---
+
+#### Canvas Rendering
+
+```typescript
+function renderCanvas(peaks: number[], height: number) {
+  ctx.beginPath();
+
+  for (let i = 0; i < peaks.length; i++) {
+    const x = (i / peaks.length) * width;
+    const y = centerY - peaks[i] * amplitude;
+    i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+  }
+
+  ctx.fill();
+  ctx.stroke();
+}
+```
+
+**Characteristics:**
+
+- Pixel-based (direct drawing)
+- Imperative API
+- You control rendering
+
+---
+
+### 3. Performance Question
+
+**The real question:** At what peak count does each technology perform acceptably?
+
+```
+Peak Count → Rendering Tech → Performance?
+
+1,000 peaks → SVG    → ??? (needs testing)
+1,000 peaks → Canvas → ??? (needs testing)
+
+5,000 peaks → SVG    → ??? (needs testing)
+5,000 peaks → Canvas → ??? (needs testing)
+
+15,000 peaks → SVG    → ??? (needs testing)
+15,000 peaks → Canvas → ??? (needs testing)
+```
+
+**Current code has 500-point limit with comment:**
+
+```typescript
+// Downsample to max ~500 points to avoid SVG lag
+const maxPoints = 500;
+```
+
+**Questions:**
+
+- Did someone actually experience lag at 501 points?
+- Or was 500 a conservative guess?
+- On what hardware? Which browser? What year?
+- Would 1,000 or 5,000 points work fine in 2026?
+
+**We don't actually know without testing!**
+
+---
+
+### What We Know vs What We Don't Know
+
+#### ✅ What We Know
+
+**Data optimization is independent:**
+
+```
+Viewport culling + Adaptive resolution
+  ↓
+Generate: Float32Array(N) peaks
+  ↓
+  ├→ Render with SVG
+  └→ Render with Canvas
+```
+
+Both SVG and Canvas can receive the same peak array.
+
+**Industry uses Canvas:**
+
+- WaveSurfer.js: Canvas (SVG mode exists but deprecated)
+- Peaks.js (BBC): Canvas only
+- Most modern web audio tools: Canvas
+
+---
+
+#### ❓ What We Don't Know (Requires Testing)
+
+**SVG performance with N peaks:**
+
+- 1,000 peaks: Is it smooth?
+- 5,000 peaks: Still acceptable?
+- 10,000 peaks: Does it lag?
+- 15,000 peaks: Unusable?
+
+**Canvas performance with N peaks:**
+
+- Likely faster than SVG (general consensus)
+- But by how much? 2x? 10x?
+- Still smooth at 50,000 peaks?
+
+**Actual test needed:**
+
+- Target hardware (dev machine + test on low-end device)
+- Target browsers (Chrome, Firefox, Safari)
+- Measure: Render time, frame rate during scroll
+- Compare: SVG vs Canvas at various peak counts
+
+---
+
+### The Current Bug is Independent
+
+**The 500-point downsampling based on audio length is a bug regardless:**
+
+```
+Current (buggy):
+  5-min file (30k peaks) → downsample to 500 → render
+  30-min file (180k peaks) → downsample to 500 → render
+  Result: 30-min looks 6× worse! ❌
+
+Fixed with viewport culling (any renderer):
+  5-min file → visible peaks (1,440) → render
+  30-min file → visible peaks (1,440) → render
+  Result: Both look identical! ✅
+```
+
+This bug exists because we're downsampling based on **total audio length** instead of **visible viewport**. The fix (viewport culling) works with both SVG and Canvas.
+
+---
+
+## Visual Comparison
+
+### Problem 1: Audio Length Dependency (Current Bug)
+
+```
+Current SVG Implementation (Fixed 500 SVG points):
+
+5-minute song (30,000 peaks):
+  Downsampling: 30,000 / 500 = 60 peaks per point
+  Quality: ▁▂▅█▅▂▁▂▃▆█▆▃▂▁▂▄▇█▇▄▂  (acceptable)
+
+30-minute song (180,000 peaks):
+  Downsampling: 180,000 / 500 = 360 peaks per point
+  Quality: ▃▃▅▅██▅▅▃▃▅▅██▅▅▃▃▅▅██  (6x less detail! 🐛)
+
+Problem: Longer songs show LESS detail. This is backwards!
+```
+
+### Problem 2: No Zoom Support
+
+```
+Current (SVG, 100 peaks/sec, no viewport culling):
+Zoom Out:  ▁▂▅█▅▂▁   ▂▃▆█▆▃▂   ▁▂▄▇█▇▄▂   (shows all, okay)
+Zoom In:   ▅▅▅███▅▅▅▅▅▂▂▂▃▃▃▆▆▆▆███▆▆▆▃   (blocky, limited to 100 peaks/sec!)
+
+Proposed (Canvas, adaptive resolution):
+Zoom Out:  ▁▂▅█▅▂▁   ▂▃▆█▆▃▂   ▁▂▄▇█▇▄▂   (same as current)
+Zoom In:   ▁▂▃▅▇█▇▅▃▂▁▂▃▄▅▆▇█▇▆▅▄▃▂▁▂▃▄   (smooth, adaptive detail!)
+```
+
+**Key Insights:**
+
+1. Current implementation has audio-length-dependent quality (bug!)
+2. At high zoom, we need more peaks to represent the same audio accurately
+3. Canvas + viewport culling fixes both issues
+
+---
+
+## Current Implementation Analysis
+
+### Peak Extraction (audio.ts:390-410)
+
+```typescript
+const PEAKS_PER_SECOND = 100;
+
+function getAudioBufferPeaks(buffer, peaksPerSecond): number[] {
+  const samplesPerPeak = Math.floor(sampleRate / peaksPerSecond);
+  // Iterates through audio samples, takes max of each chunk
+  // Returns flat array of peak values (0-1)
+}
+```
+
+- **Fixed resolution**: 100 peaks/second regardless of audio duration or zoom level
+- **Pre-computed once**: On audio load, stored in project state
+- **One-time cost**: ~44.1kHz sample rate → 441 samples per peak
+- **Storage**: For 3-minute song = 18,000 peaks (~72KB in memory)
+
+### Waveform Rendering (piano-roll.tsx:1784-1838)
+
+```typescript
+function Waveform({ peaks, height }) {
+  // Downsample to max 500 points
+  const maxPoints = 500;
+  const step = Math.max(1, Math.floor(peaks.length / maxPoints));
+
+  // Take max of each chunk
+  // Generate SVG path with percentage-based x coordinates
+  // Returns single <path> element with fill and stroke
+}
+```
+
+- **SVG-based**: Uses viewBox and percentage scaling
+- **Performance guard**: Caps at 500 points to avoid SVG lag
+- **Viewport-agnostic**: Renders entire waveform, relies on CSS scaling
+
+### Data Flow
+
+```
+Audio load → getAudioBufferPeaks(100/sec) → store.audioPeaks[]
+                                                    ↓
+                                            WaveformArea
+                                                    ↓
+                                        Waveform component
+                                                    ↓
+                                        Downsample to 500 pts
+                                                    ↓
+                                                SVG path
+```
+
+## Research Findings
+
+### Industry Best Practices
+
+#### 1. **BBC Peaks.js** (Production-Grade Waveform Library)
+
+**Key Features:**
+
+- Multi-resolution waveform data (uses `waveform-data.js`)
+- Pre-computed peaks at different zoom levels
+- Canvas-based rendering with viewport culling
+- Server-side generation via `audiowaveform` tool (C++)
+- Client-side Web Audio API fallback
+
+**Architecture:**
+
+```typescript
+// Waveform data format (JSON or binary)
+{
+  version: 2,
+  channels: 2,
+  sample_rate: 44100,
+  samples_per_pixel: 512,  // Zoom level
+  bits: 8,
+  length: 12000,
+  data: [min, max, min, max, ...]  // Interleaved peaks
+}
+```
+
+**Resampling Strategy:**
+
+- Multiple zoom levels pre-computed
+- Client requests appropriate resolution for current zoom
+- Canvas renders only visible viewport
+- ~100-512 samples per pixel at overview zoom
+- ~8-32 samples per pixel at detail zoom
+
+**Takeaway:** Multi-resolution approach is industry standard for large audio files.
+
+---
+
+#### 2. **WaveSurfer.js** (Popular Open Source)
+
+**Rendering Modes:**
+
+- Canvas 2D (default, good performance)
+- WebGL experimental (for very large files)
+
+**Peak Generation:**
+
+```javascript
+function getPeaks(buffer, pxPerSec, start, end) {
+  const sampleWidth = ~~(sampleRate / pxPerSec);
+  const peaks = [];
+  for (let i = start; i < end; i++) {
+    let max = 0,
+      min = 0;
+    for (let j = i * sampleWidth; j < (i + 1) * sampleWidth; j++) {
+      const value = chanData[j];
+      max = Math.max(value, max);
+      min = Math.min(value, min);
+    }
+    peaks.push(max, min); // Store both for filled waveform
+  }
+  return peaks;
+}
+```
+
+**Key Insights:**
+
+- Generates peaks **on-demand** based on `pxPerSec` (pixels per second)
+- Viewport-aware: only processes visible `start` to `end` range
+- Stores min/max pairs for symmetric waveforms
+- Canvas rendering with requestAnimationFrame
+
+**Takeaway:** On-demand peak generation works well for moderate file sizes.
+
+---
+
+#### 3. **WebGL Waveform Rendering** (High Performance)
+
+**Libraries Found:**
+
+- `gl-waveform` by @dy - WebGL-based renderer
+- `webgl-plot` - Real-time plotting library
+- Signal (explored): WebGL instanced rendering for MIDI
+
+**Approach:**
+
+- Use vertex buffer for peak data
+- Instanced rendering for vertical bars
+- Fragment shader for coloring/gradients
+- GPU-accelerated, handles millions of samples
+
+**Complexity Trade-off:**
+
+- 10x faster than Canvas for very large datasets
+- Requires shader programming knowledge
+- More setup code, harder to debug
+- Overkill for files < 30 minutes
+
+**Takeaway:** WebGL is for extreme cases; Canvas is sufficient for typical use.
+
+---
+
+#### 4. **Doist Ramble** (Modern Real-Time Waveform)
+
+**Recent Implementation (2026-01-02):**
+
+```javascript
+const x = Math.round(
+  width - sampleWidth - i * sampleWidthWithGap - sampleScrollOffsetRef.current,
+);
+```
+
+**Features:**
+
+- Canvas-based with scrolling effect
+- Frame-rate independent drawing (RAF with time delta)
+- Real-time audio-reactive visualization
+- Configurable bar width/gap/scroll speed
+
+**Takeaway:** Canvas + RAF is modern standard for smooth, responsive waveforms.
+
+---
+
+### SVG vs Canvas Analysis
+
+#### Current SVG Approach
+
+**Pros:**
+
+- Declarative, easy to style
+- Scales with CSS (no redraw needed)
+- Integrates with existing DOM structure
+- Vector-based, resolution-independent
+
+**Cons:**
+
+- Performance degrades with many points (>1000)
+- Not viewport-aware (renders entire duration)
+- Fixed resolution limits zoom detail
+- Path generation is CPU-bound
+
+#### Canvas Approach (Recommended)
+
+**Pros:**
+
+- High performance with many data points (tested to 50k+ points)
+- Viewport-aware rendering (only visible region)
+- Can render from higher-resolution data on zoom
+- GPU-accelerated drawing (via compositing)
+- Efficient for real-time updates
+- **Industry standard** (Peaks.js, WaveSurfer.js, Audacity web)
+
+**Cons:**
+
+- Requires manual redraw on scroll/zoom
+- Needs pixel density handling (HiDPI/retina)
+- More complex coordinate management
+- Requires cleanup (ref management)
+
+**Verdict:** Canvas is the clear winner for this use case.
+
+## Solution Options (Corrected)
+
+**Two independent decisions:**
+
+```
+Decision 1: Data Optimization
+  ├─ Viewport Culling (fixes audio-length bug)
+  └─ + Adaptive Resolution (adds zoom detail)
+
+Decision 2: Rendering Technology
+  ├─ Keep SVG
+  └─ Switch to Canvas
+
+These are orthogonal - any combination works!
+```
+
+---
+
+### Data Optimization Options
+
+#### Option 1A: Viewport Culling Only
+
+**Approach:**
+
+1. Calculate visible time range based on scroll position
+2. Slice peak array to visible range (or extract on-demand)
+3. Remove fixed 500-point downsampling
+4. Keep 100 peaks/sec resolution
+
+**Output:**
+
+```
+5-min file:  1,440 peaks (14.4s @ 100/sec)
+30-min file: 1,440 peaks (14.4s @ 100/sec)
+```
+
+**Fixes:**
+
+- ✅ Issue 1: Audio-length bug
+- ❌ Issue 2: Still no zoom detail
+
+**Complexity:** Low (1-2 hours for logic)
+
+---
+
+#### Option 1B: Viewport Culling + Adaptive Resolution
+
+**Approach:**
+
+1. Calculate visible time range (culling)
+2. Calculate target resolution based on zoom (adaptive)
+3. Extract peaks on-demand from audio buffer at target resolution
+
+**Output:**
+
+```
+Zoomed out (20 px/beat):  1,440 peaks (14.4s @ 100/sec)
+Zoomed in (200 px/beat):  11,520 peaks (14.4s @ 800/sec)
+```
+
+**Fixes:**
+
+- ✅ Issue 1: Audio-length bug
+- ✅ Issue 2: Zoom detail
+
+**Complexity:** Medium (4-6 hours for extraction + caching)
+
+---
+
+### Rendering Technology Options
+
+#### Option 2A: Keep SVG
+
+**Approach:**
+
+- Keep current SVG `<path>` rendering
+- Remove 500-point downsampling limit
+- Render all peaks from data layer
+
+**Questions to answer:**
+
+- Does SVG handle 1,440 peaks smoothly? (viewport culling)
+- Does SVG handle 11,520 peaks smoothly? (adaptive at high zoom)
+- Performance varies by browser/device - needs testing
+
+**Complexity:** Minimal (remove downsampling code)
+
+---
+
+#### Option 2B: Switch to Canvas
+
+**Approach:**
+
+- Replace SVG with Canvas
+- Implement `ctx.lineTo()` rendering
+- Handle device pixel ratio for retina displays
+
+**Benefits:**
+
+- Likely better performance (general industry consensus)
+- More control over rendering
+
+**Questions:**
+
+- How much faster is it actually? (needs measurement)
+- Is the effort worth it if SVG works fine?
+
+**Complexity:** Low-Medium (2-3 hours for canvas setup)
+
+---
+
+### Combined Options Matrix
+
+| Data                   | Rendering  | Fixes Issue 1 | Fixes Issue 2 | Effort | Testing Needed       |
+| ---------------------- | ---------- | ------------- | ------------- | ------ | -------------------- |
+| **Culling**            | **SVG**    | ✅            | ❌            | 1-2h   | SVG with 1.4K peaks  |
+| **Culling**            | **Canvas** | ✅            | ❌            | 2-3h   | Canvas perf baseline |
+| **Culling + Adaptive** | **SVG**    | ✅            | ✅            | 5-7h   | SVG with 11K peaks   |
+| **Culling + Adaptive** | **Canvas** | ✅            | ✅            | 6-9h   | Canvas perf at scale |
+
+---
+
+### Recommended Approach: Incremental + Test-Driven
+
+**Phase 1: Fix the Bug (1-2 hours)**
+
+```
+Implement: Viewport Culling
+Rendering: Keep SVG (for now)
+Result: Bug fixed, render 1,440 peaks instead of 30,000
+```
+
+**Testing checkpoint:**
+
+- Does SVG handle 1,440 peaks smoothly?
+- If YES: Bug is fixed, ship it ✅
+- If NO: Add Phase 1.5 (switch to Canvas)
+
+---
+
+**Phase 2: Add Zoom Detail (4-6 hours) - OPTIONAL**
+
+```
+Implement: Adaptive Resolution
+Rendering: Still SVG (or Canvas from Phase 1.5)
+Result: Up to 11,520 peaks at high zoom
+```
+
+**Testing checkpoint:**
+
+- Does current renderer handle 11,520 peaks smoothly?
+- If YES: Feature complete ✅
+- If NO: Switch to Canvas if not already done
+
+---
+
+**Phase 3: Optimize Renderer (2-3 hours) - IF NEEDED**
+
+```
+Implement: Canvas rendering
+Reason: Only if testing shows SVG performance issues
+```
+
+---
+
+### Key Insight: Test First, Optimize Later
+
+**Don't prematurely optimize:**
+
+1. Fix the bug with minimal changes (viewport culling)
+2. Test if SVG handles the new peak counts
+3. Only switch to Canvas if there's a measured performance problem
+
+**The 500-point limit might be overly conservative!**
+
+- Modern browsers (2026) might handle 5,000+ SVG points fine
+- We won't know until we test
+- Canvas is easier to optimize later if needed
+
+---
+
+### Option B: Canvas + Viewport Culling Only
+
+**Approach:**
+
+1. Replace SVG with Canvas
+2. Calculate visible time range
+3. Render only visible peaks
+4. Keep 100 peaks/sec resolution
+5. Remove 500-point downsampling
+
+**What you get:**
+
+```
+Same as Option A, but with Canvas:
+  5-min file:  Render 1,440 peaks → Canvas draws all 1,440 ✅
+  30-min file: Render 1,440 peaks → Canvas draws all 1,440 ✅
+
+Performance: 2-3ms per frame (Canvas) vs 5-8ms (SVG)
+```
+
+**Fixes:**
+
+- ✅ Issue 1: Audio-length bug
+- ❌ Issue 2: Still no zoom detail (yet)
+
+**Benefits:**
+
+- Better performance than SVG
+- Cleaner rendering code
+- **Can add adaptive resolution later** (Option C)
+- Industry-standard approach
+
+**Drawbacks:**
+
+- More work than Option A (canvas setup)
+- Still doesn't solve zoom detail (until Phase 3)
+
+**Implementation Complexity:** Low-Medium (2-3 hours)
+
+---
+
+### Option C: Canvas + Adaptive Resolution (Full Solution)
+
+**Approach:**
+
+1. Replace SVG with Canvas
+2. Calculate visible viewport region (culling)
+3. Calculate target resolution based on zoom (adaptive)
+4. Generate peaks on-demand from audio buffer
+5. Render all generated peaks (no downsampling)
+
+**What you get:**
+
+```
+30-min file, different zoom levels:
+
+Zoomed out (20 px/beat):
+  Visible: 57.6s × 100/sec = 5,760 peaks
+  Render: All 5,760 peaks → 3ms ✅
+
+Zoomed in (200 px/beat):
+  Visible: 5.76s × 800/sec = 4,608 peaks
+  Render: All 4,608 peaks → 2ms ✅
+
+Result: More detail when zoomed in! Quality scales! ✅
+```
+
+**Fixes:**
+
+- ✅ Issue 1: Audio-length bug (viewport culling)
+- ✅ Issue 2: Zoom detail (adaptive resolution)
+
+**Benefits:**
+
+- Fixes both problems completely
+- Smooth, continuous zoom experience
+- Minimal memory overhead (< 1MB cache)
+- Industry standard approach (Peaks.js, WaveSurfer.js)
+- Best quality at all zoom levels
+
+**Drawbacks:**
+
+- Most complex implementation
+- Requires on-demand peak extraction
+- Need to manage audio buffer reference
+
+**Implementation Complexity:** Medium (6-9 hours, split into phases)
+
+---
+
+### Option D: Higher Fixed Resolution (Quick Fix)
+
+**Approach:**
+
+1. Increase PEAKS_PER_SECOND (100 → 500 or 1000)
+2. Keep SVG or switch to Canvas
+3. Add viewport culling
+
+**Fixes:**
+
+- ✅ Issue 1: Audio-length bug (with viewport culling)
+- ⚠️ Issue 2: Partial fix (better but not adaptive)
+
+**Benefits:**
+
+- Simple implementation
+- Immediate quality improvement
+- Works with SVG or Canvas
+
+**Drawbacks:**
+
+- Wastes memory at low zoom (storing unnecessary detail)
+- Still fixed resolution (no adaptive zoom)
+- Larger project file
+
+**Implementation Complexity:** Low (1-2 hours)
+
+## Recommendation: Test-Driven Incremental Approach
+
+**Corrected thinking: Data optimization and rendering technology are orthogonal.**
+
+### Phase 1: Fix the Bug (1-2 hours)
+
+**Implement:**
+
+- Viewport culling (data layer)
+- Keep SVG (no rendering changes)
+- Remove 500-point downsampling
+
+**Code changes:**
+
+```typescript
+// In WaveformArea, calculate visible peaks
+const visibleStartSec = /* viewport start time */;
+const visibleEndSec = /* viewport end time */;
+const startIdx = Math.floor(visibleStartSec * peaksPerSecond);
+const endIdx = Math.ceil(visibleEndSec * peaksPerSecond);
+const visiblePeaks = audioPeaks.slice(startIdx, endIdx);
+
+// Pass to Waveform - remove downsampling inside
+<Waveform peaks={visiblePeaks} height={height} />
+```
+
+**Result:**
+
+- 5-min file: Render 1,440 peaks ✅
+- 30-min file: Render 1,440 peaks ✅
+- Bug fixed!
+
+**Test:**
+
+- Does SVG handle 1,440 peaks smoothly?
+- Measure: Frame rate during scroll
+- On: Dev machine + low-end device if available
+
+**Decision point:**
+
+- ✅ If smooth: Ship it! Bug is fixed.
+- ❌ If laggy: Proceed to Phase 1.5
+
+---
+
+### Phase 1.5: Switch to Canvas (2-3 hours) - IF NEEDED
+
+**Only do this if Phase 1 testing shows SVG performance issues.**
+
+**Implement:**
+
+- Replace SVG `<path>` with `<canvas>`
+- Port rendering logic to `ctx.lineTo()`
+- Handle device pixel ratio
+
+**Result:**
+
+- Same data (1,440 peaks)
+- Different renderer (Canvas instead of SVG)
+- Likely better performance
+
+**Test:**
+
+- Canvas should handle 1,440 peaks smoothly
+- Measure improvement vs SVG
+
+---
+
+### Phase 2: Add Adaptive Resolution (4-6 hours) - OPTIONAL
+
+**Only do this if users request better zoom detail.**
+
+**Implement:**
+
+- Add `extractPeaksRange()` to AudioManager
+- Calculate target resolution based on zoom
+- Extract peaks on-demand from audio buffer
+
+**Result:**
+
+- Zoomed out: 1,440 peaks (same as before)
+- Zoomed in: Up to 11,520 peaks (8× more detail)
+
+**Test:**
+
+- Does current renderer (SVG or Canvas) handle 11,520 peaks?
+- If SVG and it's slow, switch to Canvas
+
+---
+
+### Decision Matrix (Corrected)
+
+| Phase   | Data Layer            | Renderer         | Effort | When to Do                    |
+| ------- | --------------------- | ---------------- | ------ | ----------------------------- |
+| **1**   | Viewport culling      | Keep SVG         | 1-2h   | **Do first** (fixes bug)      |
+| **1.5** | (same)                | Switch to Canvas | 2-3h   | **If** SVG is slow            |
+| **2**   | + Adaptive resolution | Keep/Canvas      | 4-6h   | **If** users want zoom detail |
+
+**Total minimum:** 1-2 hours (just fix the bug)  
+**Total if Canvas needed:** 3-5 hours  
+**Total with adaptive:** 5-11 hours
+
+---
+
+### Why This Approach?
+
+**Separates concerns:**
+
+1. Bug fix (viewport culling) is independent of renderer
+2. Renderer choice (SVG vs Canvas) based on measured performance
+3. Feature enhancement (adaptive) is separate decision
+
+**Test-driven:**
+
+1. Fix bug with minimal changes
+2. Test if it works
+3. Only optimize if there's a real problem
+
+**Don't assume:**
+
+- ❌ "SVG can't handle 1,440 peaks" - We don't know!
+- ❌ "Canvas is always faster" - Measure it!
+- ❌ "Must use Canvas for adaptive" - Try SVG first!
+
+**The 500-point limit might be outdated** (from older browsers or conservative coding). Modern SVG might handle 5,000+ points fine.
+
+### Implementation Strategy (Revised)
+
+**Separating bug fix from feature enhancement.**
+
+#### Option B: Canvas + Viewport Culling (Recommended)
+
+**Goal:** Fix audio-length bug + improve performance
+
+**Phase 1: Canvas Rendering (1-2 hours)**
+
+**Tasks:**
+
+1. Replace `<svg>` with `<canvas>` in Waveform component (piano-roll.tsx:1784-1838)
+2. Implement device pixel ratio handling (Signal pattern)
+   ```typescript
+   const dpr = window.devicePixelRatio || 1;
+   canvas.width = width * dpr;
+   canvas.height = height * dpr;
+   ctx.scale(dpr, dpr);
+   ```
+3. Port SVG path rendering to Canvas 2D context
+   - Use `ctx.beginPath()`, `ctx.moveTo()`, `ctx.lineTo()`
+   - Fill and stroke with same colors as SVG
+4. **Remove the 500-point downsampling** (lines 1789-1801)
+5. Add `useEffect` hook to trigger redraw when peaks change
+
+**Files:**
+
+- `src/components/piano-roll.tsx` - Waveform component (lines 1784-1838)
+
+**Testing:**
+
+- Visual: Canvas output matches current SVG quality
+- E2E test: `e2e/transport.spec.ts` - verify waveform still renders
+
+**Success Criteria:**
+
+- Canvas renders all peaks (no 500-point limit)
+- Works on retina displays
+- Same or better performance than SVG
+
+---
+
+**Phase 2: Viewport Culling (1 hour)**
+
+**Tasks:**
+
+1. Calculate visible time range in WaveformArea
+
+   ```typescript
+   const audioStartSec = audioOffset;
+   const audioEndSec = audioOffset + audioDuration;
+
+   // Viewport bounds in beats
+   const viewportStartBeat = scrollX;
+   const viewportEndBeat = scrollX + viewportWidth / pixelsPerBeat;
+
+   // Convert to seconds
+   const viewportStartSec = (viewportStartBeat / tempo) * 60;
+   const viewportEndSec = (viewportEndBeat / tempo) * 60;
+
+   // Clamp to audio bounds
+   const visibleStartSec = Math.max(viewportStartSec, audioStartSec);
+   const visibleEndSec = Math.min(viewportEndSec, audioEndSec);
+   ```
+
+2. Slice peaks array to visible range
+
+   ```typescript
+   const startIdx = Math.floor(
+     (visibleStartSec - audioStartSec) * peaksPerSecond,
+   );
+   const endIdx = Math.ceil((visibleEndSec - audioStartSec) * peaksPerSecond);
+   const visiblePeaks = audioPeaks.slice(startIdx, endIdx);
+   ```
+
+3. Pass only visible peaks to Canvas renderer
+   ```typescript
+   <Waveform
+     peaks={visiblePeaks}
+     startTime={visibleStartSec}
+     peaksPerSecond={peaksPerSecond}
+     height={height}
+   />
+   ```
+
+**Files:**
+
+- `src/components/piano-roll.tsx` - WaveformArea component (around line 1607)
+
+**Testing:**
+
+- Test with 5-min and 30-min audio files
+- Verify waveform quality is identical for both
+- Check that scrolling updates visible peaks
+
+**Success Criteria:**
+
+- ✅ Audio-length bug FIXED (30-min file looks same as 5-min)
+- Waveform updates smoothly during scroll
+- No performance regression
+
+---
+
+#### Future: Adaptive Resolution (Optional, 4-6 hours)
+
+**Only implement if users request better zoom detail.**
+
+**Tasks:**
+
+1. Add `extractPeaksRange()` method to AudioManager
+2. Calculate target resolution based on zoom level
+3. Extract peaks on-demand from audio buffer
+4. Add simple cache (10 entries)
+
+**When to do this:**
+
+- User feedback requests more detail at zoom
+- After validating Phase 1+2 work well
+- When you have 4-6 hours available
+
+**Files:**
+
+- `src/lib/audio.ts` - Add `extractPeaksRange()` method
+- `src/components/piano-roll.tsx` - Replace stored peaks with on-demand extraction
+
+---
+
+### Summary: Incremental Delivery
+
+| Phase                | Goal                                | Effort | Fixes               |
+| -------------------- | ----------------------------------- | ------ | ------------------- |
+| **1: Canvas**        | Replace SVG, remove 500-point limit | 1-2h   | Better foundation   |
+| **2: Viewport**      | Only render visible peaks           | 1h     | ✅ Audio-length bug |
+| **Future: Adaptive** | Dynamic resolution based on zoom    | 4-6h   | ✅ Zoom detail      |
+
+**Total for bug fix: 2-3 hours**  
+**Total for full solution: 6-9 hours**
+
+**Ship Phase 1+2 first, then evaluate if Phase 3 is needed.**
+
+## Key Patterns from Signal Piano Roll
+
+While Signal doesn't render waveforms (MIDI-only), its architecture provides valuable patterns:
+
+### 1. **Viewport-Aware Rendering** (EventView Pattern)
+
+```typescript
+// From Signal: refs/signal/app/src/observer/EventView.ts
+class EventView<T> {
+  private startTick: number = 0;
+  private endTick: number = 0;
+
+  get windowedEvents(): readonly T[] {
+    const range = Range.create(this.startTick, this.endTick);
+    return this.loadEvents().filter((e) =>
+      Range.intersects(range, Range.fromLength(e.tick, e.tick + e.duration)),
+    );
+  }
+
+  setRange(startTick: number, endTick: number) {
+    this.startTick = startTick;
+    this.endTick = endTick;
+  }
+}
+```
+
+**Adapt for Waveform:**
+
+```typescript
+class WaveformView {
+  private startSecond: number = 0;
+  private endSecond: number = 0;
+  private peaksPerSecond: number = 100;
+
+  get visiblePeaks(): Float32Array {
+    const startIdx = Math.floor(this.startSecond * this.peaksPerSecond);
+    const endIdx = Math.ceil(this.endSecond * this.peaksPerSecond);
+    return this.allPeaks.subarray(startIdx, endIdx);
+  }
+
+  setViewport(startSec: number, endSec: number, zoom: number) {
+    this.startSecond = startSec;
+    this.endSecond = endSec;
+    this.peaksPerSecond = this.calculateResolution(zoom);
+  }
+}
+```
+
+---
+
+### 2. **Transform System** (Coordinate Mapping)
+
+```typescript
+// From Signal: refs/signal/app/src/entities/transform/TickTransform.ts
+class TickTransform {
+  constructor(private readonly pixelsPerTick: number) {}
+
+  getX(tick: number) {
+    return tick * this.pixelsPerTick;
+  }
+  getTick(x: number) {
+    return x / this.pixelsPerTick;
+  }
+}
+```
+
+**Adapt for Waveform:**
+
+```typescript
+class WaveformTransform {
+  constructor(
+    private pixelsPerSecond: number,
+    private tempo: number,
+  ) {}
+
+  secondsToPixels(seconds: number): number {
+    return seconds * this.pixelsPerSecond;
+  }
+
+  pixelsToSeconds(pixels: number): number {
+    return pixels / this.pixelsPerSecond;
+  }
+
+  beatsToSeconds(beats: number): number {
+    return (beats / this.tempo) * 60;
+  }
+}
+```
+
+---
+
+### 3. **Zoom Around Point** (Preserve Cursor Position)
+
+```typescript
+// From Signal: refs/signal/app/src/hooks/useTickScroll.tsx
+const scaleAroundPointX = (scaleXDelta: number, pixelX: number) => {
+  const tickAtMouse = transform.getTick(scrollLeft + pixelX);
+
+  // Apply scale
+  setScale((prev) => clamp(prev * (1 + scaleXDelta), min, max));
+
+  // Adjust scroll to keep mouse position stable
+  const newTickAtMouse = newTransform.getTick(newScrollLeft + pixelX);
+  const scrollDelta = newTickAtMouse - tickAtMouse;
+  adjustScroll(-scrollDelta);
+};
+```
+
+**Already implemented in piano-roll.tsx!** Our zoom behavior matches this pattern.
+
+---
+
+### 4. **WebGL Instanced Rendering** (Future Enhancement)
+
+Signal renders thousands of MIDI notes with one draw call using instanced rendering:
+
+```typescript
+// From Signal: refs/signal/app/src/components/PianoRoll/shaders/NoteShader.ts
+// Upload note data to GPU buffers
+const boundsBuffer = new Float32Array(notes.length * 4);
+for (let i = 0; i < notes.length; i++) {
+  boundsBuffer[i * 4 + 0] = note.x;
+  boundsBuffer[i * 4 + 1] = note.y;
+  boundsBuffer[i * 4 + 2] = note.width;
+  boundsBuffer[i * 4 + 3] = note.height;
+}
+
+// Single draw call for all notes
+gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, notes.length);
+```
+
+**For waveform:** Could adapt for rendering thousands of vertical bars, but Canvas is sufficient for now.
+
+---
+
+### 5. **Device Pixel Ratio Handling**
+
+```typescript
+// From Signal: refs/signal/app/src/components/DrawCanvas.tsx
+const dpr = window.devicePixelRatio || 1;
+canvas.width = canvas.offsetWidth * dpr;
+canvas.height = canvas.offsetHeight * dpr;
+ctx.scale(dpr, dpr);
+```
+
+**Critical for sharp rendering on retina displays!**
+
+---
+
+## Technical Details
+
+### Canvas Rendering Implementation
+
+**Based on WaveSurfer.js + Signal patterns:**
+
+```typescript
+function renderWaveform(
+  canvas: HTMLCanvasElement,
+  peaks: Float32Array, // Pre-extracted peaks for visible range
+  viewportStartTime: number,
+  viewportEndTime: number,
+  pixelsPerSecond: number,
+  peaksPerSecond: number,
+  height: number,
+) {
+  const ctx = canvas.getContext("2d", { alpha: true })!;
+  const dpr = window.devicePixelRatio || 1;
+
+  // 1. Set canvas size (logical vs physical pixels) - FROM SIGNAL
+  canvas.width = canvas.offsetWidth * dpr;
+  canvas.height = canvas.offsetHeight * dpr;
+  ctx.scale(dpr, dpr);
+
+  // 2. Clear canvas
+  ctx.clearRect(0, 0, canvas.offsetWidth, canvas.offsetHeight);
+
+  // 3. Calculate visible peak range - FROM WAVESURFER
+  const startIdx = Math.floor(viewportStartTime * peaksPerSecond);
+  const endIdx = Math.ceil(viewportEndTime * peaksPerSecond);
+  const visiblePeaks = peaks.subarray(startIdx, endIdx);
+
+  if (visiblePeaks.length === 0) return;
+
+  // 4. Draw waveform path
+  const centerY = height / 2;
+  const maxAmplitude = centerY * 0.9;
+  const pixelsPerPeak = pixelsPerSecond / peaksPerSecond;
+
+  ctx.beginPath();
+  ctx.fillStyle = "rgba(255, 255, 255, 0.3)";
+  ctx.strokeStyle = "rgba(255, 255, 255, 0.5)";
+  ctx.lineWidth = 1;
+
+  // Top half (positive amplitude)
+  for (let i = 0; i < visiblePeaks.length; i++) {
+    const x = i * pixelsPerPeak;
+    const y = centerY - visiblePeaks[i] * maxAmplitude;
+    i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+  }
+
+  // Bottom half (mirrored, draw in reverse)
+  for (let i = visiblePeaks.length - 1; i >= 0; i--) {
+    const x = i * pixelsPerPeak;
+    const y = centerY + visiblePeaks[i] * maxAmplitude;
+    ctx.lineTo(x, y);
+  }
+
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+}
+
+// Usage in component
+useEffect(() => {
+  if (!canvasRef.current) return;
+
+  const viewportWidth = containerWidth;
+  const viewportStartSec = (scrollX / pixelsPerBeat) * (60 / tempo);
+  const viewportEndSec =
+    viewportStartSec + (viewportWidth / pixelsPerBeat) * (60 / tempo);
+  const pixelsPerSecond = (tempo / 60) * pixelsPerBeat;
+
+  // Get or generate peaks for current zoom level
+  const peaks = getPeaksForZoom(
+    audioBuffer,
+    viewportStartSec,
+    viewportEndSec,
+    pixelsPerSecond,
+  );
+
+  renderWaveform(
+    canvasRef.current,
+    peaks,
+    viewportStartSec,
+    viewportEndSec,
+    pixelsPerSecond,
+    peaks.length / (viewportEndSec - viewportStartSec), // actual peaksPerSecond
+    waveformHeight,
+  );
+}, [scrollX, pixelsPerBeat, tempo, audioBuffer, waveformHeight]);
+```
+
+### Understanding "Downsampling" in the Proposal
+
+**Short answer:** Yes, there is downsampling, but it happens **during peak extraction**, not after.
+
+**Key Difference from Current SVG Implementation:**
+
+```typescript
+// ❌ CURRENT (SVG): Bad downsampling
+// 1. Extract all peaks at fixed 100/sec (30,000 peaks for 5min)
+// 2. Render: Downsample 30,000 → 500 points (lose 60:1 detail!)
+// 3. SVG draws 500 points for entire file
+
+// ✅ PROPOSED (Canvas): Smart downsampling
+// 1. Calculate viewport: only need 14.4 seconds @ default zoom
+// 2. Calculate resolution: need 266 peaks/sec for this zoom level
+// 3. Extract: Generate 3,830 peaks directly from audio samples
+// 4. Canvas draws all 3,830 peaks (no further downsampling!)
+```
+
+**The "downsampling" is actually peak extraction:**
+
+```typescript
+// This is the "downsampling" step - but it's intelligent!
+function extractPeaksRange(buffer, startSec, endSec, peaksPerSecond) {
+  const samplesPerPeak = sampleRate / peaksPerSecond;  // e.g., 166 samples → 1 peak
+
+  for (let i = 0; i < peakCount; i++) {
+    let max = 0;
+    // "Downsample" 166 audio samples into 1 peak value
+    for (let j = 0; j < samplesPerPeak; j++) {
+      max = Math.max(max, Math.abs(samples[...]))
+    }
+    peaks[i] = max;
+  }
+}
+```
+
+**So technically:**
+
+- **Yes**: 44,100 samples/sec → 266 peaks/sec is downsampling (166:1)
+- **But**: We do it **once** at the right resolution, render all results
+- **Not**: Extract high-res, then downsample again (double loss!)
+
+---
+
+**Visual Comparison of Downsampling Approaches:**
+
+```
+Audio samples (44.1kHz):  ▁▁▂▂▃▃▅▅▇▇██▇▇▅▅▃▃▂▂▁▁ (13.23M samples for 5min)
+                           ↓
+                    ┌──────┴──────┐
+                    │             │
+         ❌ CURRENT (Bad)    ✅ PROPOSED (Good)
+                    │             │
+                    ↓             ↓
+            ┌─────────────┐  ┌─────────────────┐
+            │ Step 1:     │  │ Step 1:         │
+            │ Extract ALL │  │ Calculate needs │
+            │ at 100/sec  │  │ - Viewport: 14s │
+            │ = 30,000    │  │ - Zoom: 80px/bt │
+            │   peaks     │  │ - Need: 266/sec │
+            └──────┬──────┘  └────────┬─────────┘
+                   ↓                  ↓
+            ┌─────────────┐  ┌─────────────────┐
+            │ Step 2:     │  │ Step 2:         │
+            │ Downsample  │  │ Extract visible │
+            │ 30,000→500  │  │ 14s × 266/sec   │
+            │ (60:1 loss!)│  │ = 3,726 peaks   │
+            └──────┬──────┘  └────────┬─────────┘
+                   ↓                  ↓
+            ┌─────────────┐  ┌─────────────────┐
+            │ Step 3:     │  │ Step 3:         │
+            │ SVG renders │  │ Canvas renders  │
+            │ 500 points  │  │ ALL 3,726 peaks │
+            └─────────────┘  └─────────────────┘
+
+Result:   ▃▃▅▅██▅▅▃▃     vs    ▁▂▃▅▇█▇▅▃▂▁
+         (blocky, 60:1)        (smooth, 166:1 but direct!)
+```
+
+**The key insight:**
+
+- Current: Two-stage downsampling (44.1k → 100/s → 500 points) = **compound loss**
+- Proposed: Single-stage downsampling (44.1k → 266/s, render all) = **optimal**
+
+Even though 166:1 > 60:1, the proposed approach looks better because:
+
+1. No secondary downsampling loss
+2. Adaptive to zoom (more detail when needed)
+3. Viewport-aware (only visible region)
+
+---
+
+### Adaptive Peak Resolution Strategy
+
+**Based on WaveSurfer.js approach:**
+
+```typescript
+/**
+ * Calculate optimal peaks-per-second for current zoom level
+ * Goal: ~2 peaks per pixel for smooth waveform without over-sampling
+ */
+function calculateTargetResolution(
+  pixelsPerBeat: number,
+  tempo: number,
+  minPeaksPerSecond: number = 100,
+  maxPeaksPerSecond: number = 10000,
+): number {
+  // Calculate how many pixels represent 1 second of audio
+  const pixelsPerSecond = (tempo / 60) * pixelsPerBeat;
+
+  // Target: 2-3 peaks per pixel for smooth rendering
+  // Rationale: Nyquist-inspired (need 2x sampling for accurate representation)
+  const targetPeaksPerSecond = Math.round(pixelsPerSecond * 2);
+
+  // Clamp to reasonable range
+  // Min: 100 peaks/sec (current baseline)
+  // Max: 10000 peaks/sec (44.1kHz / 4.41 samples per peak = ~220Hz frequency detail)
+  return Math.max(
+    minPeaksPerSecond,
+    Math.min(maxPeaksPerSecond, targetPeaksPerSecond),
+  );
+}
+
+// Real-world examples:
+// tempo=120, pixelsPerBeat=20 (overview):
+//   → 40 px/sec → 80 peaks/sec → clamped to 100 (use current resolution)
+//
+// tempo=120, pixelsPerBeat=80 (default):
+//   → 160 px/sec → 320 peaks/sec (3x more detail than current)
+//
+// tempo=120, pixelsPerBeat=200 (zoomed in):
+//   → 400 px/sec → 800 peaks/sec (8x more detail)
+//
+// tempo=120, pixelsPerBeat=500 (extreme zoom):
+//   → 1000 px/sec → 2000 peaks/sec (20x more detail, can see individual drum hits)
+```
+
+**Alternative: Discrete Zoom Levels (Peaks.js style)**
+
+```typescript
+// Pre-defined zoom levels matching typical use cases
+const ZOOM_LEVELS = [
+  { pixelsPerSecond: 50, peaksPerSecond: 100 }, // Overview
+  { pixelsPerSecond: 100, peaksPerSecond: 200 }, // Default
+  { pixelsPerSecond: 200, peaksPerSecond: 500 }, // Medium zoom
+  { pixelsPerSecond: 500, peaksPerSecond: 1000 }, // High zoom
+  { pixelsPerSecond: 1000, peaksPerSecond: 2000 }, // Max detail
+];
+
+function selectZoomLevel(pixelsPerSecond: number) {
+  // Find closest matching level (round up for better quality)
+  return (
+    ZOOM_LEVELS.find((level) => level.pixelsPerSecond >= pixelsPerSecond) ||
+    ZOOM_LEVELS[ZOOM_LEVELS.length - 1]
+  );
+}
+```
+
+**Recommendation:** Start with continuous calculation, optionally add discrete levels if caching proves beneficial.
+
+### Computation Analysis (Back-of-Envelope)
+
+**Scenario:** 5-minute song, 100 BPM, 44.1kHz stereo, 1920px viewport width
+
+**TL;DR Results:**
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Peak Extraction: 0.016ms - 0.8ms  (always < 1ms) ✅         │
+│ Canvas Rendering: ~2-3ms           (GPU accelerated) ✅      │
+│ Total Frame Time: ~2-4ms           (16ms budget = 60fps) ✅  │
+│                                                              │
+│ Blocking: Main thread, but imperceptible (< 1 frame)        │
+│ Workers: NOT NEEDED - computation is already fast enough    │
+│ Memory: +152KB typical, +760KB worst case (< 1MB) ✅         │
+│                                                              │
+│ Verdict: NO PERFORMANCE CONCERNS at any zoom level 🎉       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+#### Audio File Stats
+
+```
+Duration: 5 minutes = 300 seconds
+Sample rate: 44,100 Hz
+Total samples: 300s × 44,100 = 13,230,000 samples
+Audio buffer size: 13.23M × 4 bytes (float32) × 2 channels = ~106 MB
+(Tone.js already loads this into memory for playback)
+```
+
+---
+
+#### Current Implementation (SVG, 100 peaks/sec)
+
+**On Audio Load (One-time):**
+
+```
+Peak count: 300s × 100 peaks/sec = 30,000 peaks
+Samples per peak: 44,100 / 100 = 441 samples
+
+Loop iterations: 30,000 peaks × 441 samples = 13.23M operations
+Operations: Array access + Math.abs + comparison
+Cost: ~1-2 CPU cycles per sample (tight loop)
+
+Estimated time: 13.23M ops / 3 GHz CPU = ~4-8ms (FAST ✅)
+Threading: Main thread, blocks UI briefly
+Storage: 30,000 peaks × 4 bytes = 120 KB
+```
+
+**On Render (Every scroll/zoom):**
+
+```
+SVG path generation: 30,000 peaks → downsample to 500 points
+Downsample loop: 30,000 / 60 = 500 chunks, take max of each
+
+Operations: 30,000 comparisons + 500 string concatenations
+Estimated time: ~2-4ms (FAST ✅)
+Threading: Main thread (React render)
+```
+
+**⚠️ CRITICAL ISSUE FOUND:** Current implementation renders ALL peaks regardless of audio length!
+
+```typescript
+// Current code (piano-roll.tsx:1754-1758)
+<Waveform
+  peaks={audioPeaks}  // ← Entire audio file (30,000 peaks for 5min)
+  height={height - 8}
+/>
+
+// Inside Waveform component:
+const step = Math.max(1, Math.floor(peaks.length / maxPoints));
+// 5-min file:  30,000 / 500 = 60 peaks per point
+// 30-min file: 180,000 / 500 = 360 peaks per point  ← Loss of detail!
+```
+
+**Problems:**
+
+1. **Audio-length dependent quality** - Longer songs show less detail (odd!)
+2. **No viewport culling** - Renders entire duration even if scrolled
+3. **Fixed 500 points** - Works for 5min, but 30min loses 360:1 detail
+4. **SVG uses percentage scaling** - viewBox `preserveAspectRatio="none"` stretches to fit
+
+**Why it "works" currently:**
+
+- 5-minute song: 30,000 peaks / 500 = 60x downsampling (acceptable)
+- But a 30-minute song: 180,000 peaks / 500 = 360x downsampling (terrible!)
+- SVG `viewBox="0 0 1000 height"` scales to container width
+- No zoom support - always shows full duration
+
+**Verdict:** Current implementation has a **major scaling bug** that adaptive Canvas will fix!
+
+---
+
+#### Proposed Implementation (Canvas, Adaptive)
+
+**Phase 1: Canvas (Same Resolution)**
+
+**On Render:**
+
+```
+Same 30,000 peaks, downsample to 500 points
+Canvas operations:
+  - 500 × lineTo() calls
+  - 1 × fill() + stroke()
+
+Estimated time: ~1-2ms (FASTER than SVG ✅)
+Threading: Main thread (React useEffect)
+```
+
+---
+
+**Phase 2: Adaptive Resolution**
+
+**Zoom Level 1: Overview (20 px/beat)**
+
+```
+Viewport: 1920px width
+Beats visible: 1920 / 20 = 96 beats = 57.6 seconds @ 100 BPM
+Pixels per second: 100 BPM / 60 × 20 = 33.3 px/sec
+
+Target resolution: 33.3 px/sec × 2 peaks/px = 67 → clamped to 100 peaks/sec
+Visible peaks: 57.6s × 100 = 5,760 peaks
+
+Peak extraction:
+  Samples to process: 57.6s × 44,100 = 2,540,160 samples
+  Samples per peak: 441
+  Loop iterations: 5,760 peaks × 441 = 2.54M ops
+
+Estimated time: 2.54M / 3 GHz = ~0.8ms (INSTANT ✅)
+Canvas render: 5,760 lineTo() calls = ~2-3ms
+Total: ~3-4ms per render
+```
+
+**Zoom Level 2: Default (80 px/beat, current default)**
+
+```
+Viewport: 1920px width
+Beats visible: 1920 / 80 = 24 beats = 14.4 seconds
+Pixels per second: 100 BPM / 60 × 80 = 133 px/sec
+
+Target resolution: 133 × 2 = 266 peaks/sec
+Visible peaks: 14.4s × 266 = 3,830 peaks
+
+Peak extraction:
+  Samples to process: 14.4s × 44,100 = 635,040 samples
+  Samples per peak: 44,100 / 266 = 166 samples
+  Loop iterations: 3,830 × 166 = 635K ops
+
+Estimated time: 635K / 3 GHz = ~0.2ms (INSTANT ✅)
+Canvas render: 3,830 lineTo() calls = ~2ms
+Total: ~2-3ms per render
+```
+
+**Zoom Level 3: High Zoom (200 px/beat)**
+
+```
+Viewport: 1920px width
+Beats visible: 1920 / 200 = 9.6 beats = 5.76 seconds
+Pixels per second: 100 BPM / 60 × 200 = 333 px/sec
+
+Target resolution: 333 × 2 = 666 peaks/sec
+Visible peaks: 5.76s × 666 = 3,837 peaks
+
+Peak extraction:
+  Samples to process: 5.76s × 44,100 = 254,016 samples
+  Samples per peak: 44,100 / 666 = 66 samples
+  Loop iterations: 3,837 × 66 = 253K ops
+
+Estimated time: 253K / 3 GHz = ~0.08ms (INSTANT ✅)
+Canvas render: 3,837 lineTo() calls = ~2ms
+Total: ~2ms per render
+```
+
+**Zoom Level 4: Extreme Zoom (500 px/beat)**
+
+```
+Viewport: 1920px width
+Beats visible: 1920 / 500 = 3.84 beats = 2.3 seconds
+Pixels per second: 100 BPM / 60 × 500 = 833 px/sec
+
+Target resolution: 833 × 2 = 1,666 peaks/sec
+Visible peaks: 2.3s × 1,666 = 3,832 peaks
+
+Peak extraction:
+  Samples to process: 2.3s × 44,100 = 101,430 samples
+  Samples per peak: 44,100 / 1,666 = 26 samples
+  Loop iterations: 3,832 × 26 = 99.6K ops
+
+Estimated time: 99.6K / 3 GHz = ~0.03ms (INSTANT ✅)
+Canvas render: 3,832 lineTo() calls = ~2ms
+Total: ~2ms per render
+```
+
+**Zoom Level 5: Maximum Detail (1000 px/beat)**
+
+```
+Viewport: 1920px width
+Beats visible: 1920 / 1000 = 1.92 beats = 1.15 seconds
+Pixels per second: 100 BPM / 60 × 1000 = 1,667 px/sec
+
+Target resolution: 1,667 × 2 = 3,334 peaks/sec
+Visible peaks: 1.15s × 3,334 = 3,834 peaks
+
+Peak extraction:
+  Samples to process: 1.15s × 44,100 = 50,715 samples
+  Samples per peak: 44,100 / 3,334 = 13 samples
+  Loop iterations: 3,834 × 13 = 49.8K ops
+
+Estimated time: 49.8K / 3 GHz = ~0.016ms (INSTANT ✅)
+Canvas render: 3,834 lineTo() calls = ~2ms
+Total: ~2ms per render
+```
+
+---
+
+#### Key Insights
+
+**0. Current SVG Implementation Has a Critical Bug! 🐛**
+
+- Renders ALL peaks (entire audio file) regardless of viewport
+- Downsamples to fixed 500 points based on TOTAL duration
+- Result: 30-min file shows 6x less detail than 5-min file (360:1 vs 60:1)
+- No viewport awareness - waste computation on off-screen data
+- **Canvas + viewport culling fixes this fundamental issue** ✅
+
+**1. Peak Extraction is Always Fast (< 1ms)**
+
+- Even at highest zoom, only processing 50K-2.5M samples
+- Tight loop with simple operations (array access, abs, max)
+- Modern CPUs process millions of ops per millisecond
+- **NO NEED FOR WEB WORKERS** ✅
+
+**2. Canvas Rendering Dominates (2-3ms)**
+
+- Drawing 3,000-5,000 line segments takes ~2ms
+- Still well under 16ms budget (60fps)
+- GPU-accelerated compositing helps
+
+**3. Viewport Culling is Key**
+
+- Always rendering ~3,800-5,700 peaks regardless of zoom
+- Total peaks grow with zoom, but visible peaks stay constant
+- This is why viewport-aware rendering works!
+
+**4. Zoom-In is FASTER than Zoom-Out**
+
+- Counterintuitive but true!
+- Fewer samples to process when viewport is smaller
+- Higher resolution doesn't matter—viewport size does
+
+**5. Threading Analysis**
+
+```
+┌─────────────────────┬──────────┬──────────────┐
+│ Operation           │ Time     │ Thread       │
+├─────────────────────┼──────────┼──────────────┤
+│ Audio load          │ 4-8ms    │ Main (once)  │
+│ Peak extraction     │ 0.03-1ms │ Main (zoom)  │
+│ Canvas render       │ 2-3ms    │ Main (RAF)   │
+│ Total per frame     │ 2-4ms    │ 16ms budget  │
+└─────────────────────┴──────────┴──────────────┘
+
+60fps budget: 16.67ms
+Our usage: ~2-4ms (12-25% of budget)
+Remaining: ~13ms for React, layout, other rendering
+
+Verdict: NO BLOCKING ISSUES ✅
+```
+
+---
+
+#### Worst-Case Scenario
+
+**30-minute audio file, extreme zoom, cold cache:**
+
+```
+Duration: 1,800 seconds
+Total samples: 79.38M
+Viewport: 1.15 seconds @ max zoom
+
+Peak extraction: 50,715 samples = 0.016ms (same as 5-min!)
+Cache miss: Extract once, cache forever
+Impact: Imperceptible
+
+30-minute file @ overview zoom:
+  All peaks: 1,800s × 100 = 180,000 peaks
+  Load time: 79.38M ops / 3 GHz = ~26ms
+  Still < 2 frames, acceptable for one-time cost
+```
+
+---
+
+#### Comparison Table
+
+| Zoom Level | Viewport Width | Peaks/Sec | Extraction | Canvas | Total | FPS Impact    |
+| ---------- | -------------- | --------- | ---------- | ------ | ----- | ------------- |
+| Overview   | 96 beats       | 100       | 0.8ms      | 3ms    | 4ms   | None (240fps) |
+| Default    | 24 beats       | 266       | 0.2ms      | 2ms    | 2ms   | None (500fps) |
+| High       | 9.6 beats      | 666       | 0.08ms     | 2ms    | 2ms   | None (500fps) |
+| Extreme    | 3.8 beats      | 1,666     | 0.03ms     | 2ms    | 2ms   | None (500fps) |
+| Maximum    | 1.9 beats      | 3,334     | 0.016ms    | 2ms    | 2ms   | None (500fps) |
+
+**Conclusion:** Computation is negligible at all zoom levels. Canvas rendering is the bottleneck, but still only ~2-4ms per frame (well under 16ms budget).
+
+---
+
+### Memory Analysis
+
+**Current (SVG):**
+
+- Peak array: 30,000 peaks × 4 bytes = 120 KB
+- Total: ~120 KB per project
+
+**Proposed (Canvas + Adaptive):**
+
+- Audio buffer: Already in memory (Tone.js Player) = ~106 MB for 5-min 44.1kHz stereo
+- Peak cache (Phase 3):
+  ```
+  Typical session: 10 viewport positions × 3,800 peaks × 4 bytes = 152 KB
+  Worst case: 50 positions (aggressive cache) = 760 KB
+  ```
+- Total additional: **< 1 MB**
+
+**Verdict:** Minimal memory increase, negligible computation cost, huge UX improvement ✅
+
+## File Changes Summary
+
+| File                            | Change Type    | Description                                                    |
+| ------------------------------- | -------------- | -------------------------------------------------------------- |
+| `src/components/piano-roll.tsx` | Major refactor | Replace SVG Waveform with canvas-based rendering               |
+| `src/lib/audio.ts`              | New function   | Add `getAudioBufferPeaksRange()` for viewport-aware extraction |
+| `src/lib/waveform-cache.ts`     | New file       | LRU cache for computed peak segments                           |
+| `src/types.ts`                  | Minor          | Add types for peak cache entries                               |
+| `e2e/waveform.spec.ts`          | New tests      | Visual regression tests for zoom levels                        |
+
+## Testing Strategy
+
+### Unit Tests (Vitest)
+
+- Peak extraction with various resolutions
+- Cache hit/miss logic
+- Resolution calculation heuristic
+- Viewport-to-time-range conversion
+
+### E2E Tests (Playwright)
+
+- Load audio and verify waveform renders
+- Zoom in/out and verify visual detail improves/degrades
+- Scroll and verify no rendering gaps
+- Performance test: scroll/zoom maintains 60fps
+
+### Manual Testing
+
+- Various audio file formats (WAV, MP3, different sample rates)
+- Extreme zoom levels (1 px/beat to 500 px/beat)
+- Long audio files (30+ minutes)
+- Low-end device testing (throttled CPU)
+
+## Risks & Mitigations
+
+| Risk                                           | Impact | Mitigation                                       |
+| ---------------------------------------------- | ------ | ------------------------------------------------ |
+| Canvas rendering performance worse than SVG    | High   | Profile early, keep SVG as fallback option       |
+| Memory usage spike from audio buffer retention | Medium | Tone.js already keeps buffer; monitor with tests |
+| Peak computation blocks UI thread              | High   | Use debouncing, consider Web Workers for phase 3 |
+| Retina display handling bugs                   | Medium | Test on multiple pixel densities early           |
+| Cache invalidation bugs cause stale rendering  | Medium | Comprehensive cache tests, clear on audio change |
+
+## Success Metrics
+
+1. **Visual Quality:**
+   - Waveform detail improves linearly with zoom level
+   - No visible blockiness at 200+ px/beat
+   - Smooth rendering at all zoom levels
+
+2. **Performance:**
+   - Maintain 60fps during scroll and zoom
+   - Waveform renders within 100ms after zoom stop
+   - Memory usage increase < 10% vs current
+
+3. **User Experience:**
+   - Users can align notes with transients at high zoom
+   - No perceived lag when zooming in/out
+   - Works seamlessly with existing "infinite zoom" feature
+
+## Decision Matrix (Corrected - Orthogonal Concerns)
+
+**Recognizing that data optimization and rendering are independent:**
+
+### Bug Fix Path (Choose One)
+
+| Approach                        | Rendering Change | Effort | Risk   | Recommendation         |
+| ------------------------------- | ---------------- | ------ | ------ | ---------------------- |
+| **Viewport Culling + Keep SVG** | None             | 1-2h   | Low    | ✅ **Start here**      |
+| **Viewport Culling + Canvas**   | Replace renderer | 3-5h   | Medium | ⚠️ Only if SVG is slow |
+
+**Recommended:** Fix bug with SVG first (1-2h), only switch to Canvas if testing shows performance issues.
+
+---
+
+### Feature Enhancement Path (Optional)
+
+| Approach                    | Depends On   | Effort | When                      |
+| --------------------------- | ------------ | ------ | ------------------------- |
+| **Add Adaptive Resolution** | Bug fix done | +4-6h  | If users want zoom detail |
+
+**Can use either SVG or Canvas** - test which performs better at 10K+ peaks.
+
+---
+
+### Total Effort Scenarios
+
+| Scenario                   | Path                        | Total Time |
+| -------------------------- | --------------------------- | ---------- |
+| **Minimum (Bug fix only)** | Culling + SVG               | 1-2h       |
+| **If SVG lags**            | Culling + Canvas            | 3-5h       |
+| **Full solution (SVG)**    | Culling + Adaptive + SVG    | 5-8h       |
+| **Full solution (Canvas)** | Culling + Adaptive + Canvas | 7-11h      |
+
+**Key insight:** Don't commit to Canvas upfront. Test SVG first, optimize only if needed.
+
+---
+
+## Implementation Timeline (Corrected)
+
+### Phase 1: Fix Audio-Length Bug (1-2 hours)
+
+**Goal:** Fix critical bug where 30-min files look worse than 5-min files
+
+**Tasks:**
+
+1. Calculate visible time range in WaveformArea component
+
+   ```typescript
+   const viewportStartBeat = scrollX;
+   const viewportEndBeat = scrollX + viewportWidth / pixelsPerBeat;
+   const visibleStartSec =
+     beatsToSeconds(viewportStartBeat, tempo) + audioOffset;
+   const visibleEndSec = beatsToSeconds(viewportEndBeat, tempo) + audioOffset;
+   ```
+
+2. Slice peaks array to visible range
+
+   ```typescript
+   const startIdx = Math.floor(
+     (visibleStartSec - audioOffset) * peaksPerSecond,
+   );
+   const endIdx = Math.ceil((visibleEndSec - audioOffset) * peaksPerSecond);
+   const visiblePeaks = audioPeaks.slice(startIdx, endIdx);
+   ```
+
+3. Remove 500-point downsampling in Waveform component (lines 1789-1801)
+
+4. Pass visible peaks to Waveform
+   ```typescript
+   <Waveform peaks={visiblePeaks} height={height} />
+   ```
+
+**Testing:**
+
+- Load 5-min and 30-min audio files
+- Verify waveform quality is identical
+- Measure frame rate during scroll (target: 60fps)
+- Test on dev machine (if < 60fps, proceed to Phase 1.5)
+
+**Deliverable:** Bug fixed, 1,440 peaks rendered regardless of audio length
+
+---
+
+### Phase 1.5: Switch to Canvas (2-3 hours) - CONDITIONAL
+
+**Goal:** Improve rendering performance if SVG is slow
+
+**Only do this if Phase 1 testing shows < 60fps with SVG.**
+
+**Tasks:**
+
+1. Replace `<svg>` with `<canvas>` in Waveform component
+2. Implement canvas rendering:
+
+   ```typescript
+   const dpr = window.devicePixelRatio || 1;
+   canvas.width = width * dpr;
+   canvas.height = height * dpr;
+   ctx.scale(dpr, dpr);
+
+   ctx.beginPath();
+   for (let i = 0; i < peaks.length; i++) {
+     const x = (i / peaks.length) * width;
+     const y = centerY - peaks[i] * amplitude;
+     i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+   }
+   ctx.fill();
+   ctx.stroke();
+   ```
+
+3. Add useEffect to redraw on peaks change
+4. Test performance improvement
+
+**Testing:**
+
+- Same tests as Phase 1
+- Should now achieve 60fps
+
+**Deliverable:** Canvas renderer with better performance
+
+---
+
+### Phase 2: Add Adaptive Resolution (4-6 hours) - OPTIONAL
+
+**Goal:** Show more detail at high zoom levels
+
+**Only do this if users request better zoom detail.**
+
+**Tasks:**
+
+1. Add `extractPeaksRange()` to AudioManager:
+
+   ```typescript
+   extractPeaksRange(startSec, endSec, peaksPerSecond): Float32Array {
+     const buffer = this.player.buffer;
+     const samples = buffer.getChannelData(0);
+     const sampleRate = buffer.sampleRate;
+     // Extract peaks at target resolution...
+   }
+   ```
+
+2. Calculate target resolution based on zoom:
+
+   ```typescript
+   const pixelsPerSecond = (tempo / 60) * pixelsPerBeat;
+   const targetPeaksPerSecond = Math.max(
+     100,
+     Math.min(10000, pixelsPerSecond * 2),
+   );
+   ```
+
+3. Extract peaks on-demand instead of using stored array
+
+4. Add simple cache (Map with 10-entry limit)
+
+**Testing:**
+
+- Zoom from 20 px/beat to 500 px/beat
+- Verify detail increases at higher zoom
+- Measure peak extraction time (should be < 1ms)
+- Test if current renderer (SVG or Canvas) handles 10K+ peaks
+
+**Deliverable:** Adaptive waveform detail that scales with zoom
+
+---
+
+### Summary
+
+| Phase   | Goal     | Effort | Condition                     |
+| ------- | -------- | ------ | ----------------------------- |
+| **1**   | Fix bug  | 1-2h   | **Always do**                 |
+| **1.5** | Canvas   | 2-3h   | **If** SVG < 60fps            |
+| **2**   | Adaptive | 4-6h   | **If** users want zoom detail |
+
+**Minimum to fix bug:** 1-2 hours  
+**Maximum for full solution:** 7-11 hours
+
+**Key principle:** Incremental delivery with testing at each step.
+
+## Open Questions
+
+1. Should we keep audio buffer reference or reload on demand?
+   - **Answer:** Keep buffer (already in Tone.js, no additional memory cost)
+   - **Status:** ✅ Resolved - add getter to AudioManager
+
+2. What's the optimal peaks-per-pixel ratio?
+   - **Answer needed from:** Visual testing at various zoom levels
+   - **Default stance:** 2-3 peaks/pixel (Nyquist-inspired, matches WaveSurfer.js)
+   - **Status:** ⏳ Test during Phase 2 implementation
+
+3. Should we use Web Workers for peak extraction?
+   - **Answer needed from:** Performance profiling in Phase 3
+   - **Default stance:** Start on main thread, optimize if needed
+   - **Status:** ⏳ Defer to Phase 3 optimization
+
+4. Do we need to support audio files > 30 minutes?
+   - **Answer needed from:** User research / product requirements
+   - **Default stance:** Yes (full albums, DJ mixes), but cap at 10000 peaks/sec
+   - **Status:** ⏳ Test with long files during Phase 3
+
+---
+
+## Troubleshooting Guide
+
+### Issue: Blurry waveform on retina displays
+
+**Cause:** Missing device pixel ratio handling  
+**Fix:** Ensure canvas dimensions are multiplied by `window.devicePixelRatio`
+
+```typescript
+canvas.width = logicalWidth * devicePixelRatio;
+canvas.height = logicalHeight * devicePixelRatio;
+ctx.scale(devicePixelRatio, devicePixelRatio);
+```
+
+### Issue: Waveform stutters during scroll
+
+**Cause:** Peak extraction blocking main thread  
+**Fix:** Add debouncing or move to Web Worker (Phase 3)
+
+```typescript
+const debouncedRedraw = useMemo(() => debounce(renderWaveform, 100), []);
+```
+
+### Issue: Memory leak during long sessions
+
+**Cause:** Cache growing unbounded  
+**Fix:** Implement LRU eviction (Phase 3)
+
+```typescript
+if (cache.size > MAX_CACHE_SIZE) {
+  const oldestKey = cache.keys().next().value;
+  cache.delete(oldestKey);
+}
+```
+
+### Issue: Visual "pop" when switching zoom levels
+
+**Cause:** Abrupt resolution change  
+**Fix:** Smooth transition or use interpolation between levels
+
+### Issue: Waveform doesn't match audio on extreme zoom
+
+**Cause:** Insufficient peak resolution  
+**Fix:** Increase `maxPeaksPerSecond` from 10000 to 20000 (allows 2.2kHz frequency detail)
+
+### Audio Buffer Management
+
+**Key Decision:** Should we keep audio buffer reference for on-demand peak extraction?
+
+**Current State:**
+
+- Tone.js `Player` loads audio into `ToneAudioBuffer`
+- Buffer available via `audioManager.player.buffer`
+- Currently accessed once on load for peak extraction
+- Buffer remains in memory for playback
+
+**Proposal:** Add getter to AudioManager
+
+```typescript
+// In src/lib/audio.ts
+class AudioManager {
+  // ... existing code ...
+
+  get audioBuffer(): Tone.ToneAudioBuffer | null {
+    return this.player?.buffer.loaded ? this.player.buffer : null;
+  }
+
+  /**
+   * Extract peaks from loaded audio buffer for specified time range
+   * Used for adaptive waveform rendering at different zoom levels
+   */
+  extractPeaksRange(
+    startSec: number,
+    endSec: number,
+    peaksPerSecond: number,
+  ): Float32Array | null {
+    const buffer = this.audioBuffer;
+    if (!buffer) return null;
+
+    const sampleRate = buffer.sampleRate;
+    const samples = buffer.getChannelData(0); // Mono or left channel
+
+    const startSample = Math.floor(startSec * sampleRate);
+    const endSample = Math.ceil(endSec * sampleRate);
+    const samplesPerPeak = Math.floor(sampleRate / peaksPerSecond);
+
+    const peakCount = Math.ceil((endSample - startSample) / samplesPerPeak);
+    const peaks = new Float32Array(peakCount);
+
+    for (let i = 0; i < peakCount; i++) {
+      let max = 0;
+      const sampleStart = startSample + i * samplesPerPeak;
+      const sampleEnd = Math.min(sampleStart + samplesPerPeak, endSample);
+
+      for (let j = sampleStart; j < sampleEnd; j++) {
+        const abs = Math.abs(samples[j]);
+        if (abs > max) max = abs;
+      }
+
+      peaks[i] = max;
+    }
+
+    return peaks;
+  }
+}
+```
+
+**Memory Impact:**
+
+- Buffer already in memory (no additional cost)
+- Method call overhead is negligible
+- Enables adaptive resolution without storage cost
+
+---
+
+## References
+
+### Documentation
+
+- **Existing docs:** `docs/2026-01-08-waveform.md` (original waveform implementation)
+- **AGENTS.md conventions:** Task docs, E2E-first testing, linting before commit
+
+### Codebase References
+
+- **Signal piano roll:** `refs/signal/` (viewport culling, WebGL, transforms)
+  - `app/src/observer/EventView.ts` - Viewport-aware filtering
+  - `app/src/hooks/useTickScroll.tsx` - Zoom around point
+  - `app/src/components/DrawCanvas.tsx` - Device pixel ratio handling
+  - `app/src/entities/transform/TickTransform.ts` - Coordinate transforms
+
+### Industry Libraries
+
+- **BBC Peaks.js:** https://github.com/bbc/peaks.js
+  - Multi-resolution waveform data format
+  - Canvas viewport rendering
+  - Segment/point markers (potential future feature)
+- **WaveSurfer.js:** https://wavesurfer.xyz
+  - Adaptive peak generation (`getPeaks()` function)
+  - Canvas 2D rendering with zoom
+  - Plugin architecture
+
+- **waveform-data.js:** https://github.com/bbc/waveform-data.js
+  - Binary waveform data format
+  - Resampling algorithms
+  - Client/server architecture
+
+- **webaudio-peaks:** https://github.com/naomiaro/webaudio-peaks
+  - Simple peak extraction library
+  - TypedArray and AudioBuffer support
+  - Configurable bits (Int8, Int16, Int32)
+
+### Web Standards
+
+- **Web Audio API:** [`AudioBuffer.getChannelData()`](https://developer.mozilla.org/en-US/docs/Web/API/AudioBuffer/getChannelData)
+- **Canvas API:** [CanvasRenderingContext2D](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D)
+- **Canvas optimization:** [Paul Irish - RequestAnimationFrame](https://www.paulirish.com/2011/requestanimationframe-for-smart-animating/)
+- **Device Pixel Ratio:** [Window.devicePixelRatio](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio)
+
+### Articles
+
+- **Doist Ramble #3:** https://www.doist.dev/building-ramble-3-visualizing-the-waveform/ (Jan 2026)
+  - Modern canvas waveform implementation
+  - Frame-rate independent drawing
+  - Audio-reactive visualization
+
+## Status
+
+**Created:** 2026-01-31  
+**Status:** ✅ Research Complete - Ready for review
+
+**Research Completed:**
+
+- ✅ Analyzed current SVG implementation (lines 1784-1838 in piano-roll.tsx)
+- ✅ Explored Signal codebase patterns (viewport culling, transforms, WebGL)
+- ✅ Researched industry libraries (Peaks.js, WaveSurfer.js, webaudio-peaks)
+- ✅ Reviewed recent implementations (Doist Ramble, Jan 2026)
+- ✅ Defined 3-phase implementation plan with clear success criteria
+- ✅ Estimated effort: 7-10 hours (independently shippable phases)
+
+**Recommendation:** Canvas + Adaptive Resolution (industry standard, proven at scale)
+
+### Next Steps
+
+1. ✅ **User review** - Read this document, provide feedback below
+2. **Approval** - Confirm Canvas + Adaptive approach or request changes
+3. **Branching** - Create feature branch (`feat/canvas-waveform`)
+4. **Phase 1** - Implement Canvas foundation (2-3h, independently valuable)
+5. **Phase 2** - Add adaptive resolution (3-4h, core feature)
+6. **Phase 3** - Optimization & polish (2-3h, can defer if needed)
+
+**Decision Point:** Approve to proceed, or request alternative approach below.
+
+---
+
+## Feedback Log
+
+**2026-01-31 - Research Phase:**
+
+- Explored refs/signal codebase for rendering patterns
+- Searched web for WebGL, Canvas, and waveform techniques
+- Researched code examples from Peaks.js, WaveSurfer.js, and related libraries
+- Documented findings in "Research Findings" section above
+
+**2026-01-31 - User Feedback & Corrections:**
+
+- User correctly identified that computation analysis conflated separate issues
+- User pointed out that SVG vs Canvas is **orthogonal** to data optimization
+- Revised document to clearly separate three concerns:
+  1. **Data optimization** (viewport culling, adaptive resolution)
+  2. **Rendering technology** (SVG vs Canvas)
+  3. **Performance** (requires actual testing, not assumptions)
+- **New recommendation:** Fix bug with SVG first (1-2h), test performance, only switch to Canvas if needed
+- **Removed unfounded claims** about SVG performance limits - needs actual testing
+- **Key insight:** The 500-point limit might be overly conservative for modern browsers
+
+---
+
+## Summary: Corrected Understanding
+
+### Three Orthogonal Concerns
+
+1. **Data Optimization** (what peaks to generate)
+   - Viewport culling: Only visible region
+   - Adaptive resolution: More peaks at high zoom
+   - Independent of rendering technology
+
+2. **Rendering Technology** (how to display peaks)
+   - SVG: `<path d="M ..." />`
+   - Canvas: `ctx.lineTo(x, y)`
+   - Independent of data optimization
+
+3. **Performance** (does it run smoothly?)
+   - Depends on: Peak count × Rendering tech
+   - Requires: Actual testing on target devices
+   - Don't assume without measuring
+
+### Recommended Approach
+
+**Phase 1: Fix Bug (1-2h)**
+
+- Implement viewport culling
+- Keep SVG (minimal changes)
+- Remove 500-point downsampling
+- **Test:** Does SVG handle 1,440 peaks at 60fps?
+
+**Phase 1.5: Canvas (2-3h) - IF NEEDED**
+
+- Only if Phase 1 testing shows SVG is slow
+- Switch to Canvas rendering
+- Re-test performance
+
+**Phase 2: Adaptive (4-6h) - OPTIONAL**
+
+- Only if users want zoom detail
+- Works with either SVG or Canvas
+- **Test:** Does renderer handle 10K+ peaks?
+
+**Total minimum:** 1-2 hours (fix bug with SVG)  
+**Total maximum:** 7-11 hours (full solution with optimizations)
+
+_(Implementation notes will be appended here)_

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -102,7 +102,7 @@ See [architecture.md](architecture.md) for implementation details.
 
 - [x] feat: shortcut for mute/solo track for each audio / midi
   - [ ] feat: indicate mute toggle in main view
-- [ ] feat: higher resolution waveform at zoom (canvas instead of svg?)
+- [x] feat: higher resolution waveform at zoom (canvas instead of svg?)
 - [ ] feat: add mixer view (modal?)
 - [ ] fix: metronome toggle doesn't work always (e.g. require playback pause/play)
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -50,12 +50,12 @@ export function App() {
       if (project.audioAssetKey) {
         const asset = await loadAsset(project.audioAssetKey);
         if (asset) {
-          const { buffer, peaks, peaksPerSecond } = await loadAudioFile(
+          const { buffer, audioView } = await loadAudioFile(
             new File([asset.blob], asset.name),
           );
           audioManager.player.buffer = buffer;
           audioManager.syncAudioTrack(project.audioOffset);
-          project.setAudioPeaks(peaks, peaksPerSecond);
+          project.setAudioView(audioView);
         } else {
           toast.warning(
             "Audio asset not found. The audio track will be cleared.",

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -9,6 +9,7 @@ import {
 import { useTransport } from "../hooks/use-transport";
 import { useWindowEvent } from "../hooks/use-window-event";
 import { audioManager } from "../lib/audio";
+import { type AudioView, queryAudioView } from "../lib/audio-view";
 import {
   isBlackKey,
   MAX_PITCH,
@@ -257,7 +258,7 @@ export function PianoRoll() {
     setAudioOffset,
     setAudioTrackSelected,
     clearAudioFile,
-    audioPeaks,
+    audioView,
     undo,
     redo,
     canUndo,
@@ -1058,7 +1059,7 @@ export function PianoRoll() {
             audioFileName={audioFileName}
             tempo={tempo}
             playheadBeat={secondsToBeats(position, tempo)}
-            audioPeaks={audioPeaks}
+            audioView={audioView}
             height={waveformHeight}
             beatsPerBar={beatsPerBar}
             isSelected={isAudioTrackSelected}
@@ -1614,7 +1615,7 @@ function WaveformArea({
   audioFileName,
   tempo,
   playheadBeat,
-  audioPeaks,
+  audioView,
   height,
   beatsPerBar,
   isSelected,
@@ -1631,7 +1632,7 @@ function WaveformArea({
   audioFileName: string | null;
   tempo: number;
   playheadBeat: number;
-  audioPeaks: number[];
+  audioView: AudioView | null;
   height: number;
   beatsPerBar: number;
   isSelected: boolean;
@@ -1672,6 +1673,16 @@ function WaveformArea({
   // Calculate screen positions
   const audioStartX = (audioOffsetBeats - scrollX) * pixelsPerBeat;
   const audioWidth = audioDurationBeats * pixelsPerBeat;
+
+  // Calculate visible portion of audio for waveform rendering
+  // visibleStart/End are in seconds relative to audio start (0 = audio beginning)
+  const visibleStartBeats = scrollX;
+  const visibleEndBeats = scrollX + viewportWidth / pixelsPerBeat;
+  const visibleStartSeconds = beatsToSeconds(visibleStartBeats, tempo);
+  const visibleEndSeconds = beatsToSeconds(visibleEndBeats, tempo);
+  // Adjust for audio offset (convert viewport time to audio-relative time)
+  const audioVisibleStart = Math.max(0, visibleStartSeconds - audioOffset);
+  const audioVisibleEnd = Math.max(0, visibleEndSeconds - audioOffset);
 
   // Playhead position
   const playheadX = (playheadBeat - scrollX) * pixelsPerBeat;
@@ -1750,9 +1761,12 @@ function WaveformArea({
           onMouseDown={handleMouseDown}
         >
           {/* Waveform SVG */}
-          {audioPeaks.length > 0 && (
+          {audioView && audioView.data.length > 0 && (
             <Waveform
-              peaks={audioPeaks}
+              audioView={audioView}
+              visibleStart={audioVisibleStart}
+              visibleEnd={audioVisibleEnd}
+              pixelWidth={Math.max(1, Math.round(audioWidth))}
               height={height - 8} // Account for top-1 bottom-1 padding
             />
           )}
@@ -1782,23 +1796,31 @@ function WaveformArea({
 }
 
 // Waveform SVG component - renders peaks as a filled polygon
-// Downsamples peaks to max ~500 points to avoid SVG lag
-function Waveform({ peaks, height }: { peaks: number[]; height: number }) {
-  if (peaks.length === 0) return null;
+// Uses viewport culling and downsamples to pixel width for optimal performance
+function Waveform({
+  audioView,
+  visibleStart,
+  visibleEnd,
+  pixelWidth,
+  height,
+}: {
+  audioView: AudioView;
+  visibleStart: number; // seconds
+  visibleEnd: number; // seconds
+  pixelWidth: number;
+  height: number;
+}) {
+  if (audioView.data.length === 0) return null;
 
-  // Downsample to max 500 points for performance
-  const maxPoints = 500;
-  const step = Math.max(1, Math.floor(peaks.length / maxPoints));
-  const sampledPeaks: number[] = [];
+  // Use viewport-aware processing: slice to visible range, downsample to pixel width
+  const visiblePoints = queryAudioView(
+    audioView,
+    visibleStart,
+    visibleEnd,
+    pixelWidth,
+  );
 
-  for (let i = 0; i < peaks.length; i += step) {
-    // Take max of this chunk for accuracy
-    let max = 0;
-    for (let j = i; j < Math.min(i + step, peaks.length); j++) {
-      if (peaks[j] > max) max = peaks[j];
-    }
-    sampledPeaks.push(max);
-  }
+  if (visiblePoints.length === 0) return null;
 
   // Use viewBox coordinates (0-1000 for x, 0-height for y)
   const viewBoxWidth = 1000;
@@ -1809,10 +1831,10 @@ function Waveform({ peaks, height }: { peaks: number[]; height: number }) {
   const upperPoints: string[] = [];
   const lowerPoints: string[] = [];
 
-  for (let i = 0; i < sampledPeaks.length; i++) {
+  for (let i = 0; i < visiblePoints.length; i++) {
     // X position scaled to viewBox width
-    const x = (i / (sampledPeaks.length - 1 || 1)) * viewBoxWidth;
-    const amplitude = sampledPeaks[i] * maxAmplitude;
+    const x = (i / (visiblePoints.length - 1 || 1)) * viewBoxWidth;
+    const amplitude = visiblePoints[i] * maxAmplitude;
 
     upperPoints.push(`${x},${centerY - amplitude}`);
     lowerPoints.unshift(`${x},${centerY + amplitude}`);

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -1864,7 +1864,8 @@ function Waveform({
         d={pathData}
         fill="rgba(255, 255, 255, 0.3)"
         stroke="rgba(255, 255, 255, 0.5)"
-        strokeWidth="0.02"
+        strokeWidth="1"
+        vectorEffect="non-scaling-stroke"
       />
     </svg>
   );

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -1764,6 +1764,7 @@ function WaveformArea({
           {audioView && audioView.data.length > 0 && (
             <Waveform
               audioView={audioView}
+              audioDuration={audioDuration}
               visibleStart={audioVisibleStart}
               visibleEnd={audioVisibleEnd}
               pixelWidth={Math.max(1, Math.round(audioWidth))}
@@ -1799,12 +1800,14 @@ function WaveformArea({
 // Uses viewport culling and downsamples to pixel width for optimal performance
 function Waveform({
   audioView,
+  audioDuration,
   visibleStart,
   visibleEnd,
   pixelWidth,
   height,
 }: {
   audioView: AudioView;
+  audioDuration: number; // total audio duration in seconds
   visibleStart: number; // seconds
   visibleEnd: number; // seconds
   pixelWidth: number;
@@ -1812,15 +1815,27 @@ function Waveform({
 }) {
   if (audioView.data.length === 0) return null;
 
+  // Estimate visible portion's pixel width for downsampling target
+  const visibleDuration = visibleEnd - visibleStart;
+  const visiblePixelWidth = Math.max(
+    1,
+    Math.round((visibleDuration / audioDuration) * pixelWidth),
+  );
+
   // Use viewport-aware processing: slice to visible range, downsample to pixel width
-  const visiblePoints = queryAudioView(
+  const slice = queryAudioView(
     audioView,
     visibleStart,
     visibleEnd,
-    pixelWidth,
+    visiblePixelWidth,
   );
 
-  if (visiblePoints.length === 0) return null;
+  if (slice.data.length === 0) return null;
+
+  // Calculate SVG position within the audio container based on actual bounds
+  const leftPercent = (slice.actualStart / audioDuration) * 100;
+  const widthPercent =
+    ((slice.actualEnd - slice.actualStart) / audioDuration) * 100;
 
   // Use viewBox coordinates (0-1000 for x, 0-height for y)
   const viewBoxWidth = 1000;
@@ -1831,10 +1846,10 @@ function Waveform({
   const upperPoints: string[] = [];
   const lowerPoints: string[] = [];
 
-  for (let i = 0; i < visiblePoints.length; i++) {
+  for (let i = 0; i < slice.data.length; i++) {
     // X position scaled to viewBox width
-    const x = (i / (visiblePoints.length - 1 || 1)) * viewBoxWidth;
-    const amplitude = visiblePoints[i] * maxAmplitude;
+    const x = (i / (slice.data.length - 1 || 1)) * viewBoxWidth;
+    const amplitude = slice.data[i] * maxAmplitude;
 
     upperPoints.push(`${x},${centerY - amplitude}`);
     lowerPoints.unshift(`${x},${centerY + amplitude}`);
@@ -1845,7 +1860,13 @@ function Waveform({
 
   return (
     <svg
-      className="absolute inset-0 w-full h-full"
+      className="absolute"
+      style={{
+        left: `${leftPercent}%`,
+        width: `${widthPercent}%`,
+        top: 0,
+        height: "100%",
+      }}
       viewBox={`0 0 ${viewBoxWidth} ${height}`}
       preserveAspectRatio="none"
     >

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -1768,7 +1768,6 @@ function WaveformArea({
               visibleStart={audioVisibleStart}
               visibleEnd={audioVisibleEnd}
               pixelWidth={Math.max(1, Math.round(audioWidth))}
-              height={height - 8} // Account for top-1 bottom-1 padding
             />
           )}
           {/* File name and offset indicator */}
@@ -1804,14 +1803,12 @@ function Waveform({
   visibleStart,
   visibleEnd,
   pixelWidth,
-  height,
 }: {
   audioView: AudioView;
   audioDuration: number; // total audio duration in seconds
   visibleStart: number; // seconds
   visibleEnd: number; // seconds
   pixelWidth: number;
-  height: number;
 }) {
   if (audioView.data.length === 0) return null;
 
@@ -1837,25 +1834,18 @@ function Waveform({
   const widthPercent =
     ((slice.actualEnd - slice.actualStart) / audioDuration) * 100;
 
-  // Use viewBox coordinates (0-1000 for x, 0-height for y)
-  const viewBoxWidth = 1000;
-  const centerY = height / 2;
-  const maxAmplitude = centerY * 0.9; // Leave some margin
-
-  // Create path points for upper and lower halves
+  // Build path using normalized data (0-1), let viewBox handle scaling
+  // viewBox: x=[0, numPoints], y=[-1, 1] (center at 0, amplitude up/down)
+  const n = slice.data.length;
   const upperPoints: string[] = [];
   const lowerPoints: string[] = [];
 
-  for (let i = 0; i < slice.data.length; i++) {
-    // X position scaled to viewBox width
-    const x = (i / (slice.data.length - 1 || 1)) * viewBoxWidth;
-    const amplitude = slice.data[i] * maxAmplitude;
-
-    upperPoints.push(`${x},${centerY - amplitude}`);
-    lowerPoints.unshift(`${x},${centerY + amplitude}`);
+  for (let i = 0; i < n; i++) {
+    const amp = slice.data[i]; // Already 0-1 normalized
+    upperPoints.push(`${i},${-amp}`);
+    lowerPoints.unshift(`${i},${amp}`);
   }
 
-  // Close the path by connecting upper and lower halves
   const pathData = `M ${upperPoints.join(" L ")} L ${lowerPoints.join(" L ")} Z`;
 
   return (
@@ -1864,17 +1854,17 @@ function Waveform({
       style={{
         left: `${leftPercent}%`,
         width: `${widthPercent}%`,
-        top: 0,
-        height: "100%",
+        top: "5%",
+        height: "90%",
       }}
-      viewBox={`0 0 ${viewBoxWidth} ${height}`}
+      viewBox={`0 -1 ${n - 1 || 1} 2`}
       preserveAspectRatio="none"
     >
       <path
         d={pathData}
         fill="rgba(255, 255, 255, 0.3)"
         stroke="rgba(255, 255, 255, 0.5)"
-        strokeWidth="1"
+        strokeWidth="0.02"
       />
     </svg>
   );

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -269,7 +269,7 @@ export function Transport({
     setShowDebug,
     setAudioFile,
     setAudioOffset,
-    setAudioPeaks,
+    setAudioView,
     clearAudioFile,
   } = useProjectStore();
 
@@ -285,7 +285,7 @@ export function Transport({
 
   const loadAudioMutation = useMutation({
     mutationFn: async (file: File) => {
-      const { buffer, peaks, peaksPerSecond } = await loadAudioFile(file);
+      const { buffer, audioView } = await loadAudioFile(file);
 
       // Save audio to IndexedDB for persistence
       const assetKey = await saveAsset(file);
@@ -295,7 +295,7 @@ export function Transport({
       audioManager.player.sync().start(0);
       setAudioOffset(0);
 
-      setAudioPeaks(peaks, peaksPerSecond);
+      setAudioView(audioView);
     },
   });
 

--- a/src/lib/audio-view.test.ts
+++ b/src/lib/audio-view.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   type AudioView,
+  type AudioViewSlice,
   createAudioView,
   EMPTY_AUDIO_VIEW,
   queryAudioView,
@@ -99,35 +100,41 @@ describe("queryAudioView", () => {
     sampleRate: 1000,
   });
 
-  it("returns empty array for empty data", () => {
+  const emptySlice: AudioViewSlice = { data: [], actualStart: 0, actualEnd: 0 };
+
+  it("returns empty slice for empty data", () => {
     const result = queryAudioView(EMPTY_AUDIO_VIEW, 0, 5, 500);
-    expect(result).toEqual([]);
+    expect(result).toEqual(emptySlice);
   });
 
-  it("returns empty array for zero target points", () => {
+  it("returns empty slice for zero target points", () => {
     const view = createTestView(100);
     const result = queryAudioView(view, 0, 5, 0);
-    expect(result).toEqual([]);
+    expect(result).toEqual(emptySlice);
   });
 
-  it("returns empty array for negative target points", () => {
+  it("returns empty slice for negative target points", () => {
     const view = createTestView(100);
     const result = queryAudioView(view, 0, 5, -100);
-    expect(result).toEqual([]);
+    expect(result).toEqual(emptySlice);
   });
 
-  it("slices to visible range", () => {
+  it("slices to visible range and returns actual bounds", () => {
     // 100 points at 10 points/sec = 10 seconds
     // View seconds 2-4 (indices 20-40)
     const view = createTestView(100);
     const result = queryAudioView(view, 2, 4, 1000); // Large targetPoints to avoid downsampling
 
     // Should get ~20 points (indices 20-40)
-    expect(result.length).toBeGreaterThanOrEqual(19);
-    expect(result.length).toBeLessThanOrEqual(21);
+    expect(result.data.length).toBeGreaterThanOrEqual(19);
+    expect(result.data.length).toBeLessThanOrEqual(21);
 
     // First point should be around index 20 value
-    expect(result[0]).toBeCloseTo(view.data[20], 1);
+    expect(result.data[0]).toBeCloseTo(view.data[20], 1);
+
+    // Actual bounds should be aligned to data boundaries
+    expect(result.actualStart).toBeCloseTo(2, 1);
+    expect(result.actualEnd).toBeCloseTo(4, 1);
   });
 
   it("clamps start index to 0 for negative startTime", () => {
@@ -135,7 +142,8 @@ describe("queryAudioView", () => {
     const result = queryAudioView(view, -5, 2, 1000);
 
     // Should start from index 0
-    expect(result[0]).toBeCloseTo(view.data[0], 1);
+    expect(result.data[0]).toBeCloseTo(view.data[0], 1);
+    expect(result.actualStart).toBe(0);
   });
 
   it("clamps end index to data length", () => {
@@ -144,8 +152,9 @@ describe("queryAudioView", () => {
     const result = queryAudioView(view, 8, 15, 1000);
 
     // Should get points from index 80 to 99
-    expect(result.length).toBe(20);
-    expect(result[result.length - 1]).toBeCloseTo(view.data[99], 1);
+    expect(result.data.length).toBe(20);
+    expect(result.data[result.data.length - 1]).toBeCloseTo(view.data[99], 1);
+    expect(result.actualEnd).toBe(10); // Clamped to audio duration
   });
 
   it("returns points as-is when fewer than target", () => {
@@ -157,7 +166,9 @@ describe("queryAudioView", () => {
     // 5 points, 1000 target points - no downsampling needed
     const result = queryAudioView(view, 0, 0.5, 1000);
 
-    expect(result).toEqual(view.data);
+    expect(result.data).toEqual(view.data);
+    expect(result.actualStart).toBe(0);
+    expect(result.actualEnd).toBe(0.5);
   });
 
   it("downsamples to target points when more points than targets", () => {
@@ -165,7 +176,7 @@ describe("queryAudioView", () => {
     const view = createTestView(1000);
     const result = queryAudioView(view, 0, 100, 100);
 
-    expect(result).toHaveLength(100);
+    expect(result.data).toHaveLength(100);
   });
 
   it("preserves max values when downsampling", () => {
@@ -178,9 +189,9 @@ describe("queryAudioView", () => {
     // Spike at index 50 should appear in pixel 5
     const result = queryAudioView(view, 0, 10, 10);
 
-    expect(result).toHaveLength(10);
-    expect(result[5]).toBe(1.0); // Max preserved
-    expect(result[0]).toBe(0.1); // No spike here
+    expect(result.data).toHaveLength(10);
+    expect(result.data[5]).toBe(1.0); // Max preserved
+    expect(result.data[0]).toBe(0.1); // No spike here
   });
 
   it("handles query starting partway through audio", () => {
@@ -190,8 +201,9 @@ describe("queryAudioView", () => {
     const result = queryAudioView(view, 3, 5, 500);
 
     // Should get points from index 30-50
-    expect(result.length).toBeGreaterThanOrEqual(19);
-    expect(result[0]).toBeCloseTo(view.data[30], 1);
+    expect(result.data.length).toBeGreaterThanOrEqual(19);
+    expect(result.data[0]).toBeCloseTo(view.data[30], 1);
+    expect(result.actualStart).toBeCloseTo(3, 1);
   });
 
   it("handles empty visible range (endTime <= startTime)", () => {
@@ -199,7 +211,7 @@ describe("queryAudioView", () => {
     const result = queryAudioView(view, 5, 5, 100);
 
     // startIdx = 50, endIdx = 50, slice is empty
-    expect(result).toEqual([]);
+    expect(result).toEqual(emptySlice);
   });
 
   it("handles visible range entirely before audio", () => {
@@ -208,7 +220,7 @@ describe("queryAudioView", () => {
     const result = queryAudioView(view, -5, -2, 100);
 
     // startIdx clamped to 0, endIdx = 0, slice is empty
-    expect(result).toEqual([]);
+    expect(result).toEqual(emptySlice);
   });
 
   it("handles visible range entirely after audio", () => {
@@ -217,6 +229,6 @@ describe("queryAudioView", () => {
     const result = queryAudioView(view, 15, 20, 100);
 
     // startIdx = 150, endIdx = 200, both beyond length, slice is empty
-    expect(result).toEqual([]);
+    expect(result).toEqual(emptySlice);
   });
 });

--- a/src/lib/audio-view.test.ts
+++ b/src/lib/audio-view.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import {
+  type AudioView,
+  createAudioView,
+  EMPTY_AUDIO_VIEW,
+  queryAudioView,
+} from "./audio-view";
+
+describe("createAudioView", () => {
+  it("extracts peak values from audio samples", () => {
+    // 1 second of audio at 100 Hz sample rate, extract at 10 points/sec
+    // Each point covers 10 samples
+    const samples = new Float32Array([
+      // Point 0: samples 0-9, max = 0.5
+      0.1, 0.2, 0.3, 0.4, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0,
+      // Point 1: samples 10-19, max = 0.8
+      0.0, 0.2, 0.4, 0.6, 0.8, 0.6, 0.4, 0.2, 0.0, 0.0,
+      // Point 2: samples 20-29, max = 0.3
+      0.1, 0.2, 0.3, 0.2, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0,
+    ]);
+
+    const view = createAudioView(samples, 100, 10);
+
+    expect(view.data).toHaveLength(3);
+    expect(view.data[0]).toBeCloseTo(0.5);
+    expect(view.data[1]).toBeCloseTo(0.8);
+    expect(view.data[2]).toBeCloseTo(0.3);
+    expect(view.samplesPerPoint).toBe(10);
+    expect(view.sampleRate).toBe(100);
+  });
+
+  it("handles negative sample values (takes absolute)", () => {
+    const samples = new Float32Array([
+      -0.9,
+      0.1,
+      0.2,
+      0.3,
+      0.4, // Max should be 0.9
+    ]);
+
+    const view = createAudioView(samples, 100, 20); // 5 samples per point
+
+    expect(view.data).toHaveLength(1);
+    expect(view.data[0]).toBeCloseTo(0.9);
+  });
+
+  it("returns EMPTY_AUDIO_VIEW for empty samples", () => {
+    const samples = new Float32Array([]);
+    const view = createAudioView(samples, 44100, 100);
+    expect(view).toEqual(EMPTY_AUDIO_VIEW);
+  });
+
+  it("returns EMPTY_AUDIO_VIEW for zero pointsPerSecond", () => {
+    const samples = new Float32Array([0.5, 0.5, 0.5]);
+    const view = createAudioView(samples, 44100, 0);
+    expect(view).toEqual(EMPTY_AUDIO_VIEW);
+  });
+
+  it("returns EMPTY_AUDIO_VIEW for negative pointsPerSecond", () => {
+    const samples = new Float32Array([0.5, 0.5, 0.5]);
+    const view = createAudioView(samples, 44100, -10);
+    expect(view).toEqual(EMPTY_AUDIO_VIEW);
+  });
+
+  it("handles partial final chunk", () => {
+    // 25 samples at 100 Hz, 10 points/sec = 10 samples per point
+    // Should produce 3 points (0-9, 10-19, 20-24)
+    const samples = new Float32Array(25).fill(0.5);
+    samples[22] = 0.9; // Set a peak in the partial final chunk
+
+    const view = createAudioView(samples, 100, 10);
+
+    expect(view.data).toHaveLength(3);
+    expect(view.data[2]).toBeCloseTo(0.9);
+  });
+
+  it("produces correct number of points for typical audio", () => {
+    // 3 seconds of audio at 44100 Hz, extract at 800 points/sec
+    const duration = 3;
+    const sampleRate = 44100;
+    const pointsPerSecond = 800;
+    const samples = new Float32Array(duration * sampleRate).fill(0.1);
+
+    const view = createAudioView(samples, sampleRate, pointsPerSecond);
+
+    // Due to integer division of samplesPerPoint, actual count can vary
+    // samplesPerPoint = floor(44100/800) = 55, so we get ceil(132300/55) = 2406 points
+    const samplesPerPoint = Math.floor(sampleRate / pointsPerSecond);
+    const expectedPoints = Math.ceil(samples.length / samplesPerPoint);
+    expect(view.data.length).toBe(expectedPoints);
+  });
+});
+
+describe("queryAudioView", () => {
+  // Create test view: 100 points at 10 points/sec = 10 seconds of audio
+  const createTestView = (count: number): AudioView => ({
+    data: Array.from({ length: count }, (_, i) => (i + 1) / count),
+    samplesPerPoint: 100, // 1000 Hz / 10 points/sec
+    sampleRate: 1000,
+  });
+
+  it("returns empty array for empty data", () => {
+    const result = queryAudioView(EMPTY_AUDIO_VIEW, 0, 5, 500);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array for zero target points", () => {
+    const view = createTestView(100);
+    const result = queryAudioView(view, 0, 5, 0);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array for negative target points", () => {
+    const view = createTestView(100);
+    const result = queryAudioView(view, 0, 5, -100);
+    expect(result).toEqual([]);
+  });
+
+  it("slices to visible range", () => {
+    // 100 points at 10 points/sec = 10 seconds
+    // View seconds 2-4 (indices 20-40)
+    const view = createTestView(100);
+    const result = queryAudioView(view, 2, 4, 1000); // Large targetPoints to avoid downsampling
+
+    // Should get ~20 points (indices 20-40)
+    expect(result.length).toBeGreaterThanOrEqual(19);
+    expect(result.length).toBeLessThanOrEqual(21);
+
+    // First point should be around index 20 value
+    expect(result[0]).toBeCloseTo(view.data[20], 1);
+  });
+
+  it("clamps start index to 0 for negative startTime", () => {
+    const view = createTestView(100);
+    const result = queryAudioView(view, -5, 2, 1000);
+
+    // Should start from index 0
+    expect(result[0]).toBeCloseTo(view.data[0], 1);
+  });
+
+  it("clamps end index to data length", () => {
+    const view = createTestView(100);
+    // 100 points at 10/sec = 10 seconds, view 8-15 (beyond end)
+    const result = queryAudioView(view, 8, 15, 1000);
+
+    // Should get points from index 80 to 99
+    expect(result.length).toBe(20);
+    expect(result[result.length - 1]).toBeCloseTo(view.data[99], 1);
+  });
+
+  it("returns points as-is when fewer than target", () => {
+    const view: AudioView = {
+      data: [0.1, 0.2, 0.3, 0.4, 0.5],
+      samplesPerPoint: 100,
+      sampleRate: 1000,
+    };
+    // 5 points, 1000 target points - no downsampling needed
+    const result = queryAudioView(view, 0, 0.5, 1000);
+
+    expect(result).toEqual(view.data);
+  });
+
+  it("downsamples to target points when more points than targets", () => {
+    // 1000 points, view all, downsample to 100 pixels
+    const view = createTestView(1000);
+    const result = queryAudioView(view, 0, 100, 100);
+
+    expect(result).toHaveLength(100);
+  });
+
+  it("preserves max values when downsampling", () => {
+    // 100 points with a spike at index 50
+    const data = new Array(100).fill(0.1);
+    data[50] = 1.0;
+    const view: AudioView = { data, samplesPerPoint: 100, sampleRate: 1000 };
+
+    // Downsample to 10 pixels (10 points per pixel)
+    // Spike at index 50 should appear in pixel 5
+    const result = queryAudioView(view, 0, 10, 10);
+
+    expect(result).toHaveLength(10);
+    expect(result[5]).toBe(1.0); // Max preserved
+    expect(result[0]).toBe(0.1); // No spike here
+  });
+
+  it("handles query starting partway through audio", () => {
+    // 100 points at 10 points/sec = 10 seconds
+    // Query starts at second 3
+    const view = createTestView(100);
+    const result = queryAudioView(view, 3, 5, 500);
+
+    // Should get points from index 30-50
+    expect(result.length).toBeGreaterThanOrEqual(19);
+    expect(result[0]).toBeCloseTo(view.data[30], 1);
+  });
+
+  it("handles empty visible range (endTime <= startTime)", () => {
+    const view = createTestView(100);
+    const result = queryAudioView(view, 5, 5, 100);
+
+    // startIdx = 50, endIdx = 50, slice is empty
+    expect(result).toEqual([]);
+  });
+
+  it("handles visible range entirely before audio", () => {
+    const view = createTestView(100);
+    // Visible range -5 to -2 seconds (before audio starts)
+    const result = queryAudioView(view, -5, -2, 100);
+
+    // startIdx clamped to 0, endIdx = 0, slice is empty
+    expect(result).toEqual([]);
+  });
+
+  it("handles visible range entirely after audio", () => {
+    const view = createTestView(100); // 10 seconds
+    // Visible range 15-20 seconds (after audio ends)
+    const result = queryAudioView(view, 15, 20, 100);
+
+    // startIdx = 150, endIdx = 200, both beyond length, slice is empty
+    expect(result).toEqual([]);
+  });
+});

--- a/src/lib/audio-view.test.ts
+++ b/src/lib/audio-view.test.ts
@@ -231,4 +231,50 @@ describe("queryAudioView", () => {
     // startIdx = 150, endIdx = 200, both beyond length, slice is empty
     expect(result).toEqual(emptySlice);
   });
+
+  it("scroll stability: adjacent queries have consistent overlapping data", () => {
+    // Simulate realistic scenario: 3 min audio at 800 pts/sec
+    // Viewport showing ~2 seconds, rendered to 200 pixels
+    const pointsPerSec = 800;
+    const duration = 180; // 3 minutes
+    const viewportDuration = 2; // 2 seconds visible
+    const targetPoints = 200; // pixels
+
+    // Create view with distinct values so we can detect changes
+    const view: AudioView = {
+      data: Array.from(
+        { length: duration * pointsPerSec },
+        (_, i) => (i % 100) / 100,
+      ),
+      samplesPerPoint: 60, // 48000 / 800
+      sampleRate: 48000,
+    };
+
+    // Query at different scroll positions (small increments)
+    const results: Array<{ data: number[] }> = [];
+    for (let scrollSec = 30; scrollSec < 30.1; scrollSec += 0.01) {
+      const result = queryAudioView(
+        view,
+        scrollSec,
+        scrollSec + viewportDuration,
+        targetPoints,
+      );
+      results.push({ data: result.data });
+    }
+
+    // Verify: adjacent queries should have consistent overlapping data
+    // When data shifts by 1, current[1] should equal next[0]
+    let shiftsMatch = 0;
+    for (let i = 0; i < results.length - 1; i++) {
+      const curr = results[i].data;
+      const next = results[i + 1].data;
+      // Check if first element of next matches second element of curr
+      if (Math.abs(next[0] - curr[1]) < 0.0001) {
+        shiftsMatch++;
+      }
+    }
+
+    // With stable grid alignment, most adjacent shifts should match
+    expect(shiftsMatch).toBeGreaterThanOrEqual(results.length - 2);
+  });
 });

--- a/src/lib/audio-view.ts
+++ b/src/lib/audio-view.ts
@@ -77,11 +77,26 @@ export function queryAudioView(
 
   if (endIdx <= startIdx) return emptySlice;
 
-  // Calculate actual time bounds (aligned to data point boundaries)
-  const actualStart = (startIdx * samplesPerPoint) / sampleRate;
-  const actualEnd = (endIdx * samplesPerPoint) / sampleRate;
+  // Align boundaries to coarser grid to prevent jiggling during scroll.
+  // The alignment step is based on how many source points per output point.
+  const rawLength = endIdx - startIdx;
+  const alignmentStep = Math.max(1, Math.ceil(rawLength / targetPoints));
+  const alignedStartIdx = Math.max(
+    0,
+    Math.floor(startIdx / alignmentStep) * alignmentStep,
+  );
+  const alignedEndIdx = Math.min(
+    data.length,
+    Math.ceil(endIdx / alignmentStep) * alignmentStep,
+  );
 
-  const visible = data.slice(startIdx, endIdx);
+  if (alignedEndIdx <= alignedStartIdx) return emptySlice;
+
+  // Calculate actual time bounds (aligned to coarse grid boundaries)
+  const actualStart = (alignedStartIdx * samplesPerPoint) / sampleRate;
+  const actualEnd = (alignedEndIdx * samplesPerPoint) / sampleRate;
+
+  const visible = data.slice(alignedStartIdx, alignedEndIdx);
 
   // If fewer points than target, return as-is
   if (visible.length <= targetPoints) {

--- a/src/lib/audio-view.ts
+++ b/src/lib/audio-view.ts
@@ -78,9 +78,14 @@ export function queryAudioView(
   if (endIdx <= startIdx) return emptySlice;
 
   // Align boundaries to coarser grid to prevent jiggling during scroll.
-  // The alignment step is based on how many source points per output point.
-  const rawLength = endIdx - startIdx;
-  const alignmentStep = Math.max(1, Math.ceil(rawLength / targetPoints));
+  // Compute alignment step from TIME (constant during scroll), not indices (which shift).
+  // Use Math.round (not ceil) for floating-point stability.
+  const viewportDuration = endTime - startTime;
+  const pointsPerSec = sampleRate / samplesPerPoint;
+  const alignmentStep = Math.max(
+    1,
+    Math.round((viewportDuration * pointsPerSec) / targetPoints),
+  );
   const alignedStartIdx = Math.max(
     0,
     Math.floor(startIdx / alignmentStep) * alignmentStep,
@@ -96,22 +101,26 @@ export function queryAudioView(
   const actualStart = (alignedStartIdx * samplesPerPoint) / sampleRate;
   const actualEnd = (alignedEndIdx * samplesPerPoint) / sampleRate;
 
-  const visible = data.slice(alignedStartIdx, alignedEndIdx);
+  const visibleLength = alignedEndIdx - alignedStartIdx;
 
   // If fewer points than target, return as-is
-  if (visible.length <= targetPoints) {
-    return { data: visible, actualStart, actualEnd };
+  if (visibleLength <= targetPoints) {
+    return {
+      data: data.slice(alignedStartIdx, alignedEndIdx),
+      actualStart,
+      actualEnd,
+    };
   }
 
-  // Downsample to target points
-  const step = visible.length / targetPoints;
+  // Downsample using ABSOLUTE indices (aligned to global grid).
+  // Each output point covers exactly `alignmentStep` source points,
+  // and windows are aligned to global multiples of alignmentStep.
   const result: number[] = [];
-  for (let i = 0; i < targetPoints; i++) {
-    const start = Math.floor(i * step);
-    const end = Math.floor((i + 1) * step);
+  for (let idx = alignedStartIdx; idx < alignedEndIdx; idx += alignmentStep) {
+    const windowEnd = Math.min(idx + alignmentStep, alignedEndIdx);
     let max = 0;
-    for (let j = start; j < end && j < visible.length; j++) {
-      if (visible[j] > max) max = visible[j];
+    for (let j = idx; j < windowEnd; j++) {
+      if (data[j] > max) max = data[j];
     }
     result.push(max);
   }

--- a/src/lib/audio-view.ts
+++ b/src/lib/audio-view.ts
@@ -1,0 +1,88 @@
+// AudioView - a view into audio data at some resolution
+// Decouples query interface from storage/computation strategy
+
+export interface AudioView {
+  data: number[]; // amplitude values (0-1)
+  samplesPerPoint: number; // each point represents this many samples (exact integer)
+  sampleRate: number; // for time↔sample conversion
+}
+
+export const EMPTY_AUDIO_VIEW: AudioView = {
+  data: [],
+  samplesPerPoint: 0,
+  sampleRate: 0,
+};
+
+// Build AudioView from raw samples
+export function createAudioView(
+  samples: Float32Array,
+  sampleRate: number,
+  targetPointsPerSecond: number,
+): AudioView {
+  if (samples.length === 0 || targetPointsPerSecond <= 0) {
+    return EMPTY_AUDIO_VIEW;
+  }
+
+  const samplesPerPoint = Math.floor(sampleRate / targetPointsPerSecond);
+  if (samplesPerPoint <= 0) {
+    return EMPTY_AUDIO_VIEW;
+  }
+
+  const data: number[] = [];
+
+  for (let i = 0; i < samples.length; i += samplesPerPoint) {
+    let max = 0;
+    const end = Math.min(i + samplesPerPoint, samples.length);
+    for (let j = i; j < end; j++) {
+      const abs = Math.abs(samples[j]);
+      if (abs > max) max = abs;
+    }
+    data.push(max);
+  }
+
+  return { data, samplesPerPoint, sampleRate };
+}
+
+// Query visible range, downsample to pixel width
+export function queryAudioView(
+  view: AudioView,
+  startTime: number, // seconds
+  endTime: number, // seconds
+  targetPoints: number, // pixels
+): number[] {
+  const { data, samplesPerPoint, sampleRate } = view;
+
+  if (data.length === 0 || targetPoints <= 0 || samplesPerPoint <= 0) {
+    return [];
+  }
+
+  // Convert seconds to data indices via sample indices (exact math)
+  const startSample = startTime * sampleRate;
+  const endSample = endTime * sampleRate;
+  const startIdx = Math.max(0, Math.floor(startSample / samplesPerPoint));
+  const endIdx = Math.max(
+    0,
+    Math.min(data.length, Math.ceil(endSample / samplesPerPoint)),
+  );
+
+  if (endIdx <= startIdx) return [];
+
+  const visible = data.slice(startIdx, endIdx);
+
+  // If fewer points than target, return as-is
+  if (visible.length <= targetPoints) return visible;
+
+  // Downsample to target points
+  const step = visible.length / targetPoints;
+  const result: number[] = [];
+  for (let i = 0; i < targetPoints; i++) {
+    const start = Math.floor(i * step);
+    const end = Math.floor((i + 1) * step);
+    let max = 0;
+    for (let j = start; j < end && j < visible.length; j++) {
+      if (visible[j] > max) max = visible[j];
+    }
+    result.push(max);
+  }
+  return result;
+}

--- a/src/lib/audio-view.ts
+++ b/src/lib/audio-view.ts
@@ -13,6 +13,13 @@ export const EMPTY_AUDIO_VIEW: AudioView = {
   sampleRate: 0,
 };
 
+// Result of querying AudioView - includes geometry info for renderer positioning
+export interface AudioViewSlice {
+  data: number[]; // culled and downsampled peaks
+  actualStart: number; // actual start time in seconds (aligned to data boundaries)
+  actualEnd: number; // actual end time in seconds (aligned to data boundaries)
+}
+
 // Build AudioView from raw samples
 export function createAudioView(
   samples: Float32Array,
@@ -44,16 +51,19 @@ export function createAudioView(
 }
 
 // Query visible range, downsample to pixel width
+// Returns data plus actual time bounds (aligned to data boundaries) for renderer positioning
 export function queryAudioView(
   view: AudioView,
   startTime: number, // seconds
   endTime: number, // seconds
   targetPoints: number, // pixels
-): number[] {
+): AudioViewSlice {
   const { data, samplesPerPoint, sampleRate } = view;
 
+  const emptySlice: AudioViewSlice = { data: [], actualStart: 0, actualEnd: 0 };
+
   if (data.length === 0 || targetPoints <= 0 || samplesPerPoint <= 0) {
-    return [];
+    return emptySlice;
   }
 
   // Convert seconds to data indices via sample indices (exact math)
@@ -65,12 +75,18 @@ export function queryAudioView(
     Math.min(data.length, Math.ceil(endSample / samplesPerPoint)),
   );
 
-  if (endIdx <= startIdx) return [];
+  if (endIdx <= startIdx) return emptySlice;
+
+  // Calculate actual time bounds (aligned to data point boundaries)
+  const actualStart = (startIdx * samplesPerPoint) / sampleRate;
+  const actualEnd = (endIdx * samplesPerPoint) / sampleRate;
 
   const visible = data.slice(startIdx, endIdx);
 
   // If fewer points than target, return as-is
-  if (visible.length <= targetPoints) return visible;
+  if (visible.length <= targetPoints) {
+    return { data: visible, actualStart, actualEnd };
+  }
 
   // Downsample to target points
   const step = visible.length / targetPoints;
@@ -84,5 +100,5 @@ export function queryAudioView(
     }
     result.push(max);
   }
-  return result;
+  return { data: result, actualStart, actualEnd };
 }

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -1,5 +1,11 @@
+import { toast } from "sonner";
 import * as Tone from "tone";
 import type { Note } from "../types";
+import {
+  type AudioView,
+  createAudioView,
+  EMPTY_AUDIO_VIEW,
+} from "./audio-view";
 import { OxiSynthSynth } from "./oxisynth-synth";
 import oxisynthWasmUrl from "@/assets/oxisynth/oxisynth.wasm?url";
 import oxisynthWorkletUrl from "@/assets/oxisynth/worklet.js?url";
@@ -385,47 +391,54 @@ class AudioManager {
 
 export const audioManager = new AudioManager();
 
-// Extract peaks from audio buffer for waveform display
-// Returns array of peak values (0-1) at specified resolution
-export function getAudioBufferPeaks(
-  buffer: Tone.ToneAudioBuffer,
-  peaksPerSecond: number,
-): number[] {
-  const samples = buffer.getChannelData(0); // Use left/mono channel
-  const sampleRate = buffer.sampleRate;
-  const samplesPerPeak = Math.floor(sampleRate / peaksPerSecond);
-  const peaks: number[] = [];
+// Derive POINTS_PER_SECOND from max zoom level we want to support
+// Goal: 1 point per pixel at max zoom
+//
+// At 100 BPM, 4 beats visible (1 bar) in 1920px viewport:
+//   duration = 4 beats × 0.6 sec/beat = 2.4 sec
+//   points needed = 1920 px / 2.4 sec = 800 points/sec
+//
+// Formula: POINTS_PER_SECOND = viewportWidth / (beatsAtMaxZoom × secPerBeat)
+// With viewportWidth=1920, beatsAtMaxZoom=4, BPM=100:
+//   = 1920 / (4 × 60/100) = 1920 / 2.4 = 800
+const POINTS_PER_SECOND = 800;
 
-  for (let i = 0; i < samples.length; i += samplesPerPeak) {
-    let max = 0;
-    const end = Math.min(i + samplesPerPeak, samples.length);
-    for (let j = i; j < end; j++) {
-      const abs = Math.abs(samples[j]);
-      if (abs > max) max = abs;
-    }
-    peaks.push(max);
-  }
+// Bailout threshold: avoid freezing on very long audio
+// At 48kHz, 10 min = 28.8M samples → ~50-100ms extraction (acceptable)
+// At 48kHz, 60 min = 172.8M samples → ~300-600ms extraction (too slow)
+const MAX_AUDIO_DURATION_SECONDS = 600; // 10 minutes
 
-  return peaks;
-}
-
-const PEAKS_PER_SECOND = 100;
-
-// Load audio file and extract metadata + peaks for waveform display
+// Load audio file and create AudioView for waveform display
 export async function loadAudioFile(file: File): Promise<{
   buffer: Tone.ToneAudioBuffer;
-  peaks: number[];
-  peaksPerSecond: number;
+  audioView: AudioView;
   duration: number;
 }> {
   const url = URL.createObjectURL(file);
   try {
     const buffer = await Tone.ToneAudioBuffer.fromUrl(url);
-    const peaks = getAudioBufferPeaks(buffer, PEAKS_PER_SECOND);
+
+    // Bailout for very long audio
+    if (buffer.duration > MAX_AUDIO_DURATION_SECONDS) {
+      toast.warning(
+        `Audio too long (${Math.round(buffer.duration / 60)} min). Waveform disabled.`,
+      );
+      return {
+        buffer,
+        audioView: EMPTY_AUDIO_VIEW,
+        duration: buffer.duration,
+      };
+    }
+
+    const samples = buffer.getChannelData(0); // Use left/mono channel
+    const audioView = createAudioView(
+      samples,
+      buffer.sampleRate,
+      POINTS_PER_SECOND,
+    );
     return {
       buffer,
-      peaks,
-      peaksPerSecond: PEAKS_PER_SECOND,
+      audioView,
       duration: buffer.duration,
     };
   } finally {

--- a/src/stores/project-store.ts
+++ b/src/stores/project-store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import type { AudioView } from "../lib/audio-view";
 import type { GridSnap, Locator, Note, TimeSignature } from "../types";
 import { historyStore } from "./history-store";
 
@@ -52,8 +53,7 @@ export interface ProjectState {
   waveformHeight: number; // resizable waveform area height in pixels
 
   // Waveform state
-  audioPeaks: number[]; // Peak values 0-1 for waveform display
-  peaksPerSecond: number; // Resolution of peaks array
+  audioView: AudioView | null; // Pre-computed audio data for waveform display
 
   // Actions
   addNote: (note: Note) => void;
@@ -112,7 +112,7 @@ export interface ProjectState {
   setWaveformHeight: (height: number) => void;
 
   // Waveform actions
-  setAudioPeaks: (peaks: number[], peaksPerSecond: number) => void;
+  setAudioView: (view: AudioView | null) => void;
 }
 
 let noteIdCounter = 0;
@@ -166,8 +166,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   waveformHeight: 60, // DEFAULT_WAVEFORM_HEIGHT
 
   // Waveform state
-  audioPeaks: [],
-  peaksPerSecond: 100,
+  audioView: null,
 
   addNote: (note) => {
     // Track in history
@@ -326,7 +325,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       audioAssetKey: null,
       audioDuration: 0,
       audioOffset: 0,
-      audioPeaks: [],
+      audioView: null,
       isAudioTrackSelected: false,
     }),
 
@@ -353,8 +352,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   setWaveformHeight: (height) => set({ waveformHeight: height }),
 
   // Waveform actions
-  setAudioPeaks: (peaks, peaksPerSecond) =>
-    set({ audioPeaks: peaks, peaksPerSecond }),
+  setAudioView: (view) => set({ audioView: view }),
 
   // Undo/Redo actions
   undo: () => {
@@ -640,7 +638,7 @@ export function fromSavedProject(
     // Reset transient state
     selectedNoteIds: new Set(),
     selectedLocatorId: null,
-    audioPeaks: [],
+    audioView: null,
   };
 }
 


### PR DESCRIPTION
## Summary

- First-principles analysis of waveform resolution requirements
- Identifies the two-stage pipeline bug (Stage 1 extraction is fine, Stage 2 SVG throws away detail)
- Separates orthogonal concerns: viewport culling vs adaptive resolution vs rendering tech

## Key Insights

- 16th note = 7,200 samples at 100 BPM / 48kHz
- Need ~4 peaks per 16th to distinguish transients (max 1,800 samples/peak)
- Current Stage 1: 480 samples/peak ✓
- Current Stage 2: 17,280 samples/peak for 3-min song ✗

## Next Steps

Further discussion and eventual implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)