### PR TITLE
refactor: dedupe metronome icon

### DIFF
--- a/docs/2026-02-01-icon-dedup.md
+++ b/docs/2026-02-01-icon-dedup.md
@@ -1,0 +1,32 @@
+# Icon Deduplication (Metronome + Similar)
+
+## Problem Context and Approach
+
+MetronomeIcon is defined in multiple components (e.g. transport and mixer). The goal is to consolidate duplicate icon components into a shared location and update call sites. I will also scan for other duplicated inline icon components and fold them into the shared location if they are identical or near-identical.
+
+Approach: identify all inline icon components, group duplicates by SVG structure, and move shared ones into a single file (likely a new `src/components/icons.tsx` or existing common UI file). Replace local definitions with imports to keep behavior consistent.
+
+## Reference Files / Patterns
+
+- `src/components/transport.tsx` (MetronomeIcon definition)
+- `src/components/mixer.tsx` (MetronomeIcon definition)
+- Existing shared UI component patterns in `src/components` (to follow project conventions)
+
+## Implementation Steps
+
+1. Create a feature branch for this refactor.
+2. Inventory inline icon components across `src/components/**`.
+3. Compare for duplicates (exact SVG and props).
+4. Create or update a shared icons module and move duplicates there.
+5. Replace inline definitions with imports.
+6. Ensure no behavior changes and run type check if needed.
+
+## Feedback Log
+
+- 2026-02-01: Initial request to dedupe MetronomeIcon and search for similar duplicacy.
+
+## Status
+
+- Done: Created feature branch; scanned for duplicate icons; centralized MetronomeIcon in shared module; updated imports.
+- Remaining: None.
+- Blockers / Open Questions: None.

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,0 +1,20 @@
+export function MetronomeIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      viewBox="0 0 24 24"
+      aria-label="Metronome"
+    >
+      <title>Metronome</title>
+      <path
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="m14.153 8.188l-.72-3.236a2.493 2.493 0 0 0-4.867 0L5.541 18.566A2 2 0 0 0 7.493 21h7.014a2 2 0 0 0 1.952-2.434l-.524-2.357M11 18l9-13m-1 0a1 1 0 1 0 2 0a1 1 0 1 0-2 0"
+      />
+    </svg>
+  );
+}

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -1,28 +1,8 @@
 import { MusicIcon, Volume2Icon, VolumeXIcon } from "lucide-react";
 import { useProjectStore } from "../stores/project-store";
+import { MetronomeIcon } from "./icons";
 import { Slider } from "./ui/slider";
 import { Toggle } from "./ui/toggle";
-
-function MetronomeIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      className={className}
-      viewBox="0 0 24 24"
-      aria-label="Metronome"
-    >
-      <title>Metronome</title>
-      <path
-        fill="none"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="m14.153 8.188l-.72-3.236a2.493 2.493 0 0 0-4.867 0L5.541 18.566A2 2 0 0 0 7.493 21h7.014a2 2 0 0 0 1.952-2.434l-.524-2.357M11 18l9-13m-1 0a1 1 0 1 0 2 0a1 1 0 1 0-2 0"
-      />
-    </svg>
-  );
-}
 
 export function Mixer() {
   const {

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -15,6 +15,7 @@ import { useWindowEvent } from "../hooks/use-window-event";
 import { audioManager, GM_PROGRAMS } from "../lib/audio";
 import { useProjectStore } from "../stores/project-store";
 import { COMMON_TIME_SIGNATURES, type GridSnap } from "../types";
+import { MetronomeIcon } from "./icons";
 import { Button } from "./ui/button";
 import {
   Command,
@@ -32,27 +33,6 @@ import {
   DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
-
-function MetronomeIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      className={className}
-      viewBox="0 0 24 24"
-      aria-label="Metronome"
-    >
-      <title>Metronome</title>
-      <path
-        fill="none"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="m14.153 8.188l-.72-3.236a2.493 2.493 0 0 0-4.867 0L5.541 18.566A2 2 0 0 0 7.493 21h7.014a2 2 0 0 0 1.952-2.434l-.524-2.357M11 18l9-13m-1 0a1 1 0 1 0 2 0a1 1 0 1 0-2 0"
-      />
-    </svg>
-  );
-}
 
 function formatTimeCompact(seconds: number): string {
   const mins = Math.floor(seconds / 60);


### PR DESCRIPTION
## Summary
- centralize MetronomeIcon in shared component module
- update mixer and transport to import the shared icon
- document the deduplication task

## Testing
- pnpm lint