### PR TITLE
refactor: model audio as tracks

### DIFF
--- a/docs/2026-06-27-audio-tracks-phase-1.md
+++ b/docs/2026-06-27-audio-tracks-phase-1.md
@@ -1,0 +1,17 @@
+# Audio Tracks Phase 1
+
+## Problem Context
+
+Issue #136 needs support for two audio tracks for stem-split transcription. The first implementation slice should move the store and persistence model away from singleton audio fields while preserving the current one-track behavior.
+
+## Approach
+
+- Replace singleton audio state with `audioTracks: AudioTrack[]` and `selectedAudioTrackId`.
+- Use id-based audio mutations immediately.
+- Keep remaining UI and audio manager behavior explicitly pointed at `audioTracks[0]` for this phase.
+- Split persisted `SavedAudioTrack` from runtime `AudioTrack` so waveform data remains transient.
+- Migrate old saved singleton audio fields into a one-element `audioTracks` array.
+
+## Follow-up
+
+The next phase should replace remaining `audioTracks[0]` boundaries with multi-lane UI rendering and per-track `AudioManager` players/channels.

--- a/e2e/mute-shortcuts.spec.ts
+++ b/e2e/mute-shortcuts.spec.ts
@@ -15,11 +15,11 @@ test.describe("Track Mute Shortcuts", () => {
       ).__store;
       const state = store.getState() as {
         midiMuted: boolean;
-        audioMuted: boolean;
+        audioTracks: Array<{ muted: boolean }>;
       };
       return {
         midiMuted: state.midiMuted,
-        audioMuted: state.audioMuted,
+        audioMuted: state.audioTracks[0]?.muted ?? false,
       };
     });
   }
