### PR TITLE
refactor: simplify `Button`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@radix-ui/react-slider": "^1.3.6",
     "@tanstack/react-query": "^5.90.16",
     "@tonejs/midi": "^2.0.28",
-    "class-variance-authority": "^0.7.1",
     "cmdk": "^1.1.1",
     "jszip": "^3.10.1",
     "lucide-react": "^0.562.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       '@tonejs/midi':
         specifier: ^2.0.28
         version: 2.0.28
-      class-variance-authority:
-        specifier: ^0.7.1
-        version: 0.7.1
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1474,13 +1471,6 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
-
-  class-variance-authority@0.7.1:
-    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
-
-  clsx@2.1.1:
-    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
-    engines: {node: '>=6'}
 
   cmdk@1.1.1:
     resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
@@ -3145,12 +3135,6 @@ snapshots:
   caniuse-lite@1.0.30001762: {}
 
   chai@6.2.2: {}
-
-  class-variance-authority@0.7.1:
-    dependencies:
-      clsx: 2.1.1
-
-  clsx@2.1.1: {}
 
   cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -99,7 +99,7 @@ export function Mixer() {
           aria-label="Toggle MIDI mute"
           title={midiMuted ? "Unmute MIDI" : "Mute MIDI"}
           className={cn(
-            "h-8 px-1.5 min-w-8",
+            "inline-flex h-8 min-w-8 items-center justify-center px-1.5",
             midiMuted &&
               "bg-red-900/50 border-red-700 text-red-400 hover:bg-red-900/70 hover:text-red-300",
           )}
@@ -144,7 +144,7 @@ export function Mixer() {
           aria-label="Toggle audio mute"
           title={audioMuted ? "Unmute audio" : "Mute audio"}
           className={cn(
-            "h-8 px-1.5 min-w-8",
+            "inline-flex h-8 min-w-8 items-center justify-center px-1.5",
             audioMuted &&
               "bg-red-900/50 border-red-700 text-red-400 hover:bg-red-900/70 hover:text-red-300",
           )}
@@ -189,7 +189,7 @@ export function Mixer() {
           aria-label="Toggle metronome mute"
           title={metronomeEnabled ? "Mute metronome" : "Unmute metronome"}
           className={cn(
-            "h-8 px-1.5 min-w-8",
+            "inline-flex h-8 min-w-8 items-center justify-center px-1.5",
             !metronomeEnabled &&
               "bg-red-900/50 border-red-700 text-red-400 hover:bg-red-900/70 hover:text-red-300",
           )}

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -99,7 +99,7 @@ export function Mixer() {
           aria-label="Toggle MIDI mute"
           title={midiMuted ? "Unmute MIDI" : "Mute MIDI"}
           className={cn(
-            "inline-flex h-8 min-w-8 items-center justify-center px-1.5",
+            "h-8 min-w-8 px-1.5",
             midiMuted &&
               "bg-red-900/50 border-red-700 text-red-400 hover:bg-red-900/70 hover:text-red-300",
           )}
@@ -144,7 +144,7 @@ export function Mixer() {
           aria-label="Toggle audio mute"
           title={audioMuted ? "Unmute audio" : "Mute audio"}
           className={cn(
-            "inline-flex h-8 min-w-8 items-center justify-center px-1.5",
+            "h-8 min-w-8 px-1.5",
             audioMuted &&
               "bg-red-900/50 border-red-700 text-red-400 hover:bg-red-900/70 hover:text-red-300",
           )}
@@ -189,7 +189,7 @@ export function Mixer() {
           aria-label="Toggle metronome mute"
           title={metronomeEnabled ? "Mute metronome" : "Unmute metronome"}
           className={cn(
-            "inline-flex h-8 min-w-8 items-center justify-center px-1.5",
+            "h-8 min-w-8 px-1.5",
             !metronomeEnabled &&
               "bg-red-900/50 border-red-700 text-red-400 hover:bg-red-900/70 hover:text-red-300",
           )}

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -1035,7 +1035,7 @@ export function PianoRoll() {
                       : "Unmute metronome (M)"
                   }
                   className={cn(
-                    "inline-flex h-5 min-w-5 items-center justify-center px-0 text-[10px]",
+                    "h-5 min-w-5 px-0 text-[10px]",
                     !metronomeEnabled &&
                       "bg-red-900/50 border-red-700 text-red-300 hover:bg-red-900/70 hover:text-red-200",
                   )}
@@ -1073,7 +1073,7 @@ export function PianoRoll() {
                       : "Mute audio (Shift+2)"
                   }
                   className={cn(
-                    "inline-flex h-5 min-w-5 items-center justify-center px-0 text-[10px]",
+                    "h-5 min-w-5 px-0 text-[10px]",
                     audioMuted &&
                       "bg-red-900/50 border-red-700 text-red-300 hover:bg-red-900/70 hover:text-red-200",
                   )}
@@ -1106,7 +1106,7 @@ export function PianoRoll() {
                     midiMuted ? "Unmute MIDI (Shift+1)" : "Mute MIDI (Shift+1)"
                   }
                   className={cn(
-                    "inline-flex h-5 min-w-5 items-center justify-center px-0 text-[10px]",
+                    "h-5 min-w-5 px-0 text-[10px]",
                     midiMuted &&
                       "bg-red-900/50 border-red-700 text-red-300 hover:bg-red-900/70 hover:text-red-200",
                   )}

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -1035,7 +1035,7 @@ export function PianoRoll() {
                       : "Unmute metronome (M)"
                   }
                   className={cn(
-                    "h-5 min-w-5 px-0 text-[10px]",
+                    "inline-flex h-5 min-w-5 items-center justify-center px-0 text-[10px]",
                     !metronomeEnabled &&
                       "bg-red-900/50 border-red-700 text-red-300 hover:bg-red-900/70 hover:text-red-200",
                   )}
@@ -1073,7 +1073,7 @@ export function PianoRoll() {
                       : "Mute audio (Shift+2)"
                   }
                   className={cn(
-                    "h-5 min-w-5 px-0 text-[10px]",
+                    "inline-flex h-5 min-w-5 items-center justify-center px-0 text-[10px]",
                     audioMuted &&
                       "bg-red-900/50 border-red-700 text-red-300 hover:bg-red-900/70 hover:text-red-200",
                   )}
@@ -1106,7 +1106,7 @@ export function PianoRoll() {
                     midiMuted ? "Unmute MIDI (Shift+1)" : "Mute MIDI (Shift+1)"
                   }
                   className={cn(
-                    "h-5 min-w-5 px-0 text-[10px]",
+                    "inline-flex h-5 min-w-5 items-center justify-center px-0 text-[10px]",
                     midiMuted &&
                       "bg-red-900/50 border-red-700 text-red-300 hover:bg-red-900/70 hover:text-red-200",
                   )}

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -261,7 +261,7 @@ export function Settings({
           </div>
           <Button
             onClick={onProjectsClick}
-            className="h-8 w-full justify-start gap-1.5 px-3 bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
+            className="h-8 w-full justify-start gap-1.5 px-3 bg-background text-sm shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
           >
             <FolderIcon className="size-4" />
             Manage Projects
@@ -291,7 +291,7 @@ export function Settings({
               data-testid="load-audio-button"
               onClick={handleLoadClick}
               disabled={loadAudioMutation.isPending}
-              className="h-8 flex-1 gap-1.5 px-3 bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
+              className="h-8 flex-1 gap-1.5 px-3 bg-background text-sm shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
             >
               <UploadIcon className="size-4" />
               {loadAudioMutation.isPending ? "Loading..." : "Load Audio"}
@@ -300,7 +300,7 @@ export function Settings({
               <Button
                 data-testid="remove-audio-button"
                 onClick={handleRemoveAudio}
-                className="h-8 flex-1 gap-1.5 px-3 bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
+                className="h-8 flex-1 gap-1.5 px-3 bg-background text-sm shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
               >
                 <Trash2Icon className="size-4" />
                 Remove
@@ -321,7 +321,7 @@ export function Settings({
             data-testid="import-midi-button"
             onClick={handleImportMidiClick}
             disabled={importMidiMutation.isPending}
-            className="h-8 w-full justify-start gap-1.5 px-3 bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
+            className="h-8 w-full justify-start gap-1.5 px-3 bg-background text-sm shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
           >
             <UploadIcon className="size-4" />
             {importMidiMutation.isPending ? "Importing..." : "Import MIDI File"}
@@ -342,7 +342,7 @@ export function Settings({
           <Button
             data-testid="export-project-button"
             onClick={handleExportProject}
-            className="h-8 w-full justify-start gap-1.5 px-3 bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
+            className="h-8 w-full justify-start gap-1.5 px-3 bg-background text-sm shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
           >
             <DownloadIcon className="size-4" />
             Export Project
@@ -351,7 +351,7 @@ export function Settings({
             data-testid="export-midi-button"
             onClick={handleExportMidi}
             disabled={notes.length === 0}
-            className="h-8 w-full justify-start gap-1.5 px-3 bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
+            className="h-8 w-full justify-start gap-1.5 px-3 bg-background text-sm shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
           >
             <DownloadIcon className="size-4" />
             Export MIDI
@@ -360,7 +360,7 @@ export function Settings({
             data-testid="export-abc-button"
             onClick={handleExportABC}
             disabled={notes.length === 0}
-            className="h-8 w-full justify-start gap-1.5 px-3 bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
+            className="h-8 w-full justify-start gap-1.5 px-3 bg-background text-sm shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
           >
             <DownloadIcon className="size-4" />
             Export ABC
@@ -369,7 +369,7 @@ export function Settings({
             data-testid="copy-abc-button"
             onClick={handleCopyABCToClipboard}
             disabled={notes.length === 0}
-            className="h-8 w-full justify-start gap-1.5 px-3 bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
+            className="h-8 w-full justify-start gap-1.5 px-3 bg-background text-sm shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
           >
             <ClipboardIcon className="size-4" />
             Copy ABC to Clipboard

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -260,10 +260,8 @@ export function Settings({
             />
           </div>
           <Button
-            variant="outline"
-            size="sm"
             onClick={onProjectsClick}
-            className="w-full justify-start"
+            className="h-8 w-full justify-start gap-1.5 px-3 bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
           >
             <FolderIcon className="size-4" />
             Manage Projects
@@ -291,11 +289,9 @@ export function Settings({
           <div className="flex gap-2">
             <Button
               data-testid="load-audio-button"
-              variant="outline"
-              size="sm"
               onClick={handleLoadClick}
               disabled={loadAudioMutation.isPending}
-              className="flex-1"
+              className="h-8 flex-1 gap-1.5 px-3 bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
             >
               <UploadIcon className="size-4" />
               {loadAudioMutation.isPending ? "Loading..." : "Load Audio"}
@@ -303,10 +299,8 @@ export function Settings({
             {audioFileName && (
               <Button
                 data-testid="remove-audio-button"
-                variant="outline"
-                size="sm"
                 onClick={handleRemoveAudio}
-                className="flex-1"
+                className="h-8 flex-1 gap-1.5 px-3 bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
               >
                 <Trash2Icon className="size-4" />
                 Remove
@@ -325,11 +319,9 @@ export function Settings({
         <div className="pl-6 space-y-2">
           <Button
             data-testid="import-midi-button"
-            variant="outline"
-            size="sm"
             onClick={handleImportMidiClick}
             disabled={importMidiMutation.isPending}
-            className="w-full justify-start"
+            className="h-8 w-full justify-start gap-1.5 px-3 bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
           >
             <UploadIcon className="size-4" />
             {importMidiMutation.isPending ? "Importing..." : "Import MIDI File"}
@@ -349,43 +341,35 @@ export function Settings({
         <div className="pl-6 space-y-2">
           <Button
             data-testid="export-project-button"
-            variant="outline"
-            size="sm"
             onClick={handleExportProject}
-            className="w-full justify-start"
+            className="h-8 w-full justify-start gap-1.5 px-3 bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
           >
             <DownloadIcon className="size-4" />
             Export Project
           </Button>
           <Button
             data-testid="export-midi-button"
-            variant="outline"
-            size="sm"
             onClick={handleExportMidi}
             disabled={notes.length === 0}
-            className="w-full justify-start"
+            className="h-8 w-full justify-start gap-1.5 px-3 bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
           >
             <DownloadIcon className="size-4" />
             Export MIDI
           </Button>
           <Button
             data-testid="export-abc-button"
-            variant="outline"
-            size="sm"
             onClick={handleExportABC}
             disabled={notes.length === 0}
-            className="w-full justify-start"
+            className="h-8 w-full justify-start gap-1.5 px-3 bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
           >
             <DownloadIcon className="size-4" />
             Export ABC
           </Button>
           <Button
             data-testid="copy-abc-button"
-            variant="outline"
-            size="sm"
             onClick={handleCopyABCToClipboard}
             disabled={notes.length === 0}
-            className="w-full justify-start"
+            className="h-8 w-full justify-start gap-1.5 px-3 bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
           >
             <ClipboardIcon className="size-4" />
             Copy ABC to Clipboard

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -14,6 +14,7 @@ import { useTransport } from "../hooks/use-transport";
 import { useWindowEvent } from "../hooks/use-window-event";
 import { audioManager, GM_PROGRAMS } from "../lib/audio";
 import { matchKeyboardEvent } from "../lib/keyboard";
+import { cn } from "../lib/utils";
 import { useProjectStore } from "../stores/project-store";
 import { COMMON_TIME_SIGNATURES, type GridSnap } from "../types";
 import { Button } from "./ui/button";
@@ -92,9 +93,13 @@ function PlayPauseButton() {
     <Button
       data-testid="play-pause-button"
       onClick={togglePlayback}
-      variant={isPlaying ? "default" : "ghost"}
-      size="icon"
       title={isPlaying ? "Pause (Space)" : "Play (Space)"}
+      className={cn(
+        "size-9",
+        isPlaying
+          ? "bg-primary text-primary-foreground hover:bg-primary/90"
+          : "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+      )}
     >
       {isPlaying ? (
         <PauseIcon data-testid="pause-icon" className="size-5" />
@@ -139,11 +144,9 @@ function InstrumentCombobox({
       <PopoverTrigger asChild>
         <Button
           data-testid="instrument-select"
-          variant="ghost"
-          size="sm"
           role="combobox"
           aria-expanded={open}
-          className="w-44 justify-between font-normal"
+          className="h-8 w-44 justify-between gap-1.5 px-3 font-normal hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
         >
           <span className="truncate">
             {value}: {GM_PROGRAMS[value]}
@@ -320,10 +323,8 @@ export function Transport({
         <Button
           data-testid="tap-tempo-button"
           onClick={handleTapTempo}
-          variant="ghost"
-          size="sm"
           title="Tap tempo"
-          className="text-xs px-1.5"
+          className="h-8 gap-1.5 px-1.5 text-xs hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
         >
           TAP
         </Button>
@@ -337,9 +338,7 @@ export function Transport({
         <DropdownMenuTrigger asChild>
           <Button
             data-testid="time-signature-select"
-            variant="ghost"
-            size="sm"
-            className="gap-1 font-mono"
+            className="h-8 gap-1 px-3 font-mono hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
           >
             {timeSignature.numerator}/{timeSignature.denominator}
           </Button>
@@ -369,9 +368,7 @@ export function Transport({
         <DropdownMenuTrigger asChild>
           <Button
             data-testid="grid-snap-select"
-            variant="ghost"
-            size="sm"
-            className="gap-1 font-mono"
+            className="h-8 gap-1 px-3 font-mono hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
           >
             {gridSnap}
           </Button>
@@ -415,9 +412,8 @@ export function Transport({
       <Button
         data-testid="settings-button"
         onClick={onSettingsClick}
-        variant="ghost"
-        size="icon"
         title="Settings"
+        className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
       >
         <SettingsIcon className="size-5" />
       </Button>
@@ -426,9 +422,8 @@ export function Transport({
       <Button
         data-testid="mixer-button"
         onClick={onMixerClick}
-        variant="ghost"
-        size="icon"
         title="Mixer"
+        className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
       >
         <SlidersHorizontalIcon className="size-5" />
       </Button>
@@ -437,9 +432,8 @@ export function Transport({
       <Button
         data-testid="help-button"
         onClick={onHelpClick}
-        variant="ghost"
-        size="icon"
         title="Show keyboard shortcuts (?)"
+        className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
       >
         <CircleHelpIcon className="size-5" />
       </Button>

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -146,7 +146,7 @@ function InstrumentCombobox({
           data-testid="instrument-select"
           role="combobox"
           aria-expanded={open}
-          className="h-8 w-44 justify-between gap-1.5 px-3 font-normal hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+          className="h-8 w-44 justify-between gap-1.5 px-3 text-sm font-normal hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
         >
           <span className="truncate">
             {value}: {GM_PROGRAMS[value]}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,51 +1,18 @@
-import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 import { cn } from "../../lib/utils";
 
-const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive border border-border",
-  {
-    variants: {
-      variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
-        outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
-        "icon-sm": "size-8",
-        "icon-lg": "size-10",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  },
-);
-
 export function Button({
   className,
-  variant = "default",
-  size = "default",
+  type = "button",
   ...props
-}: React.ComponentProps<"button"> & VariantProps<typeof buttonVariants>) {
+}: React.ComponentProps<"button">) {
   return (
     <button
-      data-slot="button"
-      data-variant={variant}
-      data-size={size}
-      className={cn(buttonVariants({ variant, size, className }))}
+      type={type}
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center whitespace-nowrap rounded-md border border-border text-sm font-medium transition-colors focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:pointer-events-none disabled:opacity-50",
+        className,
+      )}
       {...props}
     />
   );

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -10,7 +10,7 @@ export function Button({
     <button
       type={type}
       className={cn(
-        "inline-flex shrink-0 items-center justify-center whitespace-nowrap rounded-md border border-border transition-colors focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:pointer-events-none disabled:opacity-50",
+        "inline-flex items-center justify-center rounded-md border border-border transition-colors focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:pointer-events-none disabled:opacity-50",
         className,
       )}
       {...props}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -10,7 +10,7 @@ export function Button({
     <button
       type={type}
       className={cn(
-        "inline-flex shrink-0 items-center justify-center whitespace-nowrap rounded-md border border-border text-sm font-medium transition-colors focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:pointer-events-none disabled:opacity-50",
+        "inline-flex shrink-0 items-center justify-center whitespace-nowrap rounded-md border border-border transition-colors focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:pointer-events-none disabled:opacity-50",
         className,
       )}
       {...props}

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -21,7 +21,7 @@ export function Toggle({
       aria-pressed={value}
       type="button"
       className={cn(
-        "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md border border-input bg-transparent shadow-xs transition-[color,box-shadow] hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:pointer-events-none disabled:opacity-50",
+        "rounded-md border border-input bg-transparent shadow-xs transition-[color,box-shadow] hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:pointer-events-none disabled:opacity-50",
         className,
       )}
       onClick={(event) => {

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -21,7 +21,7 @@ export function Toggle({
       aria-pressed={value}
       type="button"
       className={cn(
-        "rounded-md border border-input bg-transparent shadow-xs transition-[color,box-shadow] hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:pointer-events-none disabled:opacity-50",
+        "inline-flex items-center justify-center rounded-md border border-input bg-transparent shadow-xs transition-[color,box-shadow] hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:pointer-events-none disabled:opacity-50",
         className,
       )}
       onClick={(event) => {

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -21,7 +21,7 @@ export function Toggle({
       aria-pressed={value}
       type="button"
       className={cn(
-        "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md border border-input bg-transparent text-sm font-medium shadow-xs transition-[color,box-shadow] hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:pointer-events-none disabled:opacity-50",
+        "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md border border-input bg-transparent shadow-xs transition-[color,box-shadow] hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:pointer-events-none disabled:opacity-50",
         className,
       )}
       onClick={(event) => {


### PR DESCRIPTION
## Summary
- remove Button variant and size APIs
- move visual and size classes to existing Button call sites
- drop class-variance-authority

## Testing
- pnpm lint