### PR TITLE
feat: add db-scaled faders

### DIFF
--- a/docs/2026-02-01-db-fader-scale.md
+++ b/docs/2026-02-01-db-fader-scale.md
@@ -32,6 +32,6 @@ Approach:
 
 ## Status
 
-- What's done: dB fader mapping implemented with 0 dB markers; mixer and track controls updated; volume clamping allows +6 dB; `pnpm test-e2e` passing.
-- What's remaining: create PR.
+- What's done: dB fader mapping implemented with 0 dB markers; mixer and track controls updated; volume clamping allows +6 dB; `pnpm test-e2e` passing; PR created.
+- What's remaining: none.
 - Blockers or open questions: none.

--- a/docs/2026-02-01-db-fader-scale.md
+++ b/docs/2026-02-01-db-fader-scale.md
@@ -32,6 +32,6 @@ Approach:
 
 ## Status
 
-- What's done: task doc created.
-- What's remaining: implement dB fader mapping, update UI markers, test.
-- Blockers or open questions: confirm if stored volume should remain linear gain or migrate to dB values.
+- What's done: dB fader mapping implemented with 0 dB markers; mixer and track controls updated; volume clamping allows +6 dB; `pnpm test-e2e` passing.
+- What's remaining: create PR.
+- Blockers or open questions: none.

--- a/docs/2026-02-01-db-fader-scale.md
+++ b/docs/2026-02-01-db-fader-scale.md
@@ -7,7 +7,7 @@ Current faders use a linear 0–1 gain value with a placeholder 0 dB marker. The
 Approach:
 
 - Define a shared mapping between slider percent (0–100) and dB range (-60 to +6), plus conversion to linear gain.
-- Apply a DAW-style taper with a unity breakpoint at 75% of the slider travel.
+- Apply a DAW-style taper based on Ardour's gain-to-position curve.
 - Update fader controls (left track strip and mixer) to use the tapered mapping.
 - Place the 0 dB marker at the correct percent position.
 
@@ -21,7 +21,7 @@ Approach:
 ## Implementation steps
 
 1. Add dB conversion helpers (percent↔dB, dB↔gain) in a shared utility.
-2. Implement a unity breakpoint taper in the conversion functions.
+2. Implement the Ardour taper curve in the conversion functions.
 3. Update fader components to use dB percent mapping while preserving stored gain state.
 4. Place 0 dB marker based on the mapping (0 dB percent).
 5. Verify muted behavior remains unchanged and no regressions in E2E tests.
@@ -29,10 +29,10 @@ Approach:
 ## Feedback log
 
 - 2026-02-01: Request to implement -60 dB to +6 dB fader scale and correct 0 dB marker.
-- 2026-02-01: Request a DAW-style fader taper (more travel around 0 dB).
+- 2026-02-01: Request a DAW-style fader taper (Ardour curve).
 
 ## Status
 
-- What's done: dB fader mapping implemented with a tapered curve at 75% unity; mixer and track controls updated; volume clamping allows +6 dB; `pnpm test-e2e` passing; PR created.
+- What's done: dB fader mapping implemented with Ardour-style taper; mixer and track controls updated; volume clamping allows +6 dB; `pnpm test-e2e` passing; PR created.
 - What's remaining: none.
 - Blockers or open questions: none.

--- a/docs/2026-02-01-db-fader-scale.md
+++ b/docs/2026-02-01-db-fader-scale.md
@@ -30,9 +30,10 @@ Approach:
 
 - 2026-02-01: Request to implement -60 dB to +6 dB fader scale and correct 0 dB marker.
 - 2026-02-01: Request a DAW-style fader taper (Ardour curve).
+- 2026-02-01: Add direct dB input in mixer.
 
 ## Status
 
-- What's done: dB fader mapping implemented with Ardour-style taper; mixer and track controls updated; volume clamping allows +6 dB; `pnpm test-e2e` passing; PR created.
+- What's done: dB fader mapping implemented with Ardour-style taper; mixer and track controls updated; volume clamping allows +6 dB; direct dB inputs added in mixer; `pnpm test-e2e` passing; PR created.
 - What's remaining: none.
 - Blockers or open questions: none.

