### PR TITLE
fix: fix export filenames to match project name

### DIFF
--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -17,6 +17,7 @@ import {
 } from "../lib/abc-export";
 import { deleteAsset, saveAsset } from "../lib/asset-store";
 import { audioManager, loadAudioFile } from "../lib/audio";
+import { buildExportFileName } from "../lib/export-utils";
 import { downloadMidiFile, exportMidi } from "../lib/midi-export";
 import { importMidiNotes, type MidiImportOptions } from "../lib/midi-import";
 import { downloadProjectFile, exportProjectFile } from "../lib/project-file";
@@ -162,14 +163,10 @@ export function Settings({
         : "Piano Roll",
     });
 
-    // Generate filename with timestamp
-    const now = new Date();
-    const timestamp = now
-      .toISOString()
-      .replace(/[T:]/g, "-")
-      .replace(/\.\d+Z$/, "");
-    const safeName = projectName.replace(/[^a-zA-Z0-9-_]/g, "_");
-    const fileName = `${safeName}-${timestamp}.mid`;
+    const fileName = buildExportFileName({
+      baseName: projectName,
+      extension: ".mid",
+    });
 
     downloadMidiFile(midiData, fileName);
   };
@@ -182,14 +179,10 @@ export function Settings({
       title: audioFileName ? audioFileName.replace(/\.[^.]+$/, "") : "Untitled",
     });
 
-    // Generate filename with timestamp
-    const now = new Date();
-    const timestamp = now
-      .toISOString()
-      .replace(/[T:]/g, "-")
-      .replace(/\.\d+Z$/, "");
-    const safeName = projectName.replace(/[^a-zA-Z0-9-_]/g, "_");
-    const fileName = `${safeName}-${timestamp}.abc`;
+    const fileName = buildExportFileName({
+      baseName: projectName,
+      extension: ".abc",
+    });
 
     downloadABCFile(abcText, fileName);
   };

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -168,7 +168,8 @@ export function Settings({
       .toISOString()
       .replace(/[T:]/g, "-")
       .replace(/\.\d+Z$/, "");
-    const fileName = `toy-midi-export-${timestamp}.mid`;
+    const safeName = projectName.replace(/[^a-zA-Z0-9-_]/g, "_");
+    const fileName = `${safeName}-${timestamp}.mid`;
 
     downloadMidiFile(midiData, fileName);
   };
@@ -187,7 +188,8 @@ export function Settings({
       .toISOString()
       .replace(/[T:]/g, "-")
       .replace(/\.\d+Z$/, "");
-    const fileName = `toy-midi-export-${timestamp}.abc`;
+    const safeName = projectName.replace(/[^a-zA-Z0-9-_]/g, "_");
+    const fileName = `${safeName}-${timestamp}.abc`;
 
     downloadABCFile(abcText, fileName);
   };

--- a/src/lib/export-utils.ts
+++ b/src/lib/export-utils.ts
@@ -1,0 +1,35 @@
+type ExportFileNameOptions = {
+  baseName: string;
+  extension: string;
+  timestamp?: Date;
+};
+
+function formatTimestamp(timestamp: Date): string {
+  return timestamp
+    .toISOString()
+    .replace(/[T:]/g, "-")
+    .replace(/\.\d+Z$/, "");
+}
+
+function normalizeExtension(extension: string): string {
+  const trimmed = extension.trim().toLowerCase();
+  if (!trimmed) return "";
+  return trimmed.startsWith(".") ? trimmed : `.${trimmed}`;
+}
+
+function sanitizeBaseName(baseName: string): string {
+  const trimmed = baseName.trim();
+  if (!trimmed) return "toy-midi-export";
+  return trimmed.replace(/[^a-zA-Z0-9-_]/g, "_");
+}
+
+export function buildExportFileName({
+  baseName,
+  extension,
+  timestamp = new Date(),
+}: ExportFileNameOptions): string {
+  const safeName = sanitizeBaseName(baseName);
+  const normalizedExtension = normalizeExtension(extension);
+  const formattedTimestamp = formatTimestamp(timestamp);
+  return `${safeName}-${formattedTimestamp}${normalizedExtension}`;
+}

--- a/src/lib/project-file.ts
+++ b/src/lib/project-file.ts
@@ -3,6 +3,7 @@
 import JSZip from "jszip";
 import type { SavedProject } from "../stores/project-store";
 import { loadAsset, saveAsset } from "./asset-store";
+import { buildExportFileName } from "./export-utils";
 
 // Manifest schema for .toymidi files
 export interface ProjectManifest {
@@ -71,12 +72,10 @@ export async function exportProjectFile(
  * Download a .toymidi file
  */
 export function downloadProjectFile(blob: Blob, projectName: string): void {
-  const timestamp = new Date()
-    .toISOString()
-    .replace(/[T:]/g, "-")
-    .replace(/\.\d+Z$/, "");
-  const safeName = projectName.replace(/[^a-zA-Z0-9-_]/g, "_");
-  const fileName = `${safeName}-${timestamp}.toymidi`;
+  const fileName = buildExportFileName({
+    baseName: projectName,
+    extension: ".toymidi",
+  });
 
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");


### PR DESCRIPTION
## Summary
- use sanitized project name + timestamp for MIDI/ABC export filenames
- keep MIDI/ABC naming aligned with project export convention