### PR TITLE
fix: use exact ticks for MIDI export and import

### DIFF
--- a/src/lib/midi-export.ts
+++ b/src/lib/midi-export.ts
@@ -1,5 +1,4 @@
 import { Midi } from "@tonejs/midi";
-import { beatsToSeconds } from "../stores/project-store";
 import { Note, TimeSignature } from "../types";
 
 export interface MidiExportOptions {
@@ -37,15 +36,15 @@ export function exportMidi(options: MidiExportOptions): Uint8Array {
   track.name = trackName;
 
   // Add all notes to the track
-  // Notes in the store are in beats, need to convert to seconds
+  // Notes in the store are in beats (quarter notes), so writing ticks
+  // directly keeps grid alignment exact instead of round-tripping
+  // through seconds and the tempo
+  const ppq = midi.header.ppq;
   notes.forEach((note) => {
-    const timeInSeconds = beatsToSeconds(note.start, tempo);
-    const durationInSeconds = beatsToSeconds(note.duration, tempo);
-
     track.addNote({
       midi: note.pitch,
-      time: timeInSeconds,
-      duration: durationInSeconds,
+      ticks: Math.round(note.start * ppq),
+      durationTicks: Math.max(1, Math.round(note.duration * ppq)),
       velocity: note.velocity / 127, // @tonejs/midi uses normalized 0-1 velocity
     });
   });

--- a/src/lib/midi-import.ts
+++ b/src/lib/midi-import.ts
@@ -95,12 +95,11 @@ export async function importMidiNotes(
         }
       : { numerator: 4, denominator: 4 };
 
-  // Convert seconds to beats
-  const secondsToBeats = (seconds: number): number => {
-    return (seconds / 60) * tempo;
-  };
-
   // Collect notes from selected tracks
+  // Reading ticks directly (instead of the seconds @tonejs/midi derives
+  // from the tempo map) keeps positions exact and independent of any
+  // mid-song tempo changes
+  const ppq = midi.header.ppq;
   const notes: Note[] = [];
 
   for (const trackIndex of options.trackIndices) {
@@ -113,8 +112,8 @@ export async function importMidiNotes(
       notes.push({
         id: generateNoteId(),
         pitch: midiNote.midi,
-        start: secondsToBeats(midiNote.time),
-        duration: secondsToBeats(midiNote.duration),
+        start: midiNote.ticks / ppq,
+        duration: midiNote.durationTicks / ppq,
         velocity: Math.round(midiNote.velocity * 127),
       });
     }


### PR DESCRIPTION
## Summary

Note timing went through a lossy beats ↔ seconds ↔ ticks round-trip in both directions:

- **Export**: `exportMidi` converted beats to seconds (`beatsToSeconds`) and let `@tonejs/midi` convert back to ticks through the tempo. The double float conversion can place notes fractionally off-grid, which interacts badly with notation software import quantizers (the motivating use case is exporting to MuseScore).
- **Import**: the mirror image — `importMidiNotes` took the seconds `@tonejs/midi` derives from the file's tempo map and converted them back to beats using the *first* tempo, reintroducing the same float error and silently mangling files with mid-song tempo changes.

Since notes are stored in beats (quarter notes), both sides now use ticks directly:

- Export: `ticks: Math.round(note.start * ppq)`, `durationTicks: Math.max(1, Math.round(note.duration * ppq))`
- Import: `start: midiNote.ticks / ppq`, `duration: midiNote.durationTicks / ppq`

Grid alignment is exact by construction (beat 1.25 ↔ tick 600 at 480 PPQ, at any tempo), export → import round-trips are bit-exact, and the local `secondsToBeats` helper plus the `beatsToSeconds` import drop out. Tempo is still written/read as metadata.

Complements #142 (export naming); the two touch different parts of `exportMidi` and are independent.

## Test plan

- `pnpm lint` (format, lint, dead-code, typecheck) passes
- Existing `midi-export.test.ts` assertions are timing-agnostic (file validity only), so no test changes needed; there is no midi-import unit test yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)