--- a/docs/2026-02-01-db-fader-scale.md
+++ b/docs/2026-02-01-db-fader-scale.md
@@ -7,9 +7,9 @@ Current faders use a linear 0–1 gain value with a placeholder 0 dB marker. The
 Approach:
 
 - Define a shared mapping between slider percent (0–100) and dB range (-60 to +6), plus conversion to linear gain.
-- Update fader controls (left track strip and mixer) to use the dB mapping.
+- Apply a DAW-style taper with a unity breakpoint at 75% of the slider travel.
+- Update fader controls (left track strip and mixer) to use the tapered mapping.
 - Place the 0 dB marker at the correct percent position.
-- Ensure existing state values persist correctly (migrate if needed or map on render).
 
 ## Reference files/patterns to follow
 
@@ -20,18 +20,19 @@ Approach:
 
 ## Implementation steps
 
-1. Add dB conversion helpers (percent↔dB, dB↔gain) in a shared utility (likely `src/lib/music.ts` or `src/lib/utils.ts`).
-2. Update fader components to use dB percent mapping while preserving stored gain state.
-3. Place 0 dB marker based on the mapping (0 dB percent).
-4. Verify muted behavior remains unchanged and no regressions in E2E tests.
-5. Update docs/status and run `pnpm test-e2e` after implementation.
+1. Add dB conversion helpers (percent↔dB, dB↔gain) in a shared utility.
+2. Implement a unity breakpoint taper in the conversion functions.
+3. Update fader components to use dB percent mapping while preserving stored gain state.
+4. Place 0 dB marker based on the mapping (0 dB percent).
+5. Verify muted behavior remains unchanged and no regressions in E2E tests.
 
 ## Feedback log
 
 - 2026-02-01: Request to implement -60 dB to +6 dB fader scale and correct 0 dB marker.
+- 2026-02-01: Request a DAW-style fader taper (more travel around 0 dB).
 
 ## Status
 
-- What's done: dB fader mapping implemented with 0 dB markers; mixer and track controls updated; volume clamping allows +6 dB; `pnpm test-e2e` passing; PR created.
+- What's done: dB fader mapping implemented with a tapered curve at 75% unity; mixer and track controls updated; volume clamping allows +6 dB; `pnpm test-e2e` passing; PR created.
 - What's remaining: none.
 - Blockers or open questions: none.

--- a/e2e/transport.spec.ts
+++ b/e2e/transport.spec.ts
@@ -77,6 +77,24 @@ test.describe("Transport Controls", () => {
     await expect(metronomeToggle).toHaveAttribute("aria-pressed", "false");
   });
 
