### PR TITLE
refactor: remove redundant dialog footer close

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -7,7 +7,7 @@ import { Mixer } from "./components/mixer";
 import { PianoRoll } from "./components/piano-roll";
 import { Settings } from "./components/settings";
 import { Transport } from "./components/transport";
-import { SimpleDialog } from "./components/ui/dialog";
+import { Dialog } from "./components/ui/dialog";
 import { useDraftTextInput } from "./hooks/use-draft-text-input";
 import { useWindowEvent } from "./hooks/use-window-event";
 import { loadAsset } from "./lib/asset-store";
@@ -189,15 +189,15 @@ function Editor({ projectId }: EditorProps) {
       />
       <PianoRoll />
       <HelpOverlay isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} />
-      <SimpleDialog
+      <Dialog
         isOpen={isMixerOpen}
         onClose={() => setIsMixerOpen(false)}
         title="Mixer"
         testId="mixer-dialog"
       >
         <Mixer />
-      </SimpleDialog>
-      <SimpleDialog
+      </Dialog>
+      <Dialog
         isOpen={isSettingsOpen}
         onClose={() => setIsSettingsOpen(false)}
         title="Settings"
@@ -217,7 +217,7 @@ function Editor({ projectId }: EditorProps) {
             window.open("/", "_blank");
           }}
         />
-      </SimpleDialog>
+      </Dialog>
     </div>
   );
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -5,7 +5,6 @@ type DialogProps = {
   onClose: () => void;
   title: string;
   children: ReactNode;
-  footer?: ReactNode;
   testId?: string;
 };
 
@@ -14,7 +13,6 @@ export function Dialog({
   onClose,
   title,
   children,
-  footer,
   testId,
 }: DialogProps) {
   if (!isOpen) return null;
@@ -43,13 +41,6 @@ export function Dialog({
 
         {/* Content */}
         <div className="p-6">{children}</div>
-
-        {/* Footer */}
-        {footer && (
-          <div className="border-t border-neutral-700 px-6 py-4 flex justify-end gap-3">
-            {footer}
-          </div>
-        )}
       </div>
     </div>
   );

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,5 +1,4 @@
 import { type ReactNode } from "react";
-import { Button } from "./button";
 
 type DialogProps = {
   isOpen: boolean;
@@ -10,7 +9,7 @@ type DialogProps = {
   testId?: string;
 };
 
-function Dialog({
+export function Dialog({
   isOpen,
   onClose,
   title,
@@ -53,22 +52,5 @@ function Dialog({
         )}
       </div>
     </div>
-  );
-}
-
-// Convenience wrapper for simple close-only footer
-type SimpleDialogProps = Omit<DialogProps, "footer"> & {
-  closeLabel?: string;
-};
-
-export function SimpleDialog({
-  closeLabel = "Close",
-  ...props
-}: SimpleDialogProps) {
-  return (
-    <Dialog
-      {...props}
-      footer={<Button onClick={props.onClose}>{closeLabel}</Button>}
-    />
   );
 }


### PR DESCRIPTION
## Summary
- remove SimpleDialog footer close and use base Dialog
- keep dialogs closeable via header, backdrop, and Escape

## Testing
- pnpm test-e2e