### PR TITLE
fix: guard plain shortcuts against modifiers

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -12,6 +12,7 @@ import { useDraftTextInput } from "./hooks/use-draft-text-input";
 import { useWindowEvent } from "./hooks/use-window-event";
 import { loadAsset } from "./lib/asset-store";
 import { audioManager, loadAudioFile } from "./lib/audio";
+import { matchKeyboardEvent } from "./lib/keyboard";
 import { importProjectAudio, parseProjectFile } from "./lib/project-file";
 import {
   createProject,
@@ -111,7 +112,7 @@ export function App() {
       ) {
         return;
       }
-      if (e.key === " ") {
+      if (matchKeyboardEvent(e, "Space")) {
         e.preventDefault();
         e.stopPropagation();
         const lastProjectId = getLastProjectId();
@@ -162,7 +163,7 @@ function Editor({ projectId }: EditorProps) {
   useWindowEvent(
     "keydown",
     (e) => {
-      if (e.key !== "Escape") return;
+      if (!matchKeyboardEvent(e, "Escape")) return;
       if (isSettingsOpen) {
         e.preventDefault();
         e.stopPropagation();
@@ -252,7 +253,7 @@ function ProjectRenameInput({
   });
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Escape") {
+    if (matchKeyboardEvent(e, "Escape")) {
       e.preventDefault();
       e.stopPropagation();
       isCancelingRef.current = true;

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -10,6 +10,7 @@ import { useTransport } from "../hooks/use-transport";
 import { useWindowEvent } from "../hooks/use-window-event";
 import { audioManager } from "../lib/audio";
 import { type AudioView, queryAudioView } from "../lib/audio-view";
+import { matchKeyboardEvent } from "../lib/keyboard";
 import {
   isBlackKey,
   MAX_PITCH,
@@ -429,7 +430,7 @@ export function PianoRoll() {
       if (canUndo()) {
         undo();
       }
-    } else if (e.key === "l" || e.key === "L") {
+    } else if (matchKeyboardEvent(e, "L")) {
       // L: Add locator at current playhead position
       const playheadBeat = secondsToBeats(position, tempo);
       const snappedBeat = snapToGrid(playheadBeat, gridSnapValue);

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -390,7 +390,7 @@ export function PianoRoll() {
       return;
     }
 
-    if (e.key === "Delete" || e.key === "Backspace") {
+    if (matchKeyboardEvent(e, "Delete") || matchKeyboardEvent(e, "Backspace")) {
       if (selectedNoteIds.size > 0) {
         deleteNotes(Array.from(selectedNoteIds));
       } else if (selectedLocatorId) {
@@ -398,34 +398,34 @@ export function PianoRoll() {
       } else if (isAudioTrackSelected) {
         clearAudioFile();
       }
-    } else if (e.key === "Escape") {
+    } else if (matchKeyboardEvent(e, "Escape")) {
       deselectAll();
       selectLocator(null);
       setAudioTrackSelected(false);
-    } else if (e.key === "c" && (e.ctrlKey || e.metaKey)) {
-      // Ctrl+C or Cmd+C: Copy
+    } else if (matchKeyboardEvent(e, "Ctrl+C")) {
+      // Ctrl+C: Copy
       e.preventDefault();
       copyNotes();
-    } else if (e.key === "v" && (e.ctrlKey || e.metaKey)) {
-      // Ctrl+V or Cmd+V: Paste at snapped playhead position
+    } else if (matchKeyboardEvent(e, "Ctrl+V")) {
+      // Ctrl+V: Paste at snapped playhead position
       e.preventDefault();
       const playheadBeat = secondsToBeats(position, tempo);
       const snappedBeat = snapToGrid(playheadBeat, gridSnapValue);
       pasteNotes(snappedBeat);
-    } else if (e.key === "z" && (e.ctrlKey || e.metaKey) && e.shiftKey) {
-      // Ctrl+Shift+Z or Cmd+Shift+Z: Redo
+    } else if (matchKeyboardEvent(e, "Ctrl+Shift+Z")) {
+      // Ctrl+Shift+Z: Redo
       e.preventDefault();
       if (canRedo()) {
         redo();
       }
-    } else if (e.key === "y" && (e.ctrlKey || e.metaKey)) {
-      // Ctrl+Y or Cmd+Y: Redo (alternative)
+    } else if (matchKeyboardEvent(e, "Ctrl+Y")) {
+      // Ctrl+Y: Redo (alternative)
       e.preventDefault();
       if (canRedo()) {
         redo();
       }
-    } else if (e.key === "z" && (e.ctrlKey || e.metaKey) && !e.shiftKey) {
-      // Ctrl+Z or Cmd+Z: Undo
+    } else if (matchKeyboardEvent(e, "Ctrl+Z")) {
+      // Ctrl+Z: Undo
       e.preventDefault();
       if (canUndo()) {
         undo();

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -13,6 +13,7 @@ import { useDraftInput } from "../hooks/use-draft-input";
 import { useTransport } from "../hooks/use-transport";
 import { useWindowEvent } from "../hooks/use-window-event";
 import { audioManager, GM_PROGRAMS } from "../lib/audio";
+import { matchKeyboardEvent } from "../lib/keyboard";
 import { useProjectStore } from "../stores/project-store";
 import { COMMON_TIME_SIGNATURES, type GridSnap } from "../types";
 import { MetronomeIcon } from "./icons";
@@ -237,13 +238,7 @@ export function Transport({
     ) {
       return;
     }
-    if (
-      e.code === "KeyM" &&
-      !e.ctrlKey &&
-      !e.metaKey &&
-      !e.altKey &&
-      !e.repeat
-    ) {
+    if (matchKeyboardEvent(e, "M") && !e.repeat) {
       e.preventDefault();
       setMetronomeEnabled(!metronomeEnabled);
     }

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -83,7 +83,7 @@ function PlayPauseButton() {
     ) {
       return;
     }
-    if (e.code === "Space" && !e.repeat) {
+    if (matchKeyboardEvent(e, "Space") && !e.repeat) {
       e.preventDefault();
       togglePlayback();
     }
@@ -242,29 +242,17 @@ export function Transport({
       e.preventDefault();
       setMetronomeEnabled(!metronomeEnabled);
     }
-    if (e.code === "KeyF" && (e.ctrlKey || e.metaKey) && !e.repeat) {
+    if (matchKeyboardEvent(e, "Ctrl+F") && !e.repeat) {
       e.preventDefault();
       setAutoScrollEnabled(!autoScrollEnabled);
     }
     // Shift+1 - Toggle MIDI mute
-    if (
-      e.code === "Digit1" &&
-      e.shiftKey &&
-      !e.ctrlKey &&
-      !e.metaKey &&
-      !e.repeat
-    ) {
+    if (matchKeyboardEvent(e, "Shift+1") && !e.repeat) {
       e.preventDefault();
       setMidiMuted(!midiMuted);
     }
     // Shift+2 - Toggle audio mute
-    if (
-      e.code === "Digit2" &&
-      e.shiftKey &&
-      !e.ctrlKey &&
-      !e.metaKey &&
-      !e.repeat
-    ) {
+    if (matchKeyboardEvent(e, "Shift+2") && !e.repeat) {
       e.preventDefault();
       setAudioMuted(!audioMuted);
     }

--- a/src/hooks/use-draft-input.ts
+++ b/src/hooks/use-draft-input.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { matchKeyboardEvent } from "../lib/keyboard";
 
 type UseDraftInputOptions = {
   value: number;
@@ -75,16 +76,16 @@ export function useDraftInput({
       onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
         setDraft(e.target.value),
       onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === "Enter") {
+        if (matchKeyboardEvent(e, "Enter")) {
           commit();
           e.currentTarget.blur();
-        } else if (e.key === "Escape") {
+        } else if (matchKeyboardEvent(e, "Escape")) {
           reset();
           e.currentTarget.blur();
-        } else if (e.key === "ArrowUp") {
+        } else if (matchKeyboardEvent(e, "ArrowUp")) {
           e.preventDefault();
           increment();
-        } else if (e.key === "ArrowDown") {
+        } else if (matchKeyboardEvent(e, "ArrowDown")) {
           e.preventDefault();
           decrement();
         }

--- a/src/hooks/use-draft-text-input.ts
+++ b/src/hooks/use-draft-text-input.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { matchKeyboardEvent } from "../lib/keyboard";
 
 type UseDraftTextInputOptions = {
   value: string;
@@ -46,10 +47,10 @@ export function useDraftTextInput({
       onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
         setDraft(e.target.value),
       onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === "Enter") {
+        if (matchKeyboardEvent(e, "Enter")) {
           commit();
           e.currentTarget.blur();
-        } else if (e.key === "Escape") {
+        } else if (matchKeyboardEvent(e, "Escape")) {
           reset();
           e.currentTarget.blur();
         }

--- a/src/lib/keybindings.ts
+++ b/src/lib/keybindings.ts
@@ -54,12 +54,12 @@ export const KEYBOARD_SHORTCUTS: KeyBinding[] = [
   },
   {
     key: "Ctrl+C",
-    description: "Copy selected notes (Cmd+C on Mac)",
+    description: "Copy selected notes",
     category: "editing",
   },
   {
     key: "Ctrl+V",
-    description: "Paste notes (Cmd+V on Mac)",
+    description: "Paste notes",
     category: "editing",
   },
   {

--- a/src/lib/keyboard.test.ts
+++ b/src/lib/keyboard.test.ts
@@ -44,6 +44,42 @@ describe("parseShortcut", () => {
     `);
   });
 
+  it("parses special keys", () => {
+    expect(parseShortcut("Enter")).toMatchInlineSnapshot(`
+      {
+        "code": "Enter",
+        "key": "Enter",
+        "modifiers": {
+          "alt": false,
+          "ctrl": false,
+          "shift": false,
+        },
+      }
+    `);
+    expect(parseShortcut("ArrowUp")).toMatchInlineSnapshot(`
+      {
+        "code": "ArrowUp",
+        "key": "ArrowUp",
+        "modifiers": {
+          "alt": false,
+          "ctrl": false,
+          "shift": false,
+        },
+      }
+    `);
+    expect(parseShortcut("ArrowDown")).toMatchInlineSnapshot(`
+      {
+        "code": "ArrowDown",
+        "key": "ArrowDown",
+        "modifiers": {
+          "alt": false,
+          "ctrl": false,
+          "shift": false,
+        },
+      }
+    `);
+  });
+
   it("rejects unsupported modifiers", () => {
     expect(() => parseShortcut("Cmd+L")).toThrowError(
       "Unsupported shortcut token: L",

--- a/src/lib/keyboard.test.ts
+++ b/src/lib/keyboard.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { parseShortcut } from "./keyboard";
+
+describe("parseShortcut", () => {
+  it("parses plain letter shortcuts without modifiers", () => {
+    const parsed = parseShortcut("L");
+    expect(parsed).toMatchInlineSnapshot(`
+      {
+        "code": "KeyL",
+        "modifiers": {
+          "alt": false,
+          "ctrl": false,
+          "shift": false,
+        },
+      }
+    `);
+  });
+
+  it("parses ctrl combos", () => {
+    const parsed = parseShortcut("Ctrl+F");
+    expect(parsed).toMatchInlineSnapshot(`
+      {
+        "code": "KeyF",
+        "modifiers": {
+          "alt": false,
+          "ctrl": true,
+          "shift": false,
+        },
+      }
+    `);
+  });
+
+  it("parses digit shortcuts", () => {
+    const parsed = parseShortcut("Shift+1");
+    expect(parsed).toMatchInlineSnapshot(`
+      {
+        "code": "Digit1",
+        "modifiers": {
+          "alt": false,
+          "ctrl": false,
+          "shift": true,
+        },
+      }
+    `);
+  });
+
+  it("rejects unsupported modifiers", () => {
+    expect(() => parseShortcut("Cmd+L")).toThrowErrorMatchingInlineSnapshot(
+      '"Unsupported shortcut token: Cmd"',
+    );
+  });
+});

--- a/src/lib/keyboard.test.ts
+++ b/src/lib/keyboard.test.ts
@@ -45,8 +45,20 @@ describe("parseShortcut", () => {
   });
 
   it("rejects unsupported modifiers", () => {
-    expect(() => parseShortcut("Cmd+L")).toThrowErrorMatchingInlineSnapshot(
-      '"Unsupported shortcut token: Cmd"',
+    expect(() => parseShortcut("Cmd+L")).toThrowError(
+      "Unsupported shortcut token: L",
+    );
+  });
+
+  it("rejects alias tokens", () => {
+    expect(() => parseShortcut("Esc")).toThrowError(
+      "Unsupported shortcut token: Esc",
+    );
+    expect(() => parseShortcut("Del")).toThrowError(
+      "Unsupported shortcut token: Del",
+    );
+    expect(() => parseShortcut("Bs")).toThrowError(
+      "Unsupported shortcut token: Bs",
     );
   });
 });

--- a/src/lib/keyboard.test.ts
+++ b/src/lib/keyboard.test.ts
@@ -80,21 +80,18 @@ describe("parseShortcut", () => {
     `);
   });
 
-  it("rejects unsupported modifiers", () => {
-    expect(() => parseShortcut("Cmd+L")).toThrowError(
-      "Unsupported shortcut token: L",
+  it("invalid", () => {
+    expect(() => parseShortcut("Cmd+L")).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Invalid shortcut 'Cmd+L']`,
     );
-  });
-
-  it("rejects alias tokens", () => {
-    expect(() => parseShortcut("Esc")).toThrowError(
-      "Unsupported shortcut token: Esc",
+    expect(() => parseShortcut("Esc")).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Invalid shortcut 'Esc']`,
     );
-    expect(() => parseShortcut("Del")).toThrowError(
-      "Unsupported shortcut token: Del",
+    expect(() => parseShortcut("Del")).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Invalid shortcut 'Del']`,
     );
-    expect(() => parseShortcut("Bs")).toThrowError(
-      "Unsupported shortcut token: Bs",
+    expect(() => parseShortcut("Bs")).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Invalid shortcut 'Bs']`,
     );
   });
 });

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -26,17 +26,17 @@ function normalizeKeyToken(token: string): { code?: string; key?: string } {
   if (lower === "space") {
     return { code: "Space", key: " " };
   }
-  if (lower === "escape" || lower === "esc") {
+  if (lower === "escape") {
     return { code: "Escape", key: "Escape" };
   }
-  if (lower === "delete" || lower === "del") {
+  if (lower === "delete") {
     return { code: "Delete", key: "Delete" };
   }
-  if (lower === "backspace" || lower === "bs") {
+  if (lower === "backspace") {
     return { code: "Backspace", key: "Backspace" };
   }
 
-  return { key: token };
+  throw new Error(`Unsupported shortcut token: ${token}`);
 }
 
 export function parseShortcut(shortcut: string): ParsedShortcut {

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -8,6 +8,15 @@ type ParsedShortcut = {
   };
 };
 
+type KeyboardLikeEvent = {
+  key: string;
+  code: string;
+  shiftKey: boolean;
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+};
+
 function normalizeKeyToken(token: string): { code?: string; key?: string } {
   if (!token) {
     return {};
@@ -28,6 +37,15 @@ function normalizeKeyToken(token: string): { code?: string; key?: string } {
   }
   if (lower === "escape") {
     return { code: "Escape", key: "Escape" };
+  }
+  if (lower === "enter") {
+    return { code: "Enter", key: "Enter" };
+  }
+  if (lower === "arrowup") {
+    return { code: "ArrowUp", key: "ArrowUp" };
+  }
+  if (lower === "arrowdown") {
+    return { code: "ArrowDown", key: "ArrowDown" };
   }
   if (lower === "delete") {
     return { code: "Delete", key: "Delete" };
@@ -84,7 +102,7 @@ export function parseShortcut(shortcut: string): ParsedShortcut {
 }
 
 export function matchKeyboardEvent(
-  e: KeyboardEvent,
+  e: KeyboardLikeEvent,
   shortcut: string,
 ): boolean {
   const parsed = parseShortcut(shortcut);

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -1,0 +1,123 @@
+type ParsedShortcut = {
+  code?: string;
+  key?: string;
+  modifiers: {
+    shift: boolean;
+    alt: boolean;
+    ctrl: boolean;
+    meta: boolean;
+    ctrlOrMeta: boolean;
+  };
+};
+
+function normalizeKeyToken(token: string): { code?: string; key?: string } {
+  if (!token) {
+    return {};
+  }
+  if (token.length === 1) {
+    const char = token.toUpperCase();
+    if (char >= "A" && char <= "Z") {
+      return { code: `Key${char}` };
+    }
+    if (char >= "0" && char <= "9") {
+      return { code: `Digit${char}` };
+    }
+  }
+
+  const lower = token.toLowerCase();
+  if (lower === "space") {
+    return { code: "Space", key: " " };
+  }
+  if (lower === "escape" || lower === "esc") {
+    return { code: "Escape", key: "Escape" };
+  }
+  if (lower === "delete" || lower === "del") {
+    return { code: "Delete", key: "Delete" };
+  }
+  if (lower === "backspace" || lower === "bs") {
+    return { code: "Backspace", key: "Backspace" };
+  }
+
+  return { key: token };
+}
+
+function parseShortcut(shortcut: string): ParsedShortcut {
+  const modifiers = {
+    shift: false,
+    alt: false,
+    ctrl: false,
+    meta: false,
+    ctrlOrMeta: false,
+  };
+  let keyToken = "";
+
+  const tokens = shortcut
+    .split("+")
+    .map((token) => token.trim())
+    .filter(Boolean);
+
+  for (const token of tokens) {
+    const lower = token.toLowerCase();
+    if (lower === "shift") {
+      modifiers.shift = true;
+      continue;
+    }
+    if (lower === "alt" || lower === "option") {
+      modifiers.alt = true;
+      continue;
+    }
+    if (lower === "ctrl" || lower === "control") {
+      modifiers.ctrlOrMeta = true;
+      continue;
+    }
+    if (lower === "cmd" || lower === "command" || lower === "meta") {
+      modifiers.meta = true;
+      continue;
+    }
+    keyToken = token;
+  }
+
+  return {
+    ...normalizeKeyToken(keyToken),
+    modifiers,
+  };
+}
+
+export function matchKeyboardEvent(
+  e: KeyboardEvent,
+  shortcut: string,
+): boolean {
+  const parsed = parseShortcut(shortcut);
+  if (!parsed.code && !parsed.key) {
+    return false;
+  }
+
+  if (parsed.modifiers.ctrlOrMeta) {
+    if (!e.ctrlKey && !e.metaKey) {
+      return false;
+    }
+  } else {
+    if (e.ctrlKey !== parsed.modifiers.ctrl) {
+      return false;
+    }
+    if (e.metaKey !== parsed.modifiers.meta) {
+      return false;
+    }
+  }
+
+  if (e.shiftKey !== parsed.modifiers.shift) {
+    return false;
+  }
+  if (e.altKey !== parsed.modifiers.alt) {
+    return false;
+  }
+
+  if (parsed.code) {
+    return e.code === parsed.code;
+  }
+  if (parsed.key) {
+    return e.key.toLowerCase() === parsed.key.toLowerCase();
+  }
+
+  return false;
+}

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -17,45 +17,22 @@ type KeyboardLikeEvent = {
   metaKey: boolean;
 };
 
-function normalizeKeyToken(token: string): { code?: string; key?: string } {
-  if (!token) {
-    return {};
-  }
-  if (token.length === 1) {
-    const char = token.toUpperCase();
-    if (char >= "A" && char <= "Z") {
-      return { code: `Key${char}` };
-    }
-    if (char >= "0" && char <= "9") {
-      return { code: `Digit${char}` };
-    }
-  }
+const SPECIAL_KEYS: Record<string, { code: string; key: string }> = {
+  Space: { code: "Space", key: " " },
+  Escape: { code: "Escape", key: "Escape" },
+  Enter: { code: "Enter", key: "Enter" },
+  ArrowUp: { code: "ArrowUp", key: "ArrowUp" },
+  ArrowDown: { code: "ArrowDown", key: "ArrowDown" },
+  Delete: { code: "Delete", key: "Delete" },
+  Backspace: { code: "Backspace", key: "Backspace" },
+};
 
-  const lower = token.toLowerCase();
-  if (lower === "space") {
-    return { code: "Space", key: " " };
-  }
-  if (lower === "escape") {
-    return { code: "Escape", key: "Escape" };
-  }
-  if (lower === "enter") {
-    return { code: "Enter", key: "Enter" };
-  }
-  if (lower === "arrowup") {
-    return { code: "ArrowUp", key: "ArrowUp" };
-  }
-  if (lower === "arrowdown") {
-    return { code: "ArrowDown", key: "ArrowDown" };
-  }
-  if (lower === "delete") {
-    return { code: "Delete", key: "Delete" };
-  }
-  if (lower === "backspace") {
-    return { code: "Backspace", key: "Backspace" };
-  }
-
-  throw new Error(`Unsupported shortcut token: ${token}`);
-}
+const CHAR_KEYS: Record<string, { code: string }> = Object.fromEntries([
+  ..."ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    .split("")
+    .map((char) => [char, { code: `Key${char}` }]),
+  ..."0123456789".split("").map((char) => [char, { code: `Digit${char}` }]),
+]);
 
 export function parseShortcut(shortcut: string): ParsedShortcut {
   const modifiers = {
@@ -88,15 +65,16 @@ export function parseShortcut(shortcut: string): ParsedShortcut {
       keyToken = token;
       continue;
     }
-    throw new Error(`Unsupported shortcut token: ${token}`);
+    throw new Error(`Invalid shortcut '${shortcut}'`);
   }
 
-  if (!keyToken) {
-    throw new Error("Shortcut must include key");
+  const match = CHAR_KEYS[keyToken.toUpperCase()] || SPECIAL_KEYS[keyToken];
+  if (!match) {
+    throw new Error(`Invalid shortcut '${shortcut}'`);
   }
 
   return {
-    ...normalizeKeyToken(keyToken),
+    ...match,
     modifiers,
   };
 }

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -5,8 +5,6 @@ type ParsedShortcut = {
     shift: boolean;
     alt: boolean;
     ctrl: boolean;
-    meta: boolean;
-    ctrlOrMeta: boolean;
   };
 };
 
@@ -41,13 +39,11 @@ function normalizeKeyToken(token: string): { code?: string; key?: string } {
   return { key: token };
 }
 
-function parseShortcut(shortcut: string): ParsedShortcut {
+export function parseShortcut(shortcut: string): ParsedShortcut {
   const modifiers = {
     shift: false,
     alt: false,
     ctrl: false,
-    meta: false,
-    ctrlOrMeta: false,
   };
   let keyToken = "";
 
@@ -62,19 +58,23 @@ function parseShortcut(shortcut: string): ParsedShortcut {
       modifiers.shift = true;
       continue;
     }
-    if (lower === "alt" || lower === "option") {
+    if (lower === "alt") {
       modifiers.alt = true;
       continue;
     }
-    if (lower === "ctrl" || lower === "control") {
-      modifiers.ctrlOrMeta = true;
+    if (lower === "ctrl") {
+      modifiers.ctrl = true;
       continue;
     }
-    if (lower === "cmd" || lower === "command" || lower === "meta") {
-      modifiers.meta = true;
+    if (!keyToken) {
+      keyToken = token;
       continue;
     }
-    keyToken = token;
+    throw new Error(`Unsupported shortcut token: ${token}`);
+  }
+
+  if (!keyToken) {
+    throw new Error("Shortcut must include key");
   }
 
   return {
@@ -92,19 +92,12 @@ export function matchKeyboardEvent(
     return false;
   }
 
-  if (parsed.modifiers.ctrlOrMeta) {
-    if (!e.ctrlKey && !e.metaKey) {
-      return false;
-    }
-  } else {
-    if (e.ctrlKey !== parsed.modifiers.ctrl) {
-      return false;
-    }
-    if (e.metaKey !== parsed.modifiers.meta) {
-      return false;
-    }
+  if (e.metaKey) {
+    return false;
   }
-
+  if (e.ctrlKey !== parsed.modifiers.ctrl) {
+    return false;
+  }
   if (e.shiftKey !== parsed.modifiers.shift) {
     return false;
   }


### PR DESCRIPTION
## Summary
- add keyboard shortcut matcher for strict modifier handling
- apply matcher to L locator and M metronome shortcuts to avoid modifier collisions

## Testing
- pnpm lint