@@ -60,14 +60,14 @@ test.describe("Track Mute Shortcuts", () => {
   });
 
   test("mute shortcuts work without audio loaded", async ({ page }) => {
-    // Should be able to toggle mutes even without audio loaded
+    // MIDI can toggle without audio loaded; audio mute is track-scoped.
     await page.keyboard.press("Shift+1");
     let muteState = await getMuteState(page);
     expect(muteState.midiMuted).toBe(true);
 
     await page.keyboard.press("Shift+2");
     muteState = await getMuteState(page);
-    expect(muteState.audioMuted).toBe(true);
+    expect(muteState.audioMuted).toBe(false);
 
     // Unmute both
     await page.keyboard.press("Shift+1");

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -53,15 +53,16 @@ export function App() {
       }
 
       const project = useProjectStore.getState();
-      if (project.audioAssetKey) {
-        const asset = await loadAsset(project.audioAssetKey);
+      const audioTrack = project.audioTracks[0];
+      if (audioTrack?.assetKey) {
+        const asset = await loadAsset(audioTrack.assetKey);
         if (asset) {
           const { buffer, audioView } = await loadAudioFile(
             new File([asset.blob], asset.name),
           );
           audioManager.player.buffer = buffer;
-          audioManager.syncAudioTrack(project.audioOffset);
-          project.setAudioView(audioView);
+          audioManager.syncAudioTrack(audioTrack.offset);
+          project.updateAudioTrack(audioTrack.id, { audioView });
         } else {
           toast.warning(
             "Audio asset not found. The audio track will be cleared.",

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -18,19 +18,20 @@ import { Toggle } from "./ui/toggle";
 
 export function Mixer() {
   const {
+    audioTracks,
     midiVolume,
-    audioVolume,
     metronomeVolume,
     midiMuted,
-    audioMuted,
     metronomeEnabled,
     setMidiVolume,
-    setAudioVolume,
     setMetronomeVolume,
     setMidiMuted,
-    setAudioMuted,
+    updateAudioTrack,
     setMetronomeEnabled,
   } = useProjectStore();
+  const audioTrack = audioTracks[0];
+  const audioVolume = audioTrack?.volume ?? 0.8;
+  const audioMuted = audioTrack?.muted ?? false;
   const zeroDbPercent = dbToPercent(0);
   const formatDb = useCallback((value: number) => value.toFixed(1), []);
   const midiDbInput = useDraftInput({
@@ -44,7 +45,11 @@ export function Mixer() {
   });
   const audioDbInput = useDraftInput({
     value: gainToDb(audioVolume),
-    onCommit: (db) => setAudioVolume(dbToGain(db)),
+    onCommit: (db) => {
+      if (audioTrack) {
+        updateAudioTrack(audioTrack.id, { volume: dbToGain(db) });
+      }
+    },
     min: MIN_DB,
     max: MAX_DB,
     step: 0.5,
@@ -121,7 +126,11 @@ export function Mixer() {
           />
           <Slider
             value={[gainToPercent(audioVolume)]}
-            onValueChange={([v]) => setAudioVolume(percentToGain(v))}
+            onValueChange={([v]) => {
+              if (audioTrack) {
+                updateAudioTrack(audioTrack.id, { volume: percentToGain(v) });
+              }
+            }}
             max={100}
             step={1}
             orientation="vertical"
@@ -140,7 +149,11 @@ export function Mixer() {
         </div>
         <Toggle
           value={audioMuted}
-          onChange={setAudioMuted}
+          onChange={(muted) => {
+            if (audioTrack) {
+              updateAudioTrack(audioTrack.id, { muted });
+            }
+          }}
           aria-label="Toggle audio mute"
           title={audioMuted ? "Unmute audio" : "Mute audio"}
           className={cn(

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -241,14 +241,10 @@ export function PianoRoll() {
     totalBeats,
     tempo,
     timeSignature,
-    audioDuration,
-    audioOffset,
-    audioFileName,
-    isAudioTrackSelected,
-    audioVolume,
+    audioTracks,
+    selectedAudioTrackId,
     midiVolume,
     metronomeVolume,
-    audioMuted,
     midiMuted,
     metronomeEnabled,
     showDebug,
@@ -258,10 +254,9 @@ export function PianoRoll() {
     deleteNotes,
     selectNotes,
     deselectAll,
-    setAudioOffset,
-    setAudioTrackSelected,
-    clearAudioFile,
-    audioView,
+    updateAudioTrack,
+    deleteAudioTrack,
+    selectAudioTrack,
     undo,
     redo,
     canUndo,
@@ -286,13 +281,16 @@ export function PianoRoll() {
     setPixelsPerBeat,
     setPixelsPerKey,
     setWaveformHeight,
-    setAudioVolume,
     setMidiVolume,
     setMetronomeVolume,
-    setAudioMuted,
     setMidiMuted,
     setMetronomeEnabled,
   } = useProjectStore();
+  const audioTrack = audioTracks[0];
+  const isAudioTrackSelected =
+    Boolean(audioTrack) && selectedAudioTrackId === audioTrack.id;
+  const audioVolume = audioTrack?.volume ?? 0.8;
+  const audioMuted = audioTrack?.muted ?? false;
 
   // Transport state from hook (source of truth: Tone.js Transport)
   const { isPlaying, position } = useTransport();
@@ -423,12 +421,14 @@ export function PianoRoll() {
       } else if (selectedLocatorId) {
         deleteLocator(selectedLocatorId);
       } else if (isAudioTrackSelected) {
-        clearAudioFile();
+        if (audioTrack) {
+          deleteAudioTrack(audioTrack.id);
+        }
       }
     } else if (matchKeyboardEvent(e, "Escape")) {
       deselectAll();
       selectLocator(null);
-      setAudioTrackSelected(false);
+      selectAudioTrack(null);
     } else if (matchKeyboardEvent(e, "Ctrl+C")) {
       // Ctrl+C: Copy
       e.preventDefault();
@@ -553,7 +553,7 @@ export function PianoRoll() {
       if (e.button !== 0) {
         return;
       }
-      setAudioTrackSelected(false);
+      selectAudioTrack(null);
       const { beat, pitch } = screenToGrid(e.clientX, e.clientY);
       const snappedBeat = snapToGrid(beat, gridSnapValue, {
         floor: true,
@@ -726,7 +726,7 @@ export function PianoRoll() {
       gridToScreen,
       selectNotes,
       deselectAll,
-      setAudioTrackSelected,
+      selectAudioTrack,
       previewNote,
     ],
   );
@@ -1115,7 +1115,11 @@ export function PianoRoll() {
                 <span className="uppercase tracking-wide">Audio</span>
                 <Toggle
                   value={audioMuted}
-                  onChange={setAudioMuted}
+                  onChange={(muted) => {
+                    if (audioTrack) {
+                      updateAudioTrack(audioTrack.id, { muted });
+                    }
+                  }}
                   aria-label="Toggle audio mute"
                   title={
                     audioMuted
@@ -1138,7 +1142,13 @@ export function PianoRoll() {
                 />
                 <Slider
                   value={[gainToPercent(audioVolume)]}
-                  onValueChange={([v]) => setAudioVolume(percentToGain(v))}
+                  onValueChange={([v]) => {
+                    if (audioTrack) {
+                      updateAudioTrack(audioTrack.id, {
+                        volume: percentToGain(v),
+                      });
+                    }
+                  }}
                   max={100}
                   step={1}
                 />
@@ -1229,21 +1239,25 @@ export function PianoRoll() {
             gridSnap={gridSnap}
             scrollX={scrollX}
             viewportWidth={viewportSize.width - LEFT_PANEL_WIDTH}
-            audioDuration={audioDuration}
-            audioOffset={audioOffset}
-            audioFileName={audioFileName}
+            audioDuration={audioTrack?.duration ?? 0}
+            audioOffset={audioTrack?.offset ?? 0}
+            audioFileName={audioTrack?.fileName ?? null}
             tempo={tempo}
             playheadBeat={secondsToBeats(position, tempo)}
-            audioView={audioView}
+            audioView={audioTrack?.audioView ?? null}
             height={waveformHeight}
             beatsPerBar={beatsPerBar}
             isSelected={isAudioTrackSelected}
-            onOffsetChange={setAudioOffset}
+            onOffsetChange={(offset) => {
+              if (audioTrack) {
+                updateAudioTrack(audioTrack.id, { offset });
+              }
+            }}
             onHeightChange={setWaveformHeight}
             onSelect={() => {
               deselectAll();
               selectLocator(null);
-              setAudioTrackSelected(true);
+              selectAudioTrack(audioTrack?.id ?? null);
             }}
           />
           {/* Note grid with CSS background */}

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -20,7 +20,11 @@ import { buildExportFileName } from "../lib/export-utils";
 import { downloadMidiFile, exportMidi } from "../lib/midi-export";
 import { importMidiNotes, type MidiImportOptions } from "../lib/midi-import";
 import { downloadProjectFile, exportProjectFile } from "../lib/project-file";
-import { toSavedProject, useProjectStore } from "../stores/project-store";
+import {
+  generateAudioTrackId,
+  toSavedProject,
+  useProjectStore,
+} from "../stores/project-store";
 import { FileDropInput } from "./file-drop-input";
 import { Button } from "./ui/button";
 
@@ -43,8 +47,7 @@ export function Settings({
     isValid: (value) => value.length > 0,
   });
   const {
-    audioFileName,
-    audioAssetKey,
+    audioTracks,
     tempo,
     timeSignature,
     notes,
@@ -52,11 +55,11 @@ export function Settings({
     showDebug,
     setAutoScrollEnabled,
     setShowDebug,
-    setAudioFile,
-    setAudioOffset,
-    setAudioView,
-    clearAudioFile,
+    addAudioTrack,
+    updateAudioTrack,
+    deleteAudioTrack,
   } = useProjectStore();
+  const audioTrack = audioTracks[0];
 
   const importMidiMutation = useMutation({
     mutationFn: async (file: File) => {
@@ -103,25 +106,35 @@ export function Settings({
 
       // Save audio to IndexedDB for persistence
       const assetKey = await saveAsset(file);
-      setAudioFile(file.name, buffer.duration, assetKey);
+      const id = audioTrack?.id ?? generateAudioTrackId();
+      addAudioTrack({
+        id,
+        fileName: file.name,
+        assetKey,
+        duration: buffer.duration,
+        offset: 0,
+        volume: audioTrack?.volume ?? 0.8,
+        muted: audioTrack?.muted ?? false,
+      });
 
       audioManager.player.buffer = buffer;
       audioManager.player.sync().start(0);
-      setAudioOffset(0);
 
-      setAudioView(audioView);
+      updateAudioTrack(id, { audioView });
     },
   });
 
   const handleRemoveAudio = async () => {
     // Delete from IndexedDB if we have a key
-    if (audioAssetKey) {
-      await deleteAsset(audioAssetKey);
+    if (audioTrack?.assetKey) {
+      await deleteAsset(audioTrack.assetKey);
     }
     // Clear the audio buffer in the player
     audioManager.clearAudioBuffer();
     // Clear store state
-    clearAudioFile();
+    if (audioTrack) {
+      deleteAudioTrack(audioTrack.id);
+    }
   };
 
   const handleExportMidi = () => {
@@ -129,8 +142,8 @@ export function Settings({
       notes,
       tempo,
       timeSignature,
-      trackName: audioFileName
-        ? audioFileName.replace(/\.[^.]+$/, "")
+      trackName: audioTrack
+        ? audioTrack.fileName.replace(/\.[^.]+$/, "")
         : "Piano Roll",
     });
 
@@ -147,7 +160,9 @@ export function Settings({
       notes,
       tempo,
       timeSignature,
-      title: audioFileName ? audioFileName.replace(/\.[^.]+$/, "") : "Untitled",
+      title: audioTrack
+        ? audioTrack.fileName.replace(/\.[^.]+$/, "")
+        : "Untitled",
     });
 
     const fileName = buildExportFileName({
@@ -164,8 +179,8 @@ export function Settings({
         notes,
         tempo,
         timeSignature,
-        title: audioFileName
-          ? audioFileName.replace(/\.[^.]+$/, "")
+        title: audioTrack
+          ? audioTrack.fileName.replace(/\.[^.]+$/, "")
           : "Untitled",
       });
 
@@ -229,13 +244,13 @@ export function Settings({
           Audio
         </h3>
         <div className="pl-6 space-y-2">
-          {audioFileName && (
+          {audioTrack && (
             <div>
               <label className="block text-xs text-neutral-400 mb-1">
                 Current File
               </label>
               <div className="text-sm text-neutral-200 truncate">
-                {audioFileName}
+                {audioTrack.fileName}
               </div>
             </div>
           )}
@@ -251,7 +266,7 @@ export function Settings({
               <UploadIcon className="size-4" />
               {loadAudioMutation.isPending ? "Loading..." : "Load Audio"}
             </FileDropInput>
-            {audioFileName && (
+            {audioTrack && (
               <Button
                 data-testid="remove-audio-button"
                 onClick={handleRemoveAudio}

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -202,11 +202,11 @@ export function Transport({
   projectName,
 }: TransportProps) {
   const {
+    audioTracks,
     tempo,
     timeSignature,
     midiProgram,
     midiMuted,
-    audioMuted,
     metronomeEnabled,
     autoScrollEnabled,
     gridSnap,
@@ -214,11 +214,13 @@ export function Transport({
     setTimeSignature,
     setMidiProgram,
     setMidiMuted,
-    setAudioMuted,
+    updateAudioTrack,
     setMetronomeEnabled,
     setAutoScrollEnabled,
     setGridSnap,
   } = useProjectStore();
+  const audioTrack = audioTracks[0];
+  const audioMuted = audioTrack?.muted ?? false;
 
   const tapTimesRef = useRef<number[]>([]);
 
@@ -250,7 +252,9 @@ export function Transport({
     // Shift+2 - Toggle audio mute
     if (matchKeyboardEvent(e, "Shift+2") && !e.repeat) {
       e.preventDefault();
-      setAudioMuted(!audioMuted);
+      if (audioTrack) {
+        updateAudioTrack(audioTrack.id, { muted: !audioMuted });
+      }
     }
   });
 

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -261,11 +261,14 @@ class AudioManager {
    * When prevState is provided, only applies changed values to avoid expensive rebuilds.
    */
   applyState(state: ProjectState, prevState?: ProjectState): void {
+    const audioTrack = state.audioTracks[0];
+    const prevAudioTrack = prevState?.audioTracks[0];
+
     // Cheap operations - always apply
-    this.setAudioVolume(state.audioVolume);
+    this.setAudioVolume(audioTrack?.volume ?? 0.8);
     this.setMidiVolume(state.midiVolume);
     this.setMidiMuted(state.midiMuted);
-    this.setAudioMuted(state.audioMuted);
+    this.setAudioMuted(audioTrack?.muted ?? false);
     this.setMetronomeVolume(state.metronomeVolume);
     this.setMetronomeEnabled(state.metronomeEnabled);
     Tone.getTransport().bpm.value = state.tempo;
@@ -279,8 +282,8 @@ class AudioManager {
     if (state.notes !== prevState?.notes) {
       this.setNotes(state.notes);
     }
-    if (state.audioOffset !== prevState?.audioOffset) {
-      this.syncAudioTrack(state.audioOffset);
+    if (audioTrack?.offset !== prevAudioTrack?.offset) {
+      this.syncAudioTrack(audioTrack?.offset ?? 0);
     }
     if (state.timeSignature.numerator !== prevState?.timeSignature.numerator) {
       this.setMetronomeSequence(state.timeSignature.numerator);

--- a/src/lib/project-file.ts
+++ b/src/lib/project-file.ts
@@ -1,7 +1,7 @@
 // .toymidi project file format: ZIP containing manifest.json, project.json, and optional audio
 
 import JSZip from "jszip";
-import type { SavedProject } from "../stores/project-store";
+import type { SavedAudioTrack, SavedProject } from "../stores/project-store";
 import { loadAsset, saveAsset } from "./asset-store";
 import { buildExportFileName } from "./export-utils";
 
@@ -13,6 +13,7 @@ export interface ProjectManifest {
   files: {
     project: "project.json";
     audio?: string; // e.g., "audio/track.wav"
+    audioTracks?: Array<{ id: string; path: string }>;
   };
 }
 
@@ -21,6 +22,7 @@ export interface ParsedProjectFile {
   manifest: ProjectManifest;
   project: SavedProject;
   audioFile?: File; // Reconstructed File object for audio
+  audioFiles?: Array<{ id: string; file: File }>;
 }
 
 /**
@@ -42,25 +44,30 @@ export async function exportProjectFile(
     },
   };
 
-  // If there's an audio file, include it
-  if (projectData.audioAssetKey) {
-    const asset = await loadAsset(projectData.audioAssetKey);
+  // If there are audio files, include them
+  const exportedAudioTracks: SavedAudioTrack[] = [];
+  for (const track of projectData.audioTracks) {
+    if (!track.assetKey) {
+      exportedAudioTracks.push(track);
+      continue;
+    }
+    const asset = await loadAsset(track.assetKey);
     if (asset) {
-      const audioFileName = projectData.audioFileName || "audio.wav";
-      const audioPath = `audio/${audioFileName}`;
-      manifest.files.audio = audioPath;
+      const audioPath = `audio/${track.id}-${track.fileName}`;
+      manifest.files.audioTracks ??= [];
+      manifest.files.audioTracks.push({ id: track.id, path: audioPath });
       zip.file(audioPath, asset.blob);
     }
+    exportedAudioTracks.push({ ...track, assetKey: null });
   }
 
   // Add manifest
   zip.file("manifest.json", JSON.stringify(manifest, null, 2));
 
-  // Add project data (strip the audioAssetKey since we're bundling the file)
+  // Add project data (strip asset keys since bundled files regenerate them on import)
   const projectForExport: SavedProject = {
     ...projectData,
-    // Clear asset key - will be regenerated on import
-    audioAssetKey: null,
+    audioTracks: exportedAudioTracks,
   };
   zip.file("project.json", JSON.stringify(projectForExport, null, 2));
 
@@ -116,8 +123,28 @@ export async function parseProjectFile(file: File): Promise<ParsedProjectFile> {
   const projectText = await projectFile.async("text");
   const project = JSON.parse(projectText) as SavedProject;
 
-  // Read audio file if present
+  // Read audio files if present
   let audioFile: File | undefined;
+  const audioFiles: Array<{ id: string; file: File }> = [];
+  if (manifest.files.audioTracks) {
+    for (const audioTrack of manifest.files.audioTracks) {
+      const audioZipFile = zip.file(audioTrack.path);
+      if (audioZipFile) {
+        const audioBlob = await audioZipFile.async("blob");
+        const fileName =
+          project.audioTracks?.find((track) => track.id === audioTrack.id)
+            ?.fileName ??
+          audioTrack.path.split("/").pop() ??
+          "audio.wav";
+        audioFiles.push({
+          id: audioTrack.id,
+          file: new File([audioBlob], fileName, {
+            type: audioMimeType(fileName),
+          }),
+        });
+      }
+    }
+  }
   if (manifest.files.audio) {
     const audioZipFile = zip.file(manifest.files.audio);
     if (audioZipFile) {
@@ -127,18 +154,9 @@ export async function parseProjectFile(file: File): Promise<ParsedProjectFile> {
         manifest.files.audio.split("/").pop() ||
         "audio.wav";
 
-      // Determine MIME type from extension
-      const ext = audioFileName.split(".").pop()?.toLowerCase();
-      const mimeType =
-        ext === "mp3"
-          ? "audio/mpeg"
-          : ext === "wav"
-            ? "audio/wav"
-            : ext === "ogg"
-              ? "audio/ogg"
-              : "audio/wav";
-
-      audioFile = new File([audioBlob], audioFileName, { type: mimeType });
+      audioFile = new File([audioBlob], audioFileName, {
+        type: audioMimeType(audioFileName),
+      });
     }
   }
 
@@ -146,6 +164,7 @@ export async function parseProjectFile(file: File): Promise<ParsedProjectFile> {
     manifest,
     project,
     audioFile,
+    audioFiles,
   };
 }
 
@@ -155,16 +174,64 @@ export async function parseProjectFile(file: File): Promise<ParsedProjectFile> {
 export async function importProjectAudio(
   parsed: ParsedProjectFile,
 ): Promise<SavedProject> {
-  let updatedProject = { ...parsed.project };
+  let updatedProject = normalizeAudioTracks(parsed.project);
 
-  // If there's an audio file, save it to IndexedDB
+  if (parsed.audioFiles) {
+    for (const { id, file } of parsed.audioFiles) {
+      const assetKey = await saveAsset(file);
+      updatedProject = {
+        ...updatedProject,
+        audioTracks: updatedProject.audioTracks.map((track) =>
+          track.id === id ? { ...track, assetKey } : track,
+        ),
+      };
+    }
+  }
+
+  // Legacy single-audio project file support.
   if (parsed.audioFile) {
     const assetKey = await saveAsset(parsed.audioFile);
     updatedProject = {
       ...updatedProject,
-      audioAssetKey: assetKey,
+      audioTracks: updatedProject.audioTracks.map((track, i) =>
+        i === 0 ? { ...track, assetKey } : track,
+      ),
     };
   }
 
   return updatedProject;
+}
+
+function normalizeAudioTracks(project: SavedProject): SavedProject {
+  if (project.audioTracks) {
+    return { ...project };
+  }
+  if (!project.audioAssetKey) {
+    return { ...project, audioTracks: [] };
+  }
+  return {
+    ...project,
+    audioTracks: [
+      {
+        id: "audio-1",
+        fileName: project.audioFileName ?? "audio.wav",
+        assetKey: project.audioAssetKey,
+        duration: project.audioDuration ?? 0,
+        offset: project.audioOffset ?? 0,
+        volume: project.audioVolume ?? 0.8,
+        muted: project.audioMuted ?? false,
+      },
+    ],
+  };
+}
+
+function audioMimeType(fileName: string): string {
+  const ext = fileName.split(".").pop()?.toLowerCase();
+  return ext === "mp3"
+    ? "audio/mpeg"
+    : ext === "wav"
+      ? "audio/wav"
+      : ext === "ogg"
+        ? "audio/ogg"
+        : "audio/wav";
 }

--- a/src/stores/project-store.ts
+++ b/src/stores/project-store.ts
@@ -21,18 +21,13 @@ export interface ProjectState {
   locators: Locator[];
   selectedLocatorId: string | null;
 
-  // Audio track
-  audioFileName: string | null;
-  audioAssetKey: string | null; // Reference to IndexedDB asset
-  audioDuration: number; // in seconds
-  audioOffset: number; // in seconds - timeline position where audio starts (>= 0)
-  isAudioTrackSelected: boolean;
+  // Audio tracks
+  audioTracks: AudioTrack[];
+  selectedAudioTrackId: string | null;
 
   // Mixer state
-  audioVolume: number; // 0-1
   midiVolume: number; // 0-1
   midiMuted: boolean;
-  audioMuted: boolean;
   midiProgram: number; // GM program number 0-127
   metronomeEnabled: boolean;
   metronomeVolume: number; // 0-1
@@ -51,9 +46,6 @@ export interface ProjectState {
   pixelsPerBeat: number; // horizontal scale: screen pixels per beat
   pixelsPerKey: number; // vertical scale: screen pixels per semitone row
   waveformHeight: number; // resizable waveform area height in pixels
-
-  // Waveform state
-  audioView: AudioView | null; // Pre-computed audio data for waveform display
 
   // Actions
   addNote: (note: Note) => void;
@@ -86,16 +78,17 @@ export interface ProjectState {
   pasteNotes: (insertBeat: number) => void;
 
   // Audio actions
-  setAudioFile: (fileName: string, duration: number, assetKey: string) => void;
-  setAudioOffset: (offset: number) => void;
-  clearAudioFile: () => void;
-  setAudioTrackSelected: (selected: boolean) => void;
+  addAudioTrack: (track: SavedAudioTrack) => void;
+  updateAudioTrack: (
+    id: string,
+    updates: Partial<Omit<AudioTrack, "id">>,
+  ) => void;
+  deleteAudioTrack: (id: string) => void;
+  selectAudioTrack: (id: string | null) => void;
 
   // Mixer actions
-  setAudioVolume: (volume: number) => void;
   setMidiVolume: (volume: number) => void;
   setMidiMuted: (muted: boolean) => void;
-  setAudioMuted: (muted: boolean) => void;
   setMidiProgram: (program: number) => void;
   setMetronomeEnabled: (enabled: boolean) => void;
   setMetronomeVolume: (volume: number) => void;
@@ -110,9 +103,20 @@ export interface ProjectState {
   setPixelsPerBeat: (pixelsPerBeat: number) => void;
   setPixelsPerKey: (pixelsPerKey: number) => void;
   setWaveformHeight: (height: number) => void;
+}
 
-  // Waveform actions
-  setAudioView: (view: AudioView | null) => void;
+export interface SavedAudioTrack {
+  id: string;
+  fileName: string;
+  assetKey: string | null; // null in exported .toymidi files before import regenerates it
+  duration: number; // in seconds
+  offset: number; // in seconds - timeline position where audio starts (>= 0)
+  volume: number; // 0-1
+  muted: boolean;
+}
+
+export interface AudioTrack extends SavedAudioTrack {
+  audioView: AudioView | null; // Pre-computed audio data for waveform display, not persisted
 }
 
 let noteIdCounter = 0;
@@ -123,6 +127,11 @@ export function generateNoteId(): string {
 let locatorIdCounter = 0;
 export function generateLocatorId(): string {
   return `locator-${++locatorIdCounter}`;
+}
+
+let audioTrackIdCounter = 0;
+export function generateAudioTrackId(): string {
+  return `audio-${++audioTrackIdCounter}`;
 }
 
 export const useProjectStore = create<ProjectState>((set, get) => ({
@@ -139,17 +148,12 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   selectedLocatorId: null,
 
   // Audio state
-  audioFileName: null,
-  audioAssetKey: null,
-  audioDuration: 0,
-  audioOffset: 0,
-  isAudioTrackSelected: false,
+  audioTracks: [],
+  selectedAudioTrackId: null,
 
   // Mixer state
-  audioVolume: 0.8,
   midiVolume: 0.8,
   midiMuted: false,
-  audioMuted: false,
   midiProgram: 0, // Acoustic Grand Piano
   metronomeEnabled: false,
   metronomeVolume: 0.5,
@@ -164,9 +168,6 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   pixelsPerBeat: 80, // DEFAULT_PIXELS_PER_BEAT
   pixelsPerKey: 20, // DEFAULT_PIXELS_PER_KEY
   waveformHeight: 60, // DEFAULT_WAVEFORM_HEIGHT
-
-  // Waveform state
-  audioView: null,
 
   addNote: (note) => {
     // Track in history
@@ -313,33 +314,31 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   selectLocator: (id) => set({ selectedLocatorId: id }),
 
   // Audio actions
-  setAudioFile: (fileName, duration, assetKey) =>
+  addAudioTrack: (track) =>
     set({
-      audioFileName: fileName,
-      audioAssetKey: assetKey,
-      audioDuration: duration,
-      audioOffset: 0,
+      audioTracks: [{ ...track, audioView: null }],
+      selectedAudioTrackId: track.id,
     }),
 
-  setAudioOffset: (offset) => set({ audioOffset: offset }),
+  updateAudioTrack: (id, updates) =>
+    set((state) => ({
+      audioTracks: state.audioTracks.map((track) =>
+        track.id === id ? { ...track, ...updates } : track,
+      ),
+    })),
 
-  clearAudioFile: () =>
-    set({
-      audioFileName: null,
-      audioAssetKey: null,
-      audioDuration: 0,
-      audioOffset: 0,
-      audioView: null,
-      isAudioTrackSelected: false,
-    }),
+  deleteAudioTrack: (id) =>
+    set((state) => ({
+      audioTracks: state.audioTracks.filter((track) => track.id !== id),
+      selectedAudioTrackId:
+        state.selectedAudioTrackId === id ? null : state.selectedAudioTrackId,
+    })),
 
-  setAudioTrackSelected: (selected) => set({ isAudioTrackSelected: selected }),
+  selectAudioTrack: (id) => set({ selectedAudioTrackId: id }),
 
   // Mixer actions
-  setAudioVolume: (volume) => set({ audioVolume: volume }),
   setMidiVolume: (volume) => set({ midiVolume: volume }),
   setMidiMuted: (muted) => set({ midiMuted: muted }),
-  setAudioMuted: (muted) => set({ audioMuted: muted }),
   setMidiProgram: (program) => set({ midiProgram: program }),
   setMetronomeEnabled: (enabled) => set({ metronomeEnabled: enabled }),
   setMetronomeVolume: (volume) => set({ metronomeVolume: volume }),
@@ -354,9 +353,6 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   setPixelsPerBeat: (pixelsPerBeat) => set({ pixelsPerBeat }),
   setPixelsPerKey: (pixelsPerKey) => set({ pixelsPerKey }),
   setWaveformHeight: (height) => set({ waveformHeight: height }),
-
-  // Waveform actions
-  setAudioView: (view) => set({ audioView: view }),
 
   // Undo/Redo actions
   undo: () => {
@@ -513,7 +509,7 @@ export function beatsToSeconds(beats: number, tempo: number): number {
 
 // === Project Persistence ===
 
-const STORAGE_VERSION = 1;
+const STORAGE_VERSION = 2;
 
 export interface SavedProject {
   version: number;
@@ -522,14 +518,9 @@ export interface SavedProject {
   timeSignature?: TimeSignature; // Optional for backward compatibility
   gridSnap: GridSnap;
   locators?: Locator[]; // Optional for backward compatibility
-  audioFileName: string | null;
-  audioAssetKey: string | null; // Reference to IndexedDB asset
-  audioDuration: number;
-  audioOffset: number;
-  audioVolume: number;
+  audioTracks: SavedAudioTrack[];
   midiVolume: number;
   midiMuted?: boolean; // Optional for backward compatibility
-  audioMuted?: boolean; // Optional for backward compatibility
   midiProgram?: number; // Optional for backward compatibility
   metronomeEnabled: boolean;
   metronomeVolume: number;
@@ -540,6 +531,14 @@ export interface SavedProject {
   pixelsPerBeat?: number;
   pixelsPerKey?: number;
   waveformHeight?: number;
+
+  // Legacy singleton audio fields from version 1.
+  audioFileName?: string | null;
+  audioAssetKey?: string | null;
+  audioDuration?: number;
+  audioOffset?: number;
+  audioVolume?: number;
+  audioMuted?: boolean;
 }
 
 // Default values for new/missing fields
@@ -549,14 +548,9 @@ const DEFAULTS: Omit<SavedProject, "version"> = {
   timeSignature: { numerator: 4, denominator: 4 }, // Default 4/4 time
   gridSnap: "1/8",
   locators: [],
-  audioFileName: null,
-  audioAssetKey: null,
-  audioDuration: 0,
-  audioOffset: 0,
-  audioVolume: 0.8,
+  audioTracks: [],
   midiVolume: 0.8,
   midiMuted: false,
-  audioMuted: false,
   midiProgram: 0,
   metronomeEnabled: false,
   metronomeVolume: 0.5,
@@ -578,14 +572,11 @@ export function toSavedProject(state: ProjectState): SavedProject {
     timeSignature: state.timeSignature,
     gridSnap: state.gridSnap,
     locators: state.locators,
-    audioFileName: state.audioFileName,
-    audioAssetKey: state.audioAssetKey,
-    audioDuration: state.audioDuration,
-    audioOffset: state.audioOffset,
-    audioVolume: state.audioVolume,
+    audioTracks: state.audioTracks.map(
+      ({ audioView: _audioView, ...track }) => track,
+    ),
     midiVolume: state.midiVolume,
     midiMuted: state.midiMuted,
-    audioMuted: state.audioMuted,
     midiProgram: state.midiProgram,
     metronomeEnabled: state.metronomeEnabled,
     metronomeVolume: state.metronomeVolume,
@@ -610,6 +601,8 @@ export function fromSavedProject(
   // Merge with defaults (handles new fields gracefully)
   const merged = { ...DEFAULTS, ...data };
 
+  const audioTracks = migrateAudioTracks(data, merged.audioTracks);
+
   // Update note ID counter to avoid collisions
   const maxId = merged.notes.reduce((max, n) => {
     const match = n.id.match(/^note-(\d+)$/);
@@ -624,20 +617,22 @@ export function fromSavedProject(
   }, 0);
   locatorIdCounter = maxLocatorId;
 
+  // Update audio track ID counter to avoid collisions
+  const maxAudioTrackId = audioTracks.reduce((max, track) => {
+    const match = track.id.match(/^audio-(\d+)$/);
+    return match ? Math.max(max, Number.parseInt(match[1], 10)) : max;
+  }, 0);
+  audioTrackIdCounter = maxAudioTrackId;
+
   return {
     notes: merged.notes,
     tempo: merged.tempo,
     timeSignature: merged.timeSignature ?? DEFAULTS.timeSignature,
     gridSnap: merged.gridSnap,
     locators: merged.locators ?? DEFAULTS.locators,
-    audioFileName: merged.audioFileName,
-    audioAssetKey: merged.audioAssetKey,
-    audioDuration: merged.audioDuration,
-    audioOffset: merged.audioOffset,
-    audioVolume: merged.audioVolume,
+    audioTracks: audioTracks.map((track) => ({ ...track, audioView: null })),
     midiVolume: merged.midiVolume,
     midiMuted: merged.midiMuted ?? DEFAULTS.midiMuted,
-    audioMuted: merged.audioMuted ?? DEFAULTS.audioMuted,
     midiProgram: merged.midiProgram ?? DEFAULTS.midiProgram,
     metronomeEnabled: merged.metronomeEnabled,
     metronomeVolume: merged.metronomeVolume,
@@ -650,8 +645,31 @@ export function fromSavedProject(
     // Reset transient state
     selectedNoteIds: new Set(),
     selectedLocatorId: null,
-    audioView: null,
+    selectedAudioTrackId: null,
   };
+}
+
+function migrateAudioTracks(
+  data: Partial<SavedProject>,
+  mergedAudioTracks: SavedAudioTrack[],
+): SavedAudioTrack[] {
+  if (data.audioTracks) {
+    return data.audioTracks;
+  }
+  if (!data.audioAssetKey) {
+    return mergedAudioTracks;
+  }
+  return [
+    {
+      id: "audio-1",
+      fileName: data.audioFileName ?? "audio.wav",
+      assetKey: data.audioAssetKey,
+      duration: data.audioDuration ?? 0,
+      offset: data.audioOffset ?? 0,
+      volume: data.audioVolume ?? 0.8,
+      muted: data.audioMuted ?? false,
+    },
+  ];
 }
 
 // Expose store for E2E testing in dev mode


### PR DESCRIPTION
## Summary

- replace singleton audio project state with id-based `audioTracks`
- keep phase-1 UI/audio behavior scoped to `audioTracks[0]`
- migrate legacy singleton saved projects into one audio track
- extend `.toymidi` import/export for multiple bundled audio tracks while preserving legacy single-audio imports

Closes #136 groundwork.

## Verification

- `pnpm lint-check`