### PR TITLE
feat: add track controls in main view

### DIFF
--- a/docs/2026-02-01-db-fader-scale.md
+++ b/docs/2026-02-01-db-fader-scale.md
@@ -1,0 +1,37 @@
+# dB Fader Scale (-60dB to +6dB)
+
+## Problem context and approach
+
+Current faders use a linear 0–1 gain value with a placeholder 0 dB marker. The desired behavior is a true decibel fader range (e.g., -60 dB to +6 dB), with the visual marker placed at 0 dB (unity gain). This requires mapping slider percent to dB and to linear gain for Tone.js/state, and updating UI to reflect the proper 0 dB position.
+
+Approach:
+
+- Define a shared mapping between slider percent (0–100) and dB range (-60 to +6), plus conversion to linear gain.
+- Update fader controls (left track strip and mixer) to use the dB mapping.
+- Place the 0 dB marker at the correct percent position.
+- Ensure existing state values persist correctly (migrate if needed or map on render).
+
+## Reference files/patterns to follow
+
+- `src/components/piano-roll.tsx` (left track controls)
+- `src/components/mixer.tsx` (mixer faders)
+- `src/lib/audio.ts` (gain application)
+- `src/stores/project-store.ts` (volume state)
+
+## Implementation steps
+
+1. Add dB conversion helpers (percent↔dB, dB↔gain) in a shared utility (likely `src/lib/music.ts` or `src/lib/utils.ts`).
+2. Update fader components to use dB percent mapping while preserving stored gain state.
+3. Place 0 dB marker based on the mapping (0 dB percent).
+4. Verify muted behavior remains unchanged and no regressions in E2E tests.
+5. Update docs/status and run `pnpm test-e2e` after implementation.
+
+## Feedback log
+
+- 2026-02-01: Request to implement -60 dB to +6 dB fader scale and correct 0 dB marker.
+
+## Status
+
+- What's done: task doc created.
+- What's remaining: implement dB fader mapping, update UI markers, test.
+- Blockers or open questions: confirm if stored volume should remain linear gain or migrate to dB values.

--- a/docs/2026-02-01-track-active-indicator.md
+++ b/docs/2026-02-01-track-active-indicator.md
@@ -32,6 +32,7 @@ Approach:
 
 - 2026-02-01: Add process: create PR after implementation, run `pnpm test-e2e`, iterate until it passes.
 - 2026-02-01: Move to left-side track control strip with faders + mute buttons.
+- [x] redesign control
 
 ```
 Audio                         |
@@ -42,6 +43,8 @@ MIDI             |            |
                  |  roll      |      midi notes
                  |
 ```
+
+- [ ] don't disable fader when muted
 
 ## Status
 

--- a/docs/2026-02-01-track-active-indicator.md
+++ b/docs/2026-02-01-track-active-indicator.md
@@ -45,6 +45,6 @@ MIDI             |            |
 
 ## Status
 
-- What's done: left track control strip implemented with faders and mute buttons.
-- What's remaining: verify layout, run `pnpm test-e2e`, create PR.
+- What's done: left track control strip implemented; PR created; `pnpm test-e2e` passing.
+- What's remaining: none.
 - Blockers or open questions: none.

--- a/docs/2026-02-01-track-active-indicator.md
+++ b/docs/2026-02-01-track-active-indicator.md
@@ -1,0 +1,50 @@
+# Track Active Indicator (Main View)
+
+## Problem context and approach
+
+The main editor view does not show whether the audio or MIDI tracks are muted. Users can toggle mute via shortcuts or the mixer dialog, but there is no immediate visual status in the main view. The plan is to add a left-side track control strip with faders and mute buttons.
+
+Approach:
+
+- Use `midiMuted` / `audioMuted` and volume state from `useProjectStore()` in `src/components/piano-roll.tsx`.
+- Add a left-side track control column with faders and mute buttons for Audio and MIDI.
+- Keep controls aligned with the waveform and keyboard regions.
+
+## Reference files/patterns to follow
+
+- `src/components/piano-roll.tsx` (main view layout)
+- `src/components/mixer.tsx` (fader + mute styling)
+- `src/stores/project-store.ts` (mute state)
+
+## Implementation steps
+
+1. Add a left track control column with Audio and MIDI faders + mute buttons.
+2. Align controls with waveform and keyboard regions and include a divider.
+3. Remove header-only toggle approach.
+
+## Process
+
+1. create PR if implementation is done.
+2. run test-e2e
+3. if failed, iterate until it passes
+
+## Feedback log
+
+- 2026-02-01: Add process: create PR after implementation, run `pnpm test-e2e`, iterate until it passes.
+- 2026-02-01: Move to left-side track control strip with faders + mute buttons.
+
+```
+Audio                         |
+[<-fader->] [M]               |     audio wave form
+-----------------|------------|-------------
+MIDI             |            |
+[<-fader->] [M]  |  piano     |
+                 |  roll      |      midi notes
+                 |
+```
+
+## Status
+
+- What's done: left track control strip implemented with faders and mute buttons.
+- What's remaining: verify layout, run `pnpm test-e2e`, create PR.
+- Blockers or open questions: none.

