### PR TITLE
fix: use project name for exported MIDI track name and ABC title

### DIFF
--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -129,9 +129,7 @@ export function Settings({
       notes,
       tempo,
       timeSignature,
-      trackName: audioFileName
-        ? audioFileName.replace(/\.[^.]+$/, "")
-        : "Piano Roll",
+      trackName: projectName,
     });
 
     const fileName = buildExportFileName({
@@ -147,7 +145,7 @@ export function Settings({
       notes,
       tempo,
       timeSignature,
-      title: audioFileName ? audioFileName.replace(/\.[^.]+$/, "") : "Untitled",
+      title: projectName,
     });
 
     const fileName = buildExportFileName({
@@ -164,9 +162,7 @@ export function Settings({
         notes,
         tempo,
         timeSignature,
-        title: audioFileName
-          ? audioFileName.replace(/\.[^.]+$/, "")
-          : "Untitled",
+        title: projectName,
       });
 
       await copyABCToClipboard(abcText);

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -129,6 +129,7 @@ export function Settings({
       notes,
       tempo,
       timeSignature,
+      name: projectName,
       trackName: projectName,
     });
 

--- a/src/lib/midi-export.test.ts
+++ b/src/lib/midi-export.test.ts
@@ -1,3 +1,4 @@
+import { Midi } from "@tonejs/midi";
 import { describe, expect, it } from "vitest";
 import { Note, TimeSignature } from "../types";
 import { exportMidi } from "./midi-export";
@@ -26,6 +27,7 @@ describe("MIDI Export", () => {
       notes,
       tempo,
       timeSignature: { numerator: 4, denominator: 4 },
+      name: "Test Song",
       trackName: "Piano Roll",
     });
 
@@ -48,6 +50,7 @@ describe("MIDI Export", () => {
       notes: [],
       tempo: 120,
       timeSignature: { numerator: 4, denominator: 4 },
+      name: "Test Song",
       trackName: "Piano Roll",
     });
 
@@ -77,6 +80,7 @@ describe("MIDI Export", () => {
       notes,
       tempo: 120,
       timeSignature: { numerator: 4, denominator: 4 },
+      name: "Test Song",
       trackName: "Piano Roll",
     });
     expect(midiData).toBeInstanceOf(Uint8Array);
@@ -97,12 +101,14 @@ describe("MIDI Export", () => {
       notes,
       tempo: 60,
       timeSignature: { numerator: 4, denominator: 4 },
+      name: "Test Song",
       trackName: "Piano Roll",
     });
     const tempo240 = exportMidi({
       notes,
       tempo: 240,
       timeSignature: { numerator: 4, denominator: 4 },
+      name: "Test Song",
       trackName: "Piano Roll",
     });
 
@@ -116,7 +122,7 @@ describe("MIDI Export", () => {
     expect(tempo240.byteLength).toBeGreaterThan(0);
   });
 
-  it("should set custom track name", () => {
+  it("should set sequence name and custom track name", () => {
     const notes: Note[] = [
       {
         id: "note-1",
@@ -131,10 +137,15 @@ describe("MIDI Export", () => {
       notes,
       tempo: 120,
       timeSignature: { numerator: 4, denominator: 4 },
+      name: "My Song",
       trackName: "My Custom Track",
     });
 
     expect(midiData).toBeInstanceOf(Uint8Array);
+
+    const parsed = new Midi(midiData);
+    expect(parsed.name).toBe("My Song");
+    expect(parsed.tracks[0].name).toBe("My Custom Track");
   });
 
   it("should handle different time signatures", () => {
@@ -154,6 +165,7 @@ describe("MIDI Export", () => {
       notes,
       tempo: 120,
       timeSignature: timeSignature34,
+      name: "Test Song",
       trackName: "Piano Roll",
     });
     expect(midiData34).toBeInstanceOf(Uint8Array);
@@ -165,6 +177,7 @@ describe("MIDI Export", () => {
       notes,
       tempo: 120,
       timeSignature: timeSignature54,
+      name: "Test Song",
       trackName: "Piano Roll",
     });
     expect(midiData54).toBeInstanceOf(Uint8Array);
@@ -176,6 +189,7 @@ describe("MIDI Export", () => {
       notes,
       tempo: 120,
       timeSignature: timeSignature68,
+      name: "Test Song",
       trackName: "Piano Roll",
     });
     expect(midiData68).toBeInstanceOf(Uint8Array);

--- a/src/lib/midi-export.ts
+++ b/src/lib/midi-export.ts
@@ -6,19 +6,22 @@ export interface MidiExportOptions {
   notes: Note[];
   tempo: number;
   timeSignature: TimeSignature;
+  /** Sequence name (song title) */
+  name: string;
   trackName: string;
 }
 
 /**
  * Export notes to a MIDI file with the specified tempo and time signature
- * @param options - Notes, tempo, time signature, and track name
+ * @param options - Notes, tempo, time signature, sequence name, and track name
  * @returns Uint8Array containing the MIDI file data
  */
 export function exportMidi(options: MidiExportOptions): Uint8Array {
-  const { notes, tempo, timeSignature, trackName } = options;
+  const { notes, tempo, timeSignature, name, trackName } = options;
 
   // Create a new MIDI file
   const midi = new Midi();
+  midi.name = name;
 
   // Set tempo
   midi.header.setTempo(tempo);


### PR DESCRIPTION
## Summary

MIDI export track name and ABC export/clipboard title were still derived from the loaded audio file name (extension stripped), with `"Piano Roll"` / `"Untitled"` fallbacks. This is a leftover from before project names existed:

- #9 introduced the MIDI export when the audio file name was the only name in the app
- #54 copied the pattern for the ABC title
- #71 added project names, and #89 migrated the export *file names* to the project name — but left the embedded metadata untouched

So exporting a project named `my-song` with `backing-track.mp3` loaded produced `my-song-<timestamp>.mid` containing a track named `backing-track`.

This consolidates all three sites in `settings.tsx` to use `projectName`. Fallbacks are dropped since the project-name input enforces a non-empty value. `audioFileName` remains in use for the Audio section UI.

**Second commit** additionally sets the MIDI *sequence name* (`midi.name`) via a new required `name` option on `exportMidi`. Conventionally the sequence name carries the song title and the track name the part/instrument name; both are the project name for now, and a future instrument setting will take over the track name (program change + GM instrument name).

## Test plan

- `pnpm lint` (format, lint, dead-code, typecheck) passes
- `midi-export.test.ts` updated for the new required `name` option, with a parse-back assertion that sequence and track names round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)