### PR TITLE
chore: use array shorthand types

### DIFF
--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -57,14 +57,14 @@ function generateVerticalGridLayers(
   gridSnap: GridSnap,
   scrollX: number,
   beatsPerBar: number,
-): Array<[string, string, string]> {
+): [string, string, string][] {
   const gridSnapValue = GRID_SNAP_VALUES[gridSnap];
   const beatWidth = Math.round(pixelsPerBeat);
   const subBeatWidth = beatWidth * gridSnapValue;
   const barWidth = beatWidth * beatsPerBar;
   const offsetX = -(scrollX * beatWidth) % barWidth;
 
-  const layers: Array<[string, string, string]> = [];
+  const layers: [string, string, string][] = [];
 
   // Vertical bar lines (every 4 beats, or coarser at extreme zoom)
   let coarseBarMultiplier = 1;
@@ -141,7 +141,7 @@ function generateGridBackground(
     transparent ${11 * r}px, transparent ${12 * r}px
   )`;
 
-  const layers: Array<[string, string, string]> = [];
+  const layers: [string, string, string][] = [];
 
   // Add vertical grid lines (bar, beat, sub-beat)
   layers.push(
@@ -193,7 +193,7 @@ type DragMode =
       cellOffset: number; // which grid cell within the note was grabbed
       offsetPitch: number;
       // Original states of all notes being moved (for undo)
-      originalStates: Array<{ id: string; start: number; pitch: number }>;
+      originalStates: { id: string; start: number; pitch: number }[];
     }
   | {
       type: "duplicating";
@@ -1600,7 +1600,7 @@ function Timeline({
   beatsPerBar: number;
   gridSnapValue: number;
   onSeek: (beat: number) => void;
-  locators: Array<{ id: string; position: number; label: string }>;
+  locators: { id: string; position: number; label: string }[];
   selectedLocatorId: string | null;
   onSelectLocator: (id: string) => void;
   onRenameLocator: (id: string, currentLabel: string) => void;

--- a/src/lib/audio-view.test.ts
+++ b/src/lib/audio-view.test.ts
@@ -251,7 +251,7 @@ describe("queryAudioView", () => {
     };
 
     // Query at different scroll positions (small increments)
-    const results: Array<{ data: number[] }> = [];
+    const results: { data: number[] }[] = [];
     for (let scrollSec = 30; scrollSec < 30.1; scrollSec += 0.01) {
       const result = queryAudioView(
         view,

--- a/src/stores/project-store.ts
+++ b/src/stores/project-store.ts
@@ -59,7 +59,7 @@ export interface ProjectState {
   addNote: (note: Note) => void;
   updateNote: (id: string, updates: Partial<Omit<Note, "id">>) => void;
   updateNotes: (
-    updates: Array<{ id: string; changes: Partial<Omit<Note, "id">> }>,
+    updates: { id: string; changes: Partial<Omit<Note, "id">> }[],
   ) => void; // Batch update for history tracking
   deleteNotes: (ids: string[]) => void;
   selectNotes: (ids: string[], exclusive?: boolean) => void;
@@ -190,7 +190,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     // Track in history (only changed fields)
     const before: Partial<Omit<Note, "id">> = {};
     const after: Partial<Omit<Note, "id">> = {};
-    for (const key of Object.keys(updates) as Array<keyof typeof updates>) {
+    for (const key of Object.keys(updates) as (keyof typeof updates)[]) {
       before[key] = note[key];
       after[key] = updates[key]!;
     }
@@ -217,7 +217,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 
         const before: Partial<Omit<Note, "id">> = {};
         const after: Partial<Omit<Note, "id">> = {};
-        for (const key of Object.keys(changes) as Array<keyof typeof changes>) {
+        for (const key of Object.keys(changes) as (keyof typeof changes)[]) {
           before[key] = note[key];
           after[key] = changes[key]!;
         }


### PR DESCRIPTION
## Summary
- Convert remaining src Array<T> annotations to T[] syntax
- Keep changes limited to type syntax only

## Verification
- pnpm lint-check