--- a/docs/2026-02-01-track-active-indicator.md
+++ b/docs/2026-02-01-track-active-indicator.md
@@ -44,7 +44,8 @@ MIDI             |            |
                  |
 ```
 
-- [ ] don't disable fader when muted
+- [x] don't disable fader when muted
+- [ ] add line at 0 decibel in fader range
 
 ## Status
 

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -55,7 +55,6 @@ export function Mixer() {
           step={1}
           orientation="vertical"
           className="h-48"
-          disabled={midiMuted}
         />
         <span className="text-xs text-muted-foreground tabular-nums">
           {Math.round(midiVolume * 100)}%
@@ -90,7 +89,6 @@ export function Mixer() {
           step={1}
           orientation="vertical"
           className="h-48"
-          disabled={audioMuted}
         />
         <span className="text-xs text-muted-foreground tabular-nums">
           {Math.round(audioVolume * 100)}%

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -48,14 +48,17 @@ export function Mixer() {
           <MusicIcon className="size-4 text-muted-foreground" />
           <label className="text-xs font-medium text-neutral-300">MIDI</label>
         </div>
-        <Slider
-          value={[midiVolume * 100]}
-          onValueChange={([v]) => setMidiVolume(v / 100)}
-          max={100}
-          step={1}
-          orientation="vertical"
-          className="h-48"
-        />
+        <div className="relative h-48">
+          <div className="pointer-events-none absolute left-1/2 top-0 h-px w-3 -translate-x-1/2 bg-neutral-500/70" />
+          <Slider
+            value={[midiVolume * 100]}
+            onValueChange={([v]) => setMidiVolume(v / 100)}
+            max={100}
+            step={1}
+            orientation="vertical"
+            className="h-48"
+          />
+        </div>
         <span className="text-xs text-muted-foreground tabular-nums">
           {Math.round(midiVolume * 100)}%
         </span>
@@ -82,14 +85,17 @@ export function Mixer() {
           <Volume2Icon className="size-4 text-muted-foreground" />
           <label className="text-xs font-medium text-neutral-300">Audio</label>
         </div>
-        <Slider
-          value={[audioVolume * 100]}
-          onValueChange={([v]) => setAudioVolume(v / 100)}
-          max={100}
-          step={1}
-          orientation="vertical"
-          className="h-48"
-        />
+        <div className="relative h-48">
+          <div className="pointer-events-none absolute left-1/2 top-0 h-px w-3 -translate-x-1/2 bg-neutral-500/70" />
+          <Slider
+            value={[audioVolume * 100]}
+            onValueChange={([v]) => setAudioVolume(v / 100)}
+            max={100}
+            step={1}
+            orientation="vertical"
+            className="h-48"
+          />
+        </div>
         <span className="text-xs text-muted-foreground tabular-nums">
           {Math.round(audioVolume * 100)}%
         </span>

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -48,17 +48,14 @@ export function Mixer() {
           <MusicIcon className="size-4 text-muted-foreground" />
           <label className="text-xs font-medium text-neutral-300">MIDI</label>
         </div>
-        <div className="relative h-48">
-          <div className="pointer-events-none absolute left-1/2 top-0 h-px w-3 -translate-x-1/2 bg-neutral-500/70" />
-          <Slider
-            value={[midiVolume * 100]}
-            onValueChange={([v]) => setMidiVolume(v / 100)}
-            max={100}
-            step={1}
-            orientation="vertical"
-            className="h-48"
-          />
-        </div>
+        <Slider
+          value={[midiVolume * 100]}
+          onValueChange={([v]) => setMidiVolume(v / 100)}
+          max={100}
+          step={1}
+          orientation="vertical"
+          className="h-48"
+        />
         <span className="text-xs text-muted-foreground tabular-nums">
           {Math.round(midiVolume * 100)}%
         </span>
@@ -85,17 +82,14 @@ export function Mixer() {
           <Volume2Icon className="size-4 text-muted-foreground" />
           <label className="text-xs font-medium text-neutral-300">Audio</label>
         </div>
-        <div className="relative h-48">
-          <div className="pointer-events-none absolute left-1/2 top-0 h-px w-3 -translate-x-1/2 bg-neutral-500/70" />
-          <Slider
-            value={[audioVolume * 100]}
-            onValueChange={([v]) => setAudioVolume(v / 100)}
-            max={100}
-            step={1}
-            orientation="vertical"
-            className="h-48"
-          />
-        </div>
+        <Slider
+          value={[audioVolume * 100]}
+          onValueChange={([v]) => setAudioVolume(v / 100)}
+          max={100}
+          step={1}
+          orientation="vertical"
+          className="h-48"
+        />
         <span className="text-xs text-muted-foreground tabular-nums">
           {Math.round(audioVolume * 100)}%
         </span>

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -27,9 +27,12 @@ import {
   useProjectStore,
 } from "../stores/project-store";
 import { GRID_SNAP_VALUES, GridSnap, Note } from "../types";
+import { Slider } from "./ui/slider";
+import { Toggle } from "./ui/toggle";
 
 // Layout constants
 const KEYBOARD_WIDTH = 60;
+const TRACK_CONTROL_WIDTH = 120;
 const TIMELINE_HEIGHT = 40;
 const MIN_WAVEFORM_HEIGHT = 40;
 const MAX_WAVEFORM_HEIGHT = 200;
@@ -238,6 +241,10 @@ export function PianoRoll() {
     audioOffset,
     audioFileName,
     isAudioTrackSelected,
+    audioVolume,
+    midiVolume,
+    audioMuted,
+    midiMuted,
     showDebug,
     autoScrollEnabled,
     addNote,
@@ -273,6 +280,10 @@ export function PianoRoll() {
     setPixelsPerBeat,
     setPixelsPerKey,
     setWaveformHeight,
+    setAudioVolume,
+    setMidiVolume,
+    setAudioMuted,
+    setMidiMuted,
   } = useProjectStore();
 
   // Transport state from hook (source of truth: Tone.js Transport)
@@ -292,6 +303,7 @@ export function PianoRoll() {
   // Keep fractional values in state for smooth zoom, but render with whole pixels
   const roundedPixelsPerKey = Math.round(pixelsPerKey);
   const roundedPixelsPerBeat = Math.round(pixelsPerBeat);
+  const leftPanelWidth = TRACK_CONTROL_WIDTH + KEYBOARD_WIDTH;
 
   // Edge threshold for resize handles: 20% of grid cell, clamped to 6-20px
   const gridCellWidth = gridSnapValue * roundedPixelsPerBeat;
@@ -991,29 +1003,101 @@ export function PianoRoll() {
     <div className="flex flex-col flex-1 bg-neutral-900 text-neutral-100 select-none overflow-hidden">
       {/* Main content area - fixed layout, no native scroll */}
       <div ref={containerRef} className="flex-1 flex overflow-hidden">
-        {/* Left column: keyboard labels */}
-        <div
-          className="shrink-0 flex flex-col bg-neutral-900"
-          style={{ width: KEYBOARD_WIDTH }}
-        >
-          {/* Timeline spacer */}
-          <div className="shrink-0" style={{ height: TIMELINE_HEIGHT }} />
-          {/* Waveform spacer */}
+        {/* Left column: track controls + keyboard labels */}
+        <div className="shrink-0 flex bg-neutral-900">
           <div
-            className="shrink-0 border-b border-neutral-700 flex items-center justify-center text-xs text-neutral-500"
-            style={{ height: waveformHeight }}
+            className="shrink-0 flex flex-col"
+            style={{ width: TRACK_CONTROL_WIDTH }}
           >
-            Audio
+            {/* Timeline spacer */}
+            <div className="shrink-0" style={{ height: TIMELINE_HEIGHT }} />
+            {/* Audio controls */}
+            <div
+              className="shrink-0 border-b border-neutral-700 px-2 py-2"
+              style={{ height: waveformHeight }}
+            >
+              <div className="flex items-center justify-between text-[11px] text-neutral-400 mb-2">
+                <span className="uppercase tracking-wide">Audio</span>
+                <Toggle
+                  pressed={audioMuted}
+                  onPressedChange={setAudioMuted}
+                  aria-label="Toggle audio mute"
+                  title={
+                    audioMuted
+                      ? "Unmute audio (Shift+2)"
+                      : "Mute audio (Shift+2)"
+                  }
+                  size="sm"
+                  variant="outline"
+                  className={
+                    audioMuted
+                      ? "bg-red-900/50 border-red-700 text-red-300 hover:bg-red-900/70 hover:text-red-200 data-[state=on]:bg-red-900/50 data-[state=on]:text-red-300"
+                      : ""
+                  }
+                >
+                  M
+                </Toggle>
+              </div>
+              <Slider
+                value={[audioVolume * 100]}
+                onValueChange={([v]) => setAudioVolume(v / 100)}
+                max={100}
+                step={1}
+                disabled={audioMuted}
+              />
+            </div>
+            {/* MIDI controls */}
+            <div className="flex-1 px-2 py-2">
+              <div className="flex items-center justify-between text-[11px] text-neutral-400 mb-2">
+                <span className="uppercase tracking-wide">MIDI</span>
+                <Toggle
+                  pressed={midiMuted}
+                  onPressedChange={setMidiMuted}
+                  aria-label="Toggle MIDI mute"
+                  title={
+                    midiMuted ? "Unmute MIDI (Shift+1)" : "Mute MIDI (Shift+1)"
+                  }
+                  size="sm"
+                  variant="outline"
+                  className={
+                    midiMuted
+                      ? "bg-red-900/50 border-red-700 text-red-300 hover:bg-red-900/70 hover:text-red-200 data-[state=on]:bg-red-900/50 data-[state=on]:text-red-300"
+                      : ""
+                  }
+                >
+                  M
+                </Toggle>
+              </div>
+              <Slider
+                value={[midiVolume * 100]}
+                onValueChange={([v]) => setMidiVolume(v / 100)}
+                max={100}
+                step={1}
+                disabled={midiMuted}
+              />
+            </div>
           </div>
-          {/* Piano keyboard */}
-          <div className="flex-1 overflow-hidden">
-            <Keyboard
-              pixelsPerKey={roundedPixelsPerKey}
-              scrollY={scrollY}
-              viewportHeight={
-                viewportSize.height - TIMELINE_HEIGHT - waveformHeight
-              }
-            />
+          <div
+            className="shrink-0 flex flex-col bg-neutral-900"
+            style={{ width: KEYBOARD_WIDTH }}
+          >
+            {/* Timeline spacer */}
+            <div className="shrink-0" style={{ height: TIMELINE_HEIGHT }} />
+            {/* Waveform spacer */}
+            <div
+              className="shrink-0 border-b border-neutral-700 flex items-center justify-center text-xs text-neutral-500"
+              style={{ height: waveformHeight }}
+            ></div>
+            {/* Piano keyboard */}
+            <div className="flex-1 overflow-hidden">
+              <Keyboard
+                pixelsPerKey={roundedPixelsPerKey}
+                scrollY={scrollY}
+                viewportHeight={
+                  viewportSize.height - TIMELINE_HEIGHT - waveformHeight
+                }
+              />
+            </div>
           </div>
         </div>
 
@@ -1023,7 +1107,7 @@ export function PianoRoll() {
           <Timeline
             pixelsPerBeat={roundedPixelsPerBeat}
             scrollX={scrollX}
-            viewportWidth={viewportSize.width - KEYBOARD_WIDTH}
+            viewportWidth={viewportSize.width - leftPanelWidth}
             playheadBeat={secondsToBeats(position, tempo)}
             beatsPerBar={beatsPerBar}
             gridSnapValue={gridSnapValue}
@@ -1043,7 +1127,7 @@ export function PianoRoll() {
             pixelsPerBeat={roundedPixelsPerBeat}
             gridSnap={gridSnap}
             scrollX={scrollX}
-            viewportWidth={viewportSize.width - KEYBOARD_WIDTH}
+            viewportWidth={viewportSize.width - leftPanelWidth}
             audioDuration={audioDuration}
             audioOffset={audioOffset}
             audioFileName={audioFileName}

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -1076,7 +1076,7 @@ export function PianoRoll() {
             </div>
           </div>
           <div
-            className="shrink-0 flex flex-col bg-neutral-900"
+            className="shrink-0 flex flex-col bg-neutral-900 border-r border-neutral-700"
             style={{ width: KEYBOARD_WIDTH }}
           >
             {/* Timeline spacer */}

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -1043,7 +1043,6 @@ export function PianoRoll() {
                 onValueChange={([v]) => setAudioVolume(v / 100)}
                 max={100}
                 step={1}
-                disabled={audioMuted}
               />
             </div>
             {/* MIDI controls */}
@@ -1073,7 +1072,6 @@ export function PianoRoll() {
                 onValueChange={([v]) => setMidiVolume(v / 100)}
                 max={100}
                 step={1}
-                disabled={midiMuted}
               />
             </div>
           </div>

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -1038,15 +1038,12 @@ export function PianoRoll() {
                   M
                 </Toggle>
               </div>
-              <div className="relative">
-                <div className="pointer-events-none absolute right-0 top-1/2 h-3 w-px -translate-y-1/2 bg-neutral-500/70" />
-                <Slider
-                  value={[audioVolume * 100]}
-                  onValueChange={([v]) => setAudioVolume(v / 100)}
-                  max={100}
-                  step={1}
-                />
-              </div>
+              <Slider
+                value={[audioVolume * 100]}
+                onValueChange={([v]) => setAudioVolume(v / 100)}
+                max={100}
+                step={1}
+              />
             </div>
             {/* MIDI controls */}
             <div className="flex-1 px-2 pt-3">
@@ -1070,15 +1067,12 @@ export function PianoRoll() {
                   M
                 </Toggle>
               </div>
-              <div className="relative">
-                <div className="pointer-events-none absolute right-0 top-1/2 h-3 w-px -translate-y-1/2 bg-neutral-500/70" />
-                <Slider
-                  value={[midiVolume * 100]}
-                  onValueChange={([v]) => setMidiVolume(v / 100)}
-                  max={100}
-                  step={1}
-                />
-              </div>
+              <Slider
+                value={[midiVolume * 100]}
+                onValueChange={([v]) => setMidiVolume(v / 100)}
+                max={100}
+                step={1}
+              />
             </div>
           </div>
           <div

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -31,8 +31,9 @@ import { Slider } from "./ui/slider";
 import { Toggle } from "./ui/toggle";
 
 // Layout constants
-const KEYBOARD_WIDTH = 60;
-const TRACK_CONTROL_WIDTH = 120;
+const KEYBOARD_WIDTH = 50;
+const TRACK_CONTROL_WIDTH = 130;
+const LEFT_PANEL_WIDTH = TRACK_CONTROL_WIDTH + KEYBOARD_WIDTH;
 const TIMELINE_HEIGHT = 40;
 const MIN_WAVEFORM_HEIGHT = 40;
 const MAX_WAVEFORM_HEIGHT = 200;
@@ -303,7 +304,6 @@ export function PianoRoll() {
   // Keep fractional values in state for smooth zoom, but render with whole pixels
   const roundedPixelsPerKey = Math.round(pixelsPerKey);
   const roundedPixelsPerBeat = Math.round(pixelsPerBeat);
-  const leftPanelWidth = TRACK_CONTROL_WIDTH + KEYBOARD_WIDTH;
 
   // Edge threshold for resize handles: 20% of grid cell, clamped to 6-20px
   const gridCellWidth = gridSnapValue * roundedPixelsPerBeat;
@@ -1013,10 +1013,10 @@ export function PianoRoll() {
             <div className="shrink-0" style={{ height: TIMELINE_HEIGHT }} />
             {/* Audio controls */}
             <div
-              className="shrink-0 border-b border-neutral-700 px-2 py-2"
+              className="shrink-0 border-b border-neutral-700 px-2 pt-3"
               style={{ height: waveformHeight }}
             >
-              <div className="flex items-center justify-between text-[11px] text-neutral-400 mb-2">
+              <div className="flex items-center justify-between text-[11px] text-neutral-400 mb-3">
                 <span className="uppercase tracking-wide">Audio</span>
                 <Toggle
                   pressed={audioMuted}
@@ -1031,8 +1031,8 @@ export function PianoRoll() {
                   variant="outline"
                   className={
                     audioMuted
-                      ? "bg-red-900/50 border-red-700 text-red-300 hover:bg-red-900/70 hover:text-red-200 data-[state=on]:bg-red-900/50 data-[state=on]:text-red-300"
-                      : ""
+                      ? "h-5 min-w-5 px-0 text-[10px] bg-red-900/50 border-red-700 text-red-300 hover:bg-red-900/70 hover:text-red-200 data-[state=on]:bg-red-900/50 data-[state=on]:text-red-300"
+                      : "h-5 min-w-5 px-0 text-[10px]"
                   }
                 >
                   M
@@ -1047,8 +1047,8 @@ export function PianoRoll() {
               />
             </div>
             {/* MIDI controls */}
-            <div className="flex-1 px-2 py-2">
-              <div className="flex items-center justify-between text-[11px] text-neutral-400 mb-2">
+            <div className="flex-1 px-2 pt-3">
+              <div className="flex items-center justify-between text-[11px] text-neutral-400 mb-3">
                 <span className="uppercase tracking-wide">MIDI</span>
                 <Toggle
                   pressed={midiMuted}
@@ -1061,8 +1061,8 @@ export function PianoRoll() {
                   variant="outline"
                   className={
                     midiMuted
-                      ? "bg-red-900/50 border-red-700 text-red-300 hover:bg-red-900/70 hover:text-red-200 data-[state=on]:bg-red-900/50 data-[state=on]:text-red-300"
-                      : ""
+                      ? "h-5 min-w-5 px-0 text-[10px] bg-red-900/50 border-red-700 text-red-300 hover:bg-red-900/70 hover:text-red-200 data-[state=on]:bg-red-900/50 data-[state=on]:text-red-300"
+                      : "h-5 min-w-5 px-0 text-[10px]"
                   }
                 >
                   M
@@ -1107,7 +1107,7 @@ export function PianoRoll() {
           <Timeline
             pixelsPerBeat={roundedPixelsPerBeat}
             scrollX={scrollX}
-            viewportWidth={viewportSize.width - leftPanelWidth}
+            viewportWidth={viewportSize.width - LEFT_PANEL_WIDTH}
             playheadBeat={secondsToBeats(position, tempo)}
             beatsPerBar={beatsPerBar}
             gridSnapValue={gridSnapValue}
@@ -1127,7 +1127,7 @@ export function PianoRoll() {
             pixelsPerBeat={roundedPixelsPerBeat}
             gridSnap={gridSnap}
             scrollX={scrollX}
-            viewportWidth={viewportSize.width - leftPanelWidth}
+            viewportWidth={viewportSize.width - LEFT_PANEL_WIDTH}
             audioDuration={audioDuration}
             audioOffset={audioOffset}
             audioFileName={audioFileName}

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -1038,12 +1038,15 @@ export function PianoRoll() {
                   M
                 </Toggle>
               </div>
-              <Slider
-                value={[audioVolume * 100]}
-                onValueChange={([v]) => setAudioVolume(v / 100)}
-                max={100}
-                step={1}
-              />
+              <div className="relative">
+                <div className="pointer-events-none absolute right-0 top-1/2 h-3 w-px -translate-y-1/2 bg-neutral-500/70" />
+                <Slider
+                  value={[audioVolume * 100]}
+                  onValueChange={([v]) => setAudioVolume(v / 100)}
+                  max={100}
+                  step={1}
+                />
+              </div>
             </div>
             {/* MIDI controls */}
             <div className="flex-1 px-2 pt-3">
@@ -1067,12 +1070,15 @@ export function PianoRoll() {
                   M
                 </Toggle>
               </div>
-              <Slider
-                value={[midiVolume * 100]}
-                onValueChange={([v]) => setMidiVolume(v / 100)}
-                max={100}
-                step={1}
-              />
+              <div className="relative">
+                <div className="pointer-events-none absolute right-0 top-1/2 h-3 w-px -translate-y-1/2 bg-neutral-500/70" />
+                <Slider
+                  value={[midiVolume * 100]}
+                  onValueChange={([v]) => setMidiVolume(v / 100)}
+                  max={100}
+                  step={1}
+                />
+              </div>
             </div>
           </div>
           <div


### PR DESCRIPTION
## Summary
- add a left-side track control strip with Audio/MIDI faders and mute toggles
- align the new strip with the waveform and piano roll layout
- document the updated approach and process in the task doc

## Testing
- pnpm lint