### PR TITLE
feat: add playback speed control (0.5x/1x)

### DIFF
--- a/docs/2026-07-04-playback-speed.md
+++ b/docs/2026-07-04-playback-speed.md
@@ -1,0 +1,95 @@
+# Playback Speed (issue #140)
+
+Slow down playback for more precise transcription, without changing the
+musical tempo of the project.
+
+- Issue: https://github.com/hi-ogawa/toy-midi/issues/140
+- See the issue comment for the original design sketch (pitch-preserving
+  time-stretch via AudioWorklet). This doc refines it after checking the
+  actual code paths.
+
+## Design summary
+
+- New `playbackSpeed` state (default `1`), separate from project `tempo`.
+  Session-only — not persisted in the project file, since it's a listening
+  aid, not project data.
+- Transport runs at effective BPM: `Tone.getTransport().bpm.value = tempo * playbackSpeed`.
+  This automatically scales MIDI note scheduling (`midiPart` duration math in
+  `src/lib/audio.ts` reads live transport BPM) and the metronome
+  (`Tone.Sequence` is beat-based).
+- Audio track: `player.playbackRate = playbackSpeed`, pitch-corrected later
+  by a worklet (phase 3). At exactly 0.5x, plain playbackRate drops pitch by
+  exactly one octave — same pitch classes, usable for transcription — so the
+  MVP ships without the worklet, offering only `0.5x` / `1x`.
+
+## Known sync pitfalls (found in code review)
+
+Two places assume transport seconds map to song time at the musical tempo.
+Both break once effective BPM != tempo:
+
+1. **Playhead & playhead-relative actions.** `src/hooks/use-transport.ts`
+   exposes `transport.seconds` (wall-clock), and the UI converts with
+   `secondsToBeats(position, tempo)`:
+   - `src/components/piano-roll.tsx` — playhead render (~line 338),
+     paste at playhead (~439), add locator (~462)
+   - `src/components/transport.tsx` — `formatBarBeat(position, tempo)` (~61)
+
+   At 0.5x the playhead would move 2x too fast relative to notes.
+
+2. **Audio track start offset.** `syncAudioTrack` in `src/lib/audio.ts` does
+   `player.sync().start(offset)` — synced start times are transport
+   *seconds* (real time). At speed `s` the audio must start at
+   `audioOffset / s` real seconds to stay aligned with beat-positioned notes.
+   Also verify seek-while-synced with `playbackRate != 1`; Tone.js's synced
+   Player offset scaling with playbackRate is historically fiddly.
+
+## Implementation phases
+
+### Phase 1 — beats-based playhead refactor (own PR, correct today)
+
+Make the UI speed-independent by construction instead of threading
+`playbackSpeed` through every seconds→beats conversion.
+
+- `useTransport` returns position in **beats** derived from
+  `Tone.getTransport().ticks / PPQ` (keep seconds too if needed for the
+  time display; compute it from beats + tempo, not wall clock).
+- Update all `secondsToBeats(position, tempo)` call sites in
+  `piano-roll.tsx` / `transport.tsx` to use beats directly.
+- `audioManager.seek()` callers: check whether seek inputs are derived from
+  beats (piano roll click) and keep the conversion at the boundary.
+- E2E: playhead position after seek/play matches note grid.
+
+### Phase 2 — playbackSpeed MVP (no worklet)
+
+- `playbackSpeed` in the store (session-only), UI selector `0.5x` / `1x` in
+  the transport bar.
+- `applyState`: `bpm.value = tempo * playbackSpeed`;
+  `player.playbackRate = playbackSpeed`.
+- Fix `syncAudioTrack` to `start(audioOffset / playbackSpeed)`; re-sync when
+  speed changes (speed change while playing may simply re-seek, or pause —
+  decide during implementation, simplest acceptable behavior wins).
+- Manual check: imported song at 0.5x plays one octave down, notes/metronome/
+  playhead/waveform-vs-audio all aligned; seek works.
+- E2E: state + playhead behavior at 0.5x (audio quality is manual-only per
+  testing strategy in AGENTS.md).
+
+### Phase 3 — pitch-preserving worklet (arbitrary speeds)
+
+- Insert a pitch-shift-up-by-`1/speed` AudioWorklet between `player` and
+  `audioChannel` in `src/lib/audio.ts`. Real-time constraint: you cannot
+  time-stretch a live stream longer than its input, so slow at the source
+  (playbackRate) and correct pitch after — this is the standard chain.
+- Library: [signalsmith-stretch](https://github.com/Signalsmith-Audio/signalsmith-stretch)
+  — MIT, official JS/WASM build with AudioWorklet support; fits the existing
+  oxisynth worklet/WASM packaging pattern (`src/assets/oxisynth/`).
+  Avoid Rubber Band (GPL); `Tone.PitchShift`/`GrainPlayer` (granular) sound
+  smeared but can serve as a throwaway quality baseline during the spike.
+- Bypass the worklet entirely at 1x.
+- Then widen the speed selector: `0.25x`, `0.5x`, `0.75x`, `1x`.
+
+## Risks
+
+- Worklet/WASM packaging and audio artifacts (phase 3) — isolated by the
+  phasing; phases 1–2 carry all the app-level state/sync risk and are cheap.
+- Tone.js synced-Player + playbackRate seek behavior needs empirical
+  verification early in phase 2.

--- a/docs/2026-07-04-playback-speed.md
+++ b/docs/2026-07-04-playback-speed.md
@@ -38,7 +38,7 @@ Both break once effective BPM != tempo:
 
 2. **Audio track start offset.** `syncAudioTrack` in `src/lib/audio.ts` does
    `player.sync().start(offset)` — synced start times are transport
-   *seconds* (real time). At speed `s` the audio must start at
+   _seconds_ (real time). At speed `s` the audio must start at
    `audioOffset / s` real seconds to stay aligned with beat-positioned notes.
    Also verify seek-while-synced with `playbackRate != 1`; Tone.js's synced
    Player offset scaling with playbackRate is historically fiddly.

--- a/docs/2026-07-04-playback-speed.md
+++ b/docs/2026-07-04-playback-speed.md
@@ -47,6 +47,8 @@ Both break once effective BPM != tempo:
 
 ### Phase 1 — beats-based playhead refactor (own PR, correct today)
 
+**Status: implemented (statically verified only).**
+
 Make the UI speed-independent by construction instead of threading
 `playbackSpeed` through every seconds→beats conversion.
 
@@ -61,17 +63,33 @@ Make the UI speed-independent by construction instead of threading
 
 ### Phase 2 — playbackSpeed MVP (no worklet)
 
+**Status: implemented (statically verified only — `pnpm lint`; manual/E2E
+verification pending).**
+
 - `playbackSpeed` in the store (session-only), UI selector `0.5x` / `1x` in
-  the transport bar.
+  the transport bar (`data-testid="playback-speed-select"`).
 - `applyState`: `bpm.value = tempo * playbackSpeed`;
   `player.playbackRate = playbackSpeed`.
-- Fix `syncAudioTrack` to `start(audioOffset / playbackSpeed)`; re-sync when
-  speed changes (speed change while playing may simply re-seek, or pause —
-  decide during implementation, simplest acceptable behavior wins).
-- Manual check: imported song at 0.5x plays one octave down, notes/metronome/
-  playhead/waveform-vs-audio all aligned; seek works.
-- E2E: state + playhead behavior at 0.5x (audio quality is manual-only per
-  testing strategy in AGENTS.md).
+- **Design deviation from the sketch above**: reading Tone.js v15 source
+  (`Source.sync()` / `Player._start`) showed that synced-Player restarts
+  compute buffer offsets in raw transport seconds, never scaled by
+  `playbackRate` — so `player.sync().start(offset / speed)` would still
+  misalign on every pause→resume and seek. Instead the player is now
+  **unsynced** and `AudioManager` schedules it explicitly:
+  - `startAudioPlayback()` computes the buffer offset from the transport
+    position (`transport.seconds * playbackSpeed - audioOffset`) on every
+    `play()`, `seek()`, speed change, and audio-offset change;
+  - transport `stop`/`pause` events stop the player (alongside the existing
+    `allNotesOff`);
+  - `syncAudioTrack(offset)` now just records the offset and re-aligns if
+    playing; `settings.tsx` no longer calls `player.sync()` directly.
+- Manual check (TODO): imported song at 0.5x plays one octave down,
+  notes/metronome/playhead/waveform-vs-audio all aligned; seek and
+  pause→resume work; changing speed mid-playback stays aligned.
+- E2E: selector + speed-independent seek tests added in
+  `e2e/transport.spec.ts` ("Playback Speed" describe block, not yet run);
+  the playhead-rate-at-0.5x test is a `test.skip` skeleton pending
+  iteration against a running browser.
 
 ### Phase 3 — pitch-preserving worklet (arbitrary speeds)
 

--- a/e2e/transport.spec.ts
+++ b/e2e/transport.spec.ts
@@ -288,6 +288,65 @@ test.describe("Transport Controls", () => {
   });
 });
 
