### PR TITLE
feat: show project name in transport header

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -186,6 +186,7 @@ function Editor({ projectId }: EditorProps) {
         onSettingsClick={() => setIsSettingsOpen(true)}
         onHelpClick={() => setIsHelpOpen(true)}
         onMixerClick={() => setIsMixerOpen(true)}
+        projectName={projectName}
       />
       <PianoRoll />
       <HelpOverlay isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} />

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -192,12 +192,14 @@ type TransportProps = {
   onSettingsClick: () => void;
   onHelpClick: () => void;
   onMixerClick: () => void;
+  projectName: string;
 };
 
 export function Transport({
   onSettingsClick,
   onHelpClick,
   onMixerClick,
+  projectName,
 }: TransportProps) {
   const {
     tempo,
@@ -419,14 +421,22 @@ export function Transport({
         </DropdownMenuContent>
       </DropdownMenu>
 
-      {/* Divider */}
-      <div className="w-px h-5 bg-border" />
-
       {/* Instrument selector */}
       <InstrumentCombobox value={midiProgram} onValueChange={setMidiProgram} />
 
       {/* Spacer */}
       <div className="flex-1" />
+
+      <div
+        data-testid="project-name-header"
+        title={projectName}
+        className="text-sm text-neutral-300 truncate max-w-[220px]"
+      >
+        {projectName}
+      </div>
+
+      {/* Divider */}
+      <div className="w-px h-5 bg-border" />
 
       {/* Settings button */}
       <Button

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -421,6 +421,9 @@ export function Transport({
         </DropdownMenuContent>
       </DropdownMenu>
 
+      {/* Divider */}
+      <div className="w-px h-5 bg-border" />
+
       {/* Instrument selector */}
       <InstrumentCombobox value={midiProgram} onValueChange={setMidiProgram} />
 


### PR DESCRIPTION
## Summary
- display current project name in the right side of the transport header
- keep long names truncated with a tooltip for full text