+  test("mixer dB input", async ({ page }) => {
+    await page.getByTestId("mixer-button").click();
+    const mixerDialog = page.getByTestId("mixer-dialog");
+    const midiDbInput = mixerDialog.getByLabel("MIDI level in dB");
+
+    await midiDbInput.fill("-12.0");
+    await midiDbInput.press("Enter");
+    await expect(midiDbInput).toHaveValue("-12.0");
+
+    await midiDbInput.fill("10");
+    await midiDbInput.press("Enter");
+    await expect(midiDbInput).toHaveValue("6.0");
+
+    await midiDbInput.fill("-100");
+    await midiDbInput.press("Enter");
+    await expect(midiDbInput).toHaveValue("-60.0");
+  });
+
   test("auto-scroll toggle", async ({ page }) => {
     // Open settings dialog to access auto-scroll toggle
     await page.getByTestId("settings-button").click();

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -174,7 +174,6 @@ export function Mixer() {
             step={1}
             orientation="vertical"
             className="h-48"
-            disabled={!metronomeEnabled}
           />
         </div>
         <div className="flex items-center gap-1 text-xs text-muted-foreground tabular-nums">
@@ -184,7 +183,6 @@ export function Mixer() {
             aria-label="Metronome level in dB"
             className="w-12 h-6 px-1 text-xs font-mono bg-input border border-border rounded text-center text-foreground"
             {...metronomeDbInput.props}
-            disabled={!metronomeEnabled}
           />
           <span>dB</span>
         </div>

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -1,4 +1,5 @@
 import { MusicIcon, Volume2Icon, VolumeXIcon } from "lucide-react";
+import { dbToPercent, gainToPercent, percentToGain } from "../lib/volume";
 import { useProjectStore } from "../stores/project-store";
 import { MetronomeIcon } from "./icons";
 import { Slider } from "./ui/slider";
@@ -19,6 +20,7 @@ export function Mixer() {
     setAudioMuted,
     setMetronomeEnabled,
   } = useProjectStore();
+  const zeroDbPercent = dbToPercent(0);
 
   return (
     <div className="flex justify-center gap-8 py-4">
@@ -28,16 +30,22 @@ export function Mixer() {
           <MusicIcon className="size-4 text-muted-foreground" />
           <label className="text-xs font-medium text-neutral-300">MIDI</label>
         </div>
-        <Slider
-          value={[midiVolume * 100]}
-          onValueChange={([v]) => setMidiVolume(v / 100)}
-          max={100}
-          step={1}
-          orientation="vertical"
-          className="h-48"
-        />
+        <div className="relative h-48">
+          <div
+            className="pointer-events-none absolute left-1/2 h-px w-3 -translate-x-1/2 bg-neutral-500/70"
+            style={{ bottom: `${zeroDbPercent}%` }}
+          />
+          <Slider
+            value={[gainToPercent(midiVolume)]}
+            onValueChange={([v]) => setMidiVolume(percentToGain(v))}
+            max={100}
+            step={1}
+            orientation="vertical"
+            className="h-48"
+          />
+        </div>
         <span className="text-xs text-muted-foreground tabular-nums">
-          {Math.round(midiVolume * 100)}%
+          {Math.round(gainToPercent(midiVolume))}%
         </span>
         <Toggle
           pressed={midiMuted}
@@ -62,16 +70,22 @@ export function Mixer() {
           <Volume2Icon className="size-4 text-muted-foreground" />
           <label className="text-xs font-medium text-neutral-300">Audio</label>
         </div>
-        <Slider
-          value={[audioVolume * 100]}
-          onValueChange={([v]) => setAudioVolume(v / 100)}
-          max={100}
-          step={1}
-          orientation="vertical"
-          className="h-48"
-        />
+        <div className="relative h-48">
+          <div
+            className="pointer-events-none absolute left-1/2 h-px w-3 -translate-x-1/2 bg-neutral-500/70"
+            style={{ bottom: `${zeroDbPercent}%` }}
+          />
+          <Slider
+            value={[gainToPercent(audioVolume)]}
+            onValueChange={([v]) => setAudioVolume(percentToGain(v))}
+            max={100}
+            step={1}
+            orientation="vertical"
+            className="h-48"
+          />
+        </div>
         <span className="text-xs text-muted-foreground tabular-nums">
-          {Math.round(audioVolume * 100)}%
+          {Math.round(gainToPercent(audioVolume))}%
         </span>
         <Toggle
           pressed={audioMuted}
@@ -96,17 +110,23 @@ export function Mixer() {
           <MetronomeIcon className="size-4 text-muted-foreground" />
           <label className="text-xs font-medium text-neutral-300">Metro</label>
         </div>
-        <Slider
-          value={[metronomeVolume * 100]}
-          onValueChange={([v]) => setMetronomeVolume(v / 100)}
-          max={100}
-          step={1}
-          orientation="vertical"
-          className="h-48"
-          disabled={!metronomeEnabled}
-        />
+        <div className="relative h-48">
+          <div
+            className="pointer-events-none absolute left-1/2 h-px w-3 -translate-x-1/2 bg-neutral-500/70"
+            style={{ bottom: `${zeroDbPercent}%` }}
+          />
+          <Slider
+            value={[gainToPercent(metronomeVolume)]}
+            onValueChange={([v]) => setMetronomeVolume(percentToGain(v))}
+            max={100}
+            step={1}
+            orientation="vertical"
+            className="h-48"
+            disabled={!metronomeEnabled}
+          />
+        </div>
         <span className="text-xs text-muted-foreground tabular-nums">
-          {Math.round(metronomeVolume * 100)}%
+          {Math.round(gainToPercent(metronomeVolume))}%
         </span>
         <Toggle
           pressed={!metronomeEnabled}

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -1,4 +1,5 @@
 import { MusicIcon, Volume2Icon, VolumeXIcon } from "lucide-react";
+import { useCallback } from "react";
 import { useDraftInput } from "../hooks/use-draft-input";
 import {
   MAX_DB,
@@ -30,6 +31,7 @@ export function Mixer() {
     setMetronomeEnabled,
   } = useProjectStore();
   const zeroDbPercent = dbToPercent(0);
+  const formatDb = useCallback((value: number) => value.toFixed(1), []);
   const midiDbInput = useDraftInput({
     value: gainToDb(midiVolume),
     onCommit: (db) => setMidiVolume(dbToGain(db)),
@@ -37,7 +39,7 @@ export function Mixer() {
     max: MAX_DB,
     step: 0.5,
     parse: "float",
-    format: (value) => value.toFixed(1),
+    format: formatDb,
   });
   const audioDbInput = useDraftInput({
     value: gainToDb(audioVolume),
@@ -46,7 +48,7 @@ export function Mixer() {
     max: MAX_DB,
     step: 0.5,
     parse: "float",
-    format: (value) => value.toFixed(1),
+    format: formatDb,
   });
   const metronomeDbInput = useDraftInput({
     value: gainToDb(metronomeVolume),
@@ -55,7 +57,7 @@ export function Mixer() {
     max: MAX_DB,
     step: 0.5,
     parse: "float",
-    format: (value) => value.toFixed(1),
+    format: formatDb,
   });
 
   return (

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -1,5 +1,10 @@
 import { MusicIcon, Volume2Icon, VolumeXIcon } from "lucide-react";
-import { dbToPercent, gainToPercent, percentToGain } from "../lib/volume";
+import {
+  dbToPercent,
+  gainToDb,
+  gainToPercent,
+  percentToGain,
+} from "../lib/volume";
 import { useProjectStore } from "../stores/project-store";
 import { MetronomeIcon } from "./icons";
 import { Slider } from "./ui/slider";
@@ -45,7 +50,7 @@ export function Mixer() {
           />
         </div>
         <span className="text-xs text-muted-foreground tabular-nums">
-          {Math.round(gainToPercent(midiVolume))}%
+          {gainToDb(midiVolume).toFixed(1)} dB
         </span>
         <Toggle
           pressed={midiMuted}
@@ -85,7 +90,7 @@ export function Mixer() {
           />
         </div>
         <span className="text-xs text-muted-foreground tabular-nums">
-          {Math.round(gainToPercent(audioVolume))}%
+          {gainToDb(audioVolume).toFixed(1)} dB
         </span>
         <Toggle
           pressed={audioMuted}
@@ -126,7 +131,7 @@ export function Mixer() {
           />
         </div>
         <span className="text-xs text-muted-foreground tabular-nums">
-          {Math.round(gainToPercent(metronomeVolume))}%
+          {gainToDb(metronomeVolume).toFixed(1)} dB
         </span>
         <Toggle
           pressed={!metronomeEnabled}

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -1,5 +1,9 @@
 import { MusicIcon, Volume2Icon, VolumeXIcon } from "lucide-react";
+import { useDraftInput } from "../hooks/use-draft-input";
 import {
+  MAX_DB,
+  MIN_DB,
+  dbToGain,
   dbToPercent,
   gainToDb,
   gainToPercent,
@@ -26,6 +30,33 @@ export function Mixer() {
     setMetronomeEnabled,
   } = useProjectStore();
   const zeroDbPercent = dbToPercent(0);
+  const midiDbInput = useDraftInput({
+    value: gainToDb(midiVolume),
+    onCommit: (db) => setMidiVolume(dbToGain(db)),
+    min: MIN_DB,
+    max: MAX_DB,
+    step: 0.5,
+    parse: "float",
+    format: (value) => value.toFixed(1),
+  });
+  const audioDbInput = useDraftInput({
+    value: gainToDb(audioVolume),
+    onCommit: (db) => setAudioVolume(dbToGain(db)),
+    min: MIN_DB,
+    max: MAX_DB,
+    step: 0.5,
+    parse: "float",
+    format: (value) => value.toFixed(1),
+  });
+  const metronomeDbInput = useDraftInput({
+    value: gainToDb(metronomeVolume),
+    onCommit: (db) => setMetronomeVolume(dbToGain(db)),
+    min: MIN_DB,
+    max: MAX_DB,
+    step: 0.5,
+    parse: "float",
+    format: (value) => value.toFixed(1),
+  });
 
   return (
     <div className="flex justify-center gap-8 py-4">
@@ -49,9 +80,16 @@ export function Mixer() {
             className="h-48"
           />
         </div>
-        <span className="text-xs text-muted-foreground tabular-nums">
-          {gainToDb(midiVolume).toFixed(1)} dB
-        </span>
+        <div className="flex items-center gap-1 text-xs text-muted-foreground tabular-nums">
+          <input
+            type="text"
+            inputMode="decimal"
+            aria-label="MIDI level in dB"
+            className="w-12 h-6 px-1 text-xs font-mono bg-input border border-border rounded text-center text-foreground"
+            {...midiDbInput.props}
+          />
+          <span>dB</span>
+        </div>
         <Toggle
           pressed={midiMuted}
           onPressedChange={setMidiMuted}
@@ -89,9 +127,16 @@ export function Mixer() {
             className="h-48"
           />
         </div>
-        <span className="text-xs text-muted-foreground tabular-nums">
-          {gainToDb(audioVolume).toFixed(1)} dB
-        </span>
+        <div className="flex items-center gap-1 text-xs text-muted-foreground tabular-nums">
+          <input
+            type="text"
+            inputMode="decimal"
+            aria-label="Audio level in dB"
+            className="w-12 h-6 px-1 text-xs font-mono bg-input border border-border rounded text-center text-foreground"
+            {...audioDbInput.props}
+          />
+          <span>dB</span>
+        </div>
         <Toggle
           pressed={audioMuted}
           onPressedChange={setAudioMuted}
@@ -130,9 +175,17 @@ export function Mixer() {
             disabled={!metronomeEnabled}
           />
         </div>
-        <span className="text-xs text-muted-foreground tabular-nums">
-          {gainToDb(metronomeVolume).toFixed(1)} dB
-        </span>
+        <div className="flex items-center gap-1 text-xs text-muted-foreground tabular-nums">
+          <input
+            type="text"
+            inputMode="decimal"
+            aria-label="Metronome level in dB"
+            className="w-12 h-6 px-1 text-xs font-mono bg-input border border-border rounded text-center text-foreground"
+            {...metronomeDbInput.props}
+            disabled={!metronomeEnabled}
+          />
+          <span>dB</span>
+        </div>
         <Toggle
           pressed={!metronomeEnabled}
           onPressedChange={(muted) => setMetronomeEnabled(!muted)}

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -18,6 +18,7 @@ import {
   snapToGrid,
   clampPitch,
 } from "../lib/music";
+import { dbToPercent, gainToPercent, percentToGain } from "../lib/volume";
 import { historyStore } from "../stores/history-store";
 import {
   beatsToSeconds,
@@ -304,6 +305,7 @@ export function PianoRoll() {
   // Keep fractional values in state for smooth zoom, but render with whole pixels
   const roundedPixelsPerKey = Math.round(pixelsPerKey);
   const roundedPixelsPerBeat = Math.round(pixelsPerBeat);
+  const zeroDbPercent = dbToPercent(0);
 
   // Edge threshold for resize handles: 20% of grid cell, clamped to 6-20px
   const gridCellWidth = gridSnapValue * roundedPixelsPerBeat;
@@ -1038,12 +1040,18 @@ export function PianoRoll() {
                   M
                 </Toggle>
               </div>
-              <Slider
-                value={[audioVolume * 100]}
-                onValueChange={([v]) => setAudioVolume(v / 100)}
-                max={100}
-                step={1}
-              />
+              <div className="relative">
+                <div
+                  className="pointer-events-none absolute top-1/2 h-3 w-px -translate-y-1/2 bg-neutral-500/70"
+                  style={{ left: `${zeroDbPercent}%` }}
+                />
+                <Slider
+                  value={[gainToPercent(audioVolume)]}
+                  onValueChange={([v]) => setAudioVolume(percentToGain(v))}
+                  max={100}
+                  step={1}
+                />
+              </div>
             </div>
             {/* MIDI controls */}
             <div className="flex-1 px-2 pt-3">
@@ -1067,12 +1075,18 @@ export function PianoRoll() {
                   M
                 </Toggle>
               </div>
-              <Slider
-                value={[midiVolume * 100]}
-                onValueChange={([v]) => setMidiVolume(v / 100)}
-                max={100}
-                step={1}
-              />
+              <div className="relative">
+                <div
+                  className="pointer-events-none absolute top-1/2 h-3 w-px -translate-y-1/2 bg-neutral-500/70"
+                  style={{ left: `${zeroDbPercent}%` }}
+                />
+                <Slider
+                  value={[gainToPercent(midiVolume)]}
+                  onValueChange={([v]) => setMidiVolume(percentToGain(v))}
+                  max={100}
+                  step={1}
+                />
+              </div>
             </div>
           </div>
           <div

--- a/src/hooks/use-draft-input.ts
+++ b/src/hooks/use-draft-input.ts
@@ -6,6 +6,8 @@ type UseDraftInputOptions = {
   min?: number;
   max?: number;
   step?: number;
+  parse?: "int" | "float";
+  format?: (value: number) => string;
 };
 
 function clamp(value: number, min: number, max: number) {
@@ -35,23 +37,28 @@ export function useDraftInput({
   min = -Infinity,
   max = Infinity,
   step = 1,
+  parse = "int",
+  format = String,
 }: UseDraftInputOptions) {
-  const [draft, setDraft] = useState(String(value));
+  const [draft, setDraft] = useState(format(value));
 
   useEffect(() => {
-    setDraft(String(value));
-  }, [value]);
+    setDraft(format(value));
+  }, [format, value]);
+
+  const parseNumber = (text: string) =>
+    parse === "float" ? Number.parseFloat(text) : Number.parseInt(text, 10);
 
   const commit = () => {
-    const n = Number.parseInt(draft, 10);
+    const n = parseNumber(draft);
     if (!Number.isNaN(n)) {
       onCommit(clamp(n, min, max));
     } else {
-      setDraft(String(value)); // Reset on invalid input
+      setDraft(format(value)); // Reset on invalid input
     }
   };
 
-  const reset = () => setDraft(String(value));
+  const reset = () => setDraft(format(value));
 
   const increment = () => onCommit(clamp(value + step, min, max));
   const decrement = () => onCommit(clamp(value - step, min, max));

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -11,6 +11,7 @@ import {
   EMPTY_AUDIO_VIEW,
 } from "./audio-view";
 import { OxiSynthSynth } from "./oxisynth-synth";
+import { clampGain } from "./volume";
 
 // General MIDI Program Names (0-127)
 export const GM_PROGRAMS = [
@@ -344,23 +345,17 @@ class AudioManager {
     this.midiSynth.noteOff(pitch);
   }
 
-  // Volume controls (0-1)
+  // Volume controls (linear gain)
   setAudioVolume(volume: number): void {
-    this.audioChannel.volume.rampTo(
-      Tone.gainToDb(Math.max(0, Math.min(1, volume))),
-    );
+    this.audioChannel.volume.rampTo(Tone.gainToDb(clampGain(volume)));
   }
 
   setMidiVolume(volume: number): void {
-    this.midiChannel.volume.rampTo(
-      Tone.gainToDb(Math.max(0, Math.min(1, volume))),
-    );
+    this.midiChannel.volume.rampTo(Tone.gainToDb(clampGain(volume)));
   }
 
   setMetronomeVolume(volume: number): void {
-    this.metronomeChannel.volume.rampTo(
-      Tone.gainToDb(Math.max(0, Math.min(1, volume))),
-    );
+    this.metronomeChannel.volume.rampTo(Tone.gainToDb(clampGain(volume)));
   }
 
   setMetronomeEnabled(enabled: boolean): void {

--- a/src/lib/volume.test.ts
+++ b/src/lib/volume.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { dbToPercent, gainToPercent, percentToGain } from "./volume";
+
+describe("volume fader mapping", () => {
+  it("places unity gain near Ardour's fader position", () => {
+    const unityPercent = gainToPercent(1);
+    expect(unityPercent).toBeCloseTo(78.18, 2);
+    expect(dbToPercent(0)).toBeCloseTo(unityPercent, 5);
+  });
+
+  it("maps extremes to expected gain", () => {
+    expect(percentToGain(0)).toBeCloseTo(0, 6);
+    expect(percentToGain(100)).toBeCloseTo(2, 3);
+  });
+
+  it("round-trips percent through gain", () => {
+    const samples = [5, 25, 50, 75, 90];
+    for (const value of samples) {
+      const roundtrip = gainToPercent(percentToGain(value));
+      expect(roundtrip).toBeCloseTo(value, 3);
+    }
+  });
+});

--- a/src/lib/volume.ts
+++ b/src/lib/volume.ts
@@ -1,5 +1,7 @@
 const MIN_DB = -60;
 const MAX_DB = 6;
+const UNITY_DB = 0;
+const UNITY_PERCENT = 75;
 
 function dbToGain(db: number): number {
   return Math.pow(10, db / 20);
@@ -22,12 +24,22 @@ export function clampGain(gain: number): number {
 
 function percentToDb(percent: number): number {
   const clamped = clamp(percent, 0, 100);
-  return MIN_DB + (MAX_DB - MIN_DB) * (clamped / 100);
+  if (clamped <= UNITY_PERCENT) {
+    const t = clamped / UNITY_PERCENT;
+    return MIN_DB + (UNITY_DB - MIN_DB) * t;
+  }
+  const t = (clamped - UNITY_PERCENT) / (100 - UNITY_PERCENT);
+  return UNITY_DB + (MAX_DB - UNITY_DB) * t;
 }
 
 export function dbToPercent(db: number): number {
   const clamped = clamp(db, MIN_DB, MAX_DB);
-  return ((clamped - MIN_DB) / (MAX_DB - MIN_DB)) * 100;
+  if (clamped <= UNITY_DB) {
+    const t = (clamped - MIN_DB) / (UNITY_DB - MIN_DB);
+    return UNITY_PERCENT * t;
+  }
+  const t = (clamped - UNITY_DB) / (MAX_DB - UNITY_DB);
+  return UNITY_PERCENT + (100 - UNITY_PERCENT) * t;
 }
 
 export function percentToGain(percent: number): number {

--- a/src/lib/volume.ts
+++ b/src/lib/volume.ts
@@ -6,6 +6,11 @@ function dbToGain(db: number): number {
   return Math.pow(10, db / 20);
 }
 
+export function gainToDb(gain: number): number {
+  if (gain <= 0) return MIN_DB;
+  return 20 * Math.log10(gain);
+}
+
 const MAX_GAIN = dbToGain(MAX_DB);
 
 function clamp(value: number, min: number, max: number): number {

--- a/src/lib/volume.ts
+++ b/src/lib/volume.ts
@@ -1,0 +1,39 @@
+const MIN_DB = -60;
+const MAX_DB = 6;
+
+function dbToGain(db: number): number {
+  return Math.pow(10, db / 20);
+}
+
+function gainToDb(gain: number): number {
+  if (gain <= 0) return MIN_DB;
+  return 20 * Math.log10(gain);
+}
+
+const MAX_GAIN = dbToGain(MAX_DB);
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function clampGain(gain: number): number {
+  return clamp(gain, 0, MAX_GAIN);
+}
+
+function percentToDb(percent: number): number {
+  const clamped = clamp(percent, 0, 100);
+  return MIN_DB + (MAX_DB - MIN_DB) * (clamped / 100);
+}
+
+export function dbToPercent(db: number): number {
+  const clamped = clamp(db, MIN_DB, MAX_DB);
+  return ((clamped - MIN_DB) / (MAX_DB - MIN_DB)) * 100;
+}
+
+export function percentToGain(percent: number): number {
+  return dbToGain(percentToDb(percent));
+}
+
+export function gainToPercent(gain: number): number {
+  return dbToPercent(gainToDb(gain));
+}

--- a/src/lib/volume.ts
+++ b/src/lib/volume.ts
@@ -1,15 +1,9 @@
 const MIN_DB = -60;
 const MAX_DB = 6;
-const UNITY_DB = 0;
-const UNITY_PERCENT = 75;
+const LOG2 = Math.log(2);
 
 function dbToGain(db: number): number {
   return Math.pow(10, db / 20);
-}
-
-function gainToDb(gain: number): number {
-  if (gain <= 0) return MIN_DB;
-  return 20 * Math.log10(gain);
 }
 
 const MAX_GAIN = dbToGain(MAX_DB);
@@ -22,30 +16,19 @@ export function clampGain(gain: number): number {
   return clamp(gain, 0, MAX_GAIN);
 }
 
-function percentToDb(percent: number): number {
-  const clamped = clamp(percent, 0, 100);
-  if (clamped <= UNITY_PERCENT) {
-    const t = clamped / UNITY_PERCENT;
-    return MIN_DB + (UNITY_DB - MIN_DB) * t;
-  }
-  const t = (clamped - UNITY_PERCENT) / (100 - UNITY_PERCENT);
-  return UNITY_DB + (MAX_DB - UNITY_DB) * t;
+export function percentToGain(percent: number): number {
+  const position = clamp(percent / 100, 0, 1);
+  if (position === 0) return 0;
+  return Math.exp(((Math.pow(position, 1 / 8) * 198 - 192) / 6) * LOG2);
+}
+
+export function gainToPercent(gain: number): number {
+  if (gain <= 0) return 0;
+  const position = Math.pow(((6 * Math.log(gain)) / LOG2 + 192) / 198, 8);
+  return clamp(position * 100, 0, 100);
 }
 
 export function dbToPercent(db: number): number {
   const clamped = clamp(db, MIN_DB, MAX_DB);
-  if (clamped <= UNITY_DB) {
-    const t = (clamped - MIN_DB) / (UNITY_DB - MIN_DB);
-    return UNITY_PERCENT * t;
-  }
-  const t = (clamped - UNITY_DB) / (MAX_DB - UNITY_DB);
-  return UNITY_PERCENT + (100 - UNITY_PERCENT) * t;
-}
-
-export function percentToGain(percent: number): number {
-  return dbToGain(percentToDb(percent));
-}
-
-export function gainToPercent(gain: number): number {
-  return dbToPercent(gainToDb(gain));
+  return gainToPercent(dbToGain(clamped));
 }

--- a/src/lib/volume.ts
+++ b/src/lib/volume.ts
@@ -1,8 +1,8 @@
-const MIN_DB = -60;
-const MAX_DB = 6;
+export const MIN_DB = -60;
+export const MAX_DB = 6;
 const LOG2 = Math.log(2);
 
-function dbToGain(db: number): number {
+export function dbToGain(db: number): number {
   return Math.pow(10, db / 20);
 }
 


### PR DESCRIPTION
## Summary
- map audio/midi/metronome faders to a -60dB to +6dB scale with 0dB markers
- allow gain above unity while clamping to +6dB
- add shared volume conversion helpers

## Testing
- pnpm lint
- pnpm test-e2e