### PR TITLE
fix: preserve stereo audio playback

### DIFF
--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -232,7 +232,10 @@ class AudioManager {
 
     // Audio track
     this.player = new Tone.Player();
-    this.audioChannel = new Tone.Channel(0.8).toDestination();
+    this.audioChannel = new Tone.Channel({
+      volume: Tone.gainToDb(clampGain(0.8)),
+      channelCount: 2,
+    }).toDestination();
     this.player.connect(this.audioChannel);
 
     // Metronome click generator with native Web Audio nodes.


### PR DESCRIPTION
## Summary

- Configure the imported audio track `Tone.Channel` with `channelCount: 2` so stereo files are not downmixed by Tone's explicit panner path.
- Preserve the existing default audio gain by converting the current `0.8` linear value to dB at construction.

## Tests

- Not run, per request.

Closes #132
