### PR TITLE
test: drop redundant storage clearing in multiple-projects e2e

### DIFF
--- a/e2e/multiple-projects.spec.ts
+++ b/e2e/multiple-projects.spec.ts
@@ -6,14 +6,9 @@ async function getLastProjectId(page: Page) {
 }
 
 test.describe("Multiple Projects", () => {
+  // Each test gets a fresh browser context, so storage starts empty
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
-    // Clear all storage to start fresh
-    await page.evaluate(() => {
-      localStorage.clear();
-      // Also clear IndexedDB if needed
-    });
-    await page.reload();
   });
 
   test("can create multiple projects", async ({ page }) => {


### PR DESCRIPTION
Playwright creates a fresh browser context per test, so localStorage and IndexedDB already start empty — the `localStorage.clear()` + `reload()` in `beforeEach` was a no-op. Reduced to just `page.goto("/")`.

All 11 tests in the spec pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)