+test.describe("Playback Speed", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await clickNewProject(page);
+  });
+
+  test("speed selector updates label", async ({ page }) => {
+    const speedSelect = page.getByTestId("playback-speed-select");
+    await expect(speedSelect).toHaveText("1x");
+
+    await speedSelect.click();
+    await page
+      .getByRole("menuitemradio", { name: "0.5x", exact: true })
+      .click();
+    await expect(speedSelect).toHaveText("0.5x");
+
+    await speedSelect.click();
+    await page.getByRole("menuitemradio", { name: "1x", exact: true }).click();
+    await expect(speedSelect).toHaveText("1x");
+  });
+
+  test("seek position is speed-independent", async ({ page }) => {
+    // Switch to 0.5x
+    const speedSelect = page.getByTestId("playback-speed-select");
+    await speedSelect.click();
+    await page
+      .getByRole("menuitemradio", { name: "0.5x", exact: true })
+      .click();
+
+    // Seek to beat 4 on the timeline
+    const timeline = page.getByTestId("timeline");
+    const timelineBox = await timeline.boundingBox();
+    if (!timelineBox) {
+      throw new Error("Timeline not found");
+    }
+    const clickX = timelineBox.x + BEAT_WIDTH * 4;
+    await page.mouse.click(clickX, timelineBox.y + timelineBox.height / 2);
+    await page.waitForTimeout(100);
+
+    // Playhead lands at beat 4 and bar|beat display shows bar 2 beat 1,
+    // regardless of playback speed
+    const playhead = page.getByTestId("timeline-playhead");
+    const playheadBox = await playhead.boundingBox();
+    if (!playheadBox) {
+      throw new Error("Playhead not found");
+    }
+    const expectedX = timelineBox.x + BEAT_WIDTH * 4;
+    expect(Math.abs(playheadBox.x - expectedX)).toBeLessThan(2);
+    await expect(page.getByTestId("time-display")).toContainText("02|01");
+  });
+
+  // TODO: timing-sensitive; iterate with a running browser before enabling
+  test.skip("playhead advances at half rate at 0.5x", async () => {
+    // At 0.5x with default 120 BPM the effective BPM is 60: after ~1s of
+    // playback the playhead should be near beat 1 (it would be near beat 2
+    // at 1x). Compare playhead x positions after equal playback durations.
+  });
+});
+
 test.describe("Audio Track", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -335,7 +335,7 @@ export function PianoRoll() {
     if (!isPlaying || !autoScrollEnabled) {
       return;
     }
-    const playheadBeat = secondsToBeats(position, tempo);
+    const playheadBeat = position;
     const visibleBeatsNow = viewportSize.width / pixelsPerBeat;
     // If playhead is past 80% of visible area, scroll to put it at 20%
     if (playheadBeat > scrollX + visibleBeatsNow * 0.8) {
@@ -349,7 +349,6 @@ export function PianoRoll() {
     isPlaying,
     autoScrollEnabled,
     position,
-    tempo,
     scrollX,
     pixelsPerBeat,
     viewportSize.width,
@@ -436,7 +435,7 @@ export function PianoRoll() {
     } else if (matchKeyboardEvent(e, "Ctrl+V")) {
       // Ctrl+V: Paste at snapped playhead position
       e.preventDefault();
-      const playheadBeat = secondsToBeats(position, tempo);
+      const playheadBeat = position;
       const snappedBeat = snapToGrid(playheadBeat, gridSnapValue);
       pasteNotes(snappedBeat);
     } else if (matchKeyboardEvent(e, "Ctrl+Shift+Z")) {
@@ -459,7 +458,7 @@ export function PianoRoll() {
       }
     } else if (matchKeyboardEvent(e, "L")) {
       // L: Add locator at current playhead position
-      const playheadBeat = secondsToBeats(position, tempo);
+      const playheadBeat = position;
       const snappedBeat = snapToGrid(playheadBeat, gridSnapValue);
       handleAddLocator(snappedBeat);
     }
@@ -1209,12 +1208,11 @@ export function PianoRoll() {
             pixelsPerBeat={roundedPixelsPerBeat}
             scrollX={scrollX}
             viewportWidth={viewportSize.width - LEFT_PANEL_WIDTH}
-            playheadBeat={secondsToBeats(position, tempo)}
+            playheadBeat={position}
             beatsPerBar={beatsPerBar}
             gridSnapValue={gridSnapValue}
             onSeek={(beat) => {
-              const seconds = beatsToSeconds(beat, tempo);
-              audioManager.seek(seconds);
+              audioManager.seek(beat);
             }}
             locators={locators}
             selectedLocatorId={selectedLocatorId}
@@ -1233,7 +1231,7 @@ export function PianoRoll() {
             audioOffset={audioOffset}
             audioFileName={audioFileName}
             tempo={tempo}
-            playheadBeat={secondsToBeats(position, tempo)}
+            playheadBeat={position}
             audioView={audioView}
             height={waveformHeight}
             beatsPerBar={beatsPerBar}
@@ -1327,7 +1325,7 @@ export function PianoRoll() {
             )}
             {/* Playhead line */}
             {(() => {
-              const playheadBeat = secondsToBeats(position, tempo);
+              const playheadBeat = position;
               const playheadX = (playheadBeat - scrollX) * roundedPixelsPerBeat;
               // Only render if visible
               if (playheadX < 0 || playheadX > viewportSize.width) {

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -106,7 +106,7 @@ export function Settings({
       setAudioFile(file.name, buffer.duration, assetKey);
 
       audioManager.player.buffer = buffer;
-      audioManager.player.sync().start(0);
+      audioManager.syncAudioTrack(0);
       setAudioOffset(0);
 
       setAudioView(audioView);

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -211,6 +211,7 @@ export function Transport({
     metronomeEnabled,
     autoScrollEnabled,
     gridSnap,
+    playbackSpeed,
     setTempo,
     setTimeSignature,
     setMidiProgram,
@@ -219,6 +220,7 @@ export function Transport({
     setMetronomeEnabled,
     setAutoScrollEnabled,
     setGridSnap,
+    setPlaybackSpeed,
   } = useProjectStore();
 
   const tapTimesRef = useRef<number[]>([]);
@@ -379,6 +381,28 @@ export function Transport({
             <DropdownMenuRadioItem value="1/4T">1/4T</DropdownMenuRadioItem>
             <DropdownMenuRadioItem value="1/8T">1/8T</DropdownMenuRadioItem>
             <DropdownMenuRadioItem value="1/16T">1/16T</DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {/* Playback speed selector (audio pitch shifts down at 0.5x) */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            data-testid="playback-speed-select"
+            title="Playback speed"
+            className="h-8 gap-1 px-3 font-mono hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+          >
+            {playbackSpeed}x
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuRadioGroup
+            value={String(playbackSpeed)}
+            onValueChange={(v) => setPlaybackSpeed(Number(v))}
+          >
+            <DropdownMenuRadioItem value="0.5">0.5x</DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="1">1x</DropdownMenuRadioItem>
           </DropdownMenuRadioGroup>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -15,7 +15,7 @@ import { useWindowEvent } from "../hooks/use-window-event";
 import { audioManager, GM_PROGRAMS } from "../lib/audio";
 import { isShortcutTextInputTarget, matchKeyboardEvent } from "../lib/keyboard";
 import { cn } from "../lib/utils";
-import { useProjectStore } from "../stores/project-store";
+import { beatsToSeconds, useProjectStore } from "../stores/project-store";
 import { COMMON_TIME_SIGNATURES, type GridSnap } from "../types";
 import { Button } from "./ui/button";
 import {
@@ -42,9 +42,7 @@ function formatTimeCompact(seconds: number): string {
   return `${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}:${String(hundredths).padStart(2, "0")}`;
 }
 
-function formatBarBeat(seconds: number, tempo: number): string {
-  const beatsPerSecond = tempo / 60;
-  const totalBeats = seconds * beatsPerSecond;
+function formatBarBeat(totalBeats: number): string {
   const bar = Math.floor(totalBeats / 4) + 1; // 4/4 time signature
   const beatInBar = Math.floor(totalBeats % 4) + 1;
   return `${String(bar).padStart(2, "0")}|${String(beatInBar).padStart(2, "0")}`;
@@ -52,13 +50,16 @@ function formatBarBeat(seconds: number, tempo: number): string {
 
 // Separate component to isolate position-based re-renders
 function TimeDisplay({ tempo }: { tempo: number }) {
+  // position is in beats; time is shown in musical (project tempo) seconds,
+  // independent of playback speed
   const { position } = useTransport();
   return (
     <div
       data-testid="time-display"
       className="font-mono text-muted-foreground tabular-nums"
     >
-      {formatBarBeat(position, tempo)} - {formatTimeCompact(position)}
+      {formatBarBeat(position)} -{" "}
+      {formatTimeCompact(beatsToSeconds(position, tempo))}
     </div>
   );
 }

--- a/src/hooks/use-transport.ts
+++ b/src/hooks/use-transport.ts
@@ -6,7 +6,11 @@ import * as Tone from "tone";
  *
  * Returns:
  * - isPlaying: whether transport is playing
- * - position: current position in seconds (updates at 60fps during playback)
+ * - position: current position in beats (updates at 60fps during playback)
+ *
+ * Position is in beats (derived from transport ticks) so the UI stays
+ * aligned with the musical timeline even when the transport BPM differs
+ * from the project tempo (playback speed scaling).
  *
  * Control methods (play/pause/stop/seek) are on audioManager,
  * which handles app-specific logic like note scheduling.
@@ -79,13 +83,13 @@ const TRANSPORT_EVENT_NAMES = [
 
 type TransportState = {
   isPlaying: boolean;
-  position: number;
+  position: number; // in beats (quarter notes)
 };
 
 function deriveState(): TransportState {
   const transport = Tone.getTransport();
   return {
     isPlaying: transport.state === "started",
-    position: transport.seconds,
+    position: transport.ticks / transport.PPQ,
   };
 }

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -183,8 +183,14 @@ class AudioManager {
   private midiPart!: Tone.Part;
 
   // audio track
+  // The player is NOT synced to the transport: Tone's synced-Player computes
+  // buffer offsets in raw transport seconds, unscaled by playbackRate, which
+  // breaks alignment at playbackSpeed != 1. Instead the player is started or
+  // stopped explicitly on play/pause/seek and parameter changes.
   player!: Tone.Player;
   private audioChannel!: Tone.Channel;
+  private playbackSpeed = 1;
+  private audioOffset = 0;
 
   // metronome
   private metronome!: Metronome;
@@ -226,9 +232,15 @@ class AudioManager {
     );
     this.midiPart.start(0);
 
-    // Stop all notes when transport stops/pauses
-    Tone.getTransport().on("stop", () => this.midiSynth.allNotesOff());
-    Tone.getTransport().on("pause", () => this.midiSynth.allNotesOff());
+    // Stop all notes and the audio track when transport stops/pauses
+    Tone.getTransport().on("stop", () => {
+      this.midiSynth.allNotesOff();
+      this.player.stop();
+    });
+    Tone.getTransport().on("pause", () => {
+      this.midiSynth.allNotesOff();
+      this.player.stop();
+    });
 
     // Audio track
     this.player = new Tone.Player();
@@ -268,11 +280,19 @@ class AudioManager {
     this.setAudioMuted(state.audioMuted);
     this.setMetronomeVolume(state.metronomeVolume);
     this.setMetronomeEnabled(state.metronomeEnabled);
-    Tone.getTransport().bpm.value = state.tempo;
+    // Effective BPM scales beat-based scheduling (MIDI notes, metronome)
+    // with playback speed while note positions stay in beats
+    Tone.getTransport().bpm.value = state.tempo * state.playbackSpeed;
 
     // Program change - only when changed
     if (state.midiProgram !== prevState?.midiProgram) {
       this.setProgram(state.midiProgram);
+    }
+
+    if (state.playbackSpeed !== prevState?.playbackSpeed) {
+      this.playbackSpeed = state.playbackSpeed;
+      this.player.playbackRate = state.playbackSpeed;
+      this.restartAudioIfPlaying();
     }
 
     // Expensive operations - only when changed (or on initial sync)
@@ -290,6 +310,7 @@ class AudioManager {
   // Transport control methods (wrapper around Tone.Transport with app-specific logic)
 
   play(): void {
+    this.startAudioPlayback();
     Tone.getTransport().start();
   }
 
@@ -300,19 +321,52 @@ class AudioManager {
   seek(beats: number): void {
     const transport = Tone.getTransport();
     transport.ticks = Math.round(Math.max(0, beats) * transport.PPQ);
+    this.restartAudioIfPlaying();
   }
 
+  /**
+   * Update the audio track's timeline offset (in musical seconds at the
+   * project tempo) and re-align playback if currently playing.
+   */
   syncAudioTrack(offset: number): void {
+    this.audioOffset = offset;
+    this.restartAudioIfPlaying();
+  }
+
+  /**
+   * Start the audio track from the buffer position matching the current
+   * transport position. With transport BPM at `tempo * playbackSpeed`,
+   * musical (project tempo) seconds = transport seconds * playbackSpeed,
+   * and the buffer plays at `playbackRate = playbackSpeed`, so buffer
+   * position and musical position advance in lockstep.
+   */
+  private startAudioPlayback(): void {
+    this.player.stop();
     if (!this.player.loaded) {
       return;
     }
-    this.player.unsync();
-    this.player.sync().start(offset);
+    const songSeconds = Tone.getTransport().seconds * this.playbackSpeed;
+    const bufferOffset = songSeconds - this.audioOffset;
+    if (bufferOffset >= 0) {
+      if (bufferOffset < this.player.buffer.duration) {
+        this.player.start(undefined, bufferOffset);
+      }
+    } else {
+      // Audio starts later on the timeline: delay in real (transport) seconds
+      this.player.start(Tone.now() - bufferOffset / this.playbackSpeed, 0);
+    }
+  }
+
+  private restartAudioIfPlaying(): void {
+    if (Tone.getTransport().state === "started") {
+      this.startAudioPlayback();
+    } else {
+      this.player.stop();
+    }
   }
 
   clearAudioBuffer(): void {
     this.player.stop();
-    this.player.unsync();
     this.player.buffer = new Tone.ToneAudioBuffer();
   }
 

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -297,8 +297,9 @@ class AudioManager {
     Tone.getTransport().pause();
   }
 
-  seek(seconds: number): void {
-    Tone.getTransport().seconds = Math.max(0, seconds);
+  seek(beats: number): void {
+    const transport = Tone.getTransport();
+    transport.ticks = Math.round(Math.max(0, beats) * transport.PPQ);
   }
 
   syncAudioTrack(offset: number): void {

--- a/src/stores/project-store.ts
+++ b/src/stores/project-store.ts
@@ -37,6 +37,11 @@ export interface ProjectState {
   metronomeEnabled: boolean;
   metronomeVolume: number; // 0-1
 
+  // Playback state (session-only, not persisted)
+  // Scales the transport speed without changing the musical tempo.
+  // Audio pitch shifts with speed for now (0.5 = one octave down).
+  playbackSpeed: number; // e.g. 0.5, 1
+
   // UI state
   showDebug: boolean;
   autoScrollEnabled: boolean;
@@ -100,6 +105,9 @@ export interface ProjectState {
   setMetronomeEnabled: (enabled: boolean) => void;
   setMetronomeVolume: (volume: number) => void;
 
+  // Playback actions
+  setPlaybackSpeed: (speed: number) => void;
+
   // UI actions
   setShowDebug: (show: boolean) => void;
   setAutoScrollEnabled: (enabled: boolean) => void;
@@ -153,6 +161,9 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   midiProgram: 0, // Acoustic Grand Piano
   metronomeEnabled: false,
   metronomeVolume: 0.5,
+
+  // Playback state
+  playbackSpeed: 1,
 
   // UI state
   showDebug: false,
@@ -343,6 +354,9 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   setMidiProgram: (program) => set({ midiProgram: program }),
   setMetronomeEnabled: (enabled) => set({ metronomeEnabled: enabled }),
   setMetronomeVolume: (volume) => set({ metronomeVolume: volume }),
+
+  // Playback actions
+  setPlaybackSpeed: (speed) => set({ playbackSpeed: speed }),
 
   // UI actions
   setShowDebug: (show) => set({ showDebug: show }),


### PR DESCRIPTION
Closes #140 (phases 1–2; pitch-preserving worklet is a planned follow-up, see below).

## What

- **Beats-based transport position (refactor)**: `useTransport` now reports position in beats (`transport.ticks / PPQ`) instead of wall-clock seconds, and `audioManager.seek()` takes beats. Playhead rendering, paste/locator placement, the bar|beat display, and timeline seek stay aligned with the note grid regardless of transport BPM. Behavior-identical at 1x.
- **Playback speed control**: new session-only `playbackSpeed` state (not persisted in the project file) with a `0.5x`/`1x` selector in the transport bar. The transport runs at `tempo * playbackSpeed`, which scales MIDI note scheduling and the metronome for free; the audio track plays at the matching `playbackRate`. At 0.5x the audio sounds exactly one octave down (same pitch classes), which is usable for transcription until pitch correction lands.

## Design note: why the audio player is no longer transport-synced

The original sketch in #140 kept `player.sync()` and adjusted the start offset by speed. Reading Tone.js v15 source (`Source.sync()` / `Player._start`) showed that synced-Player restarts compute buffer offsets in **raw transport seconds, never scaled by `playbackRate`** — so at 0.5x the audio would misalign on every pause→resume and seek, not just at start. Instead, `AudioManager` now schedules the player explicitly: `startAudioPlayback()` derives the buffer position from the transport position (`transport.seconds * playbackSpeed - audioOffset`) on every play/seek/speed-change/offset-change, and transport stop/pause events stop the player. Details in `docs/2026-07-04-playback-speed.md`.

## Follow-up (phase 3)

Pitch-preserving playback via a time-stretch AudioWorklet (signalsmith-stretch, MIT, fits the existing oxisynth worklet/WASM packaging pattern), then widen the selector to 0.25x–0.75x.

## Testing

- `pnpm lint` (format, lint, dead-code, typecheck) passes.
- New E2E tests in `e2e/transport.spec.ts` ("Playback Speed"): selector state and speed-independent seek; the timing-sensitive playhead-rate test is a `test.skip` skeleton.
- ⚠️ Static verification only so far — E2E suite and manual audio check at 0.5x (alignment across pause/resume/seek) have **not** been run yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)