### PR TITLE
feat: add `/project/:id` route for direct project access

### DIFF
--- a/docs/2026-07-05-project-route.md
+++ b/docs/2026-07-05-project-route.md
@@ -1,0 +1,59 @@
+# Project route: `/project/:id` deep link
+
+Part of #152, scoped down. Product goal: each project gets a real URL —
+bookmarkable, reload lands back in the same project, e2e can `goto` directly.
+
+Deliberately NOT in scope (decided in discussion):
+
+- No client-side navigation, router, or `popstate` handling. Navigation
+  between projects is full page load; process death is the cleanup.
+- `/` startup screen logic is unchanged (no `replaceState` when opening a
+  project from the list; Settings "Projects" button stays `window.open`).
+- No `dispose()` callers, no projectName-into-store change (#152 step 3).
+
+## Design
+
+Route fork at the top of `App` (`src/app.tsx`): parse `location.pathname`
+once. `/project/:id` renders a new `ProjectRoute`; everything else renders
+the existing startup flow verbatim.
+
+`ProjectRoute` loads via `useQuery` (deduped under StrictMode, unlike a
+mutate-on-mount): `audioManager.init()` + `openProjectSession({ projectId })`
+from #153. Unknown/deleted id → the error is rendered in place (no
+redirect, no toast).
+
+### Audio unlock
+
+Browser autoplay policy only blocks `AudioContext.resume()` — i.e.
+`Tone.start()` in `audioManager.init()` (`src/lib/audio.ts`). Everything
+else (WASM worklet, soundfont fetch, `decodeAudioData`) works on a
+suspended context, which simply produces silence.
+
+So: remove `Tone.start()` from `init()`; register one-shot capture-phase
+`pointerdown`/`keydown` listeners in `main()` that call `Tone.start()`
+(`unlockAudioOnFirstGesture` in `src/lib/audio.ts`). Deep links init
+eagerly with no gate; the user's first interaction anywhere unlocks audio.
+Capture phase means "click play as the very first interaction" resumes the
+context within the same gesture. The `/` flow is unaffected: the
+project-card click fires the unlock listener before the init mutation.
+
+### Hosting
+
+Vite dev server already serves index.html for unknown paths (SPA default),
+so dev and Playwright need nothing. Production needs
+`"not_found_handling": "single-page-application"` in `wrangler.jsonc`.
+
+## Files
+
+- `src/app.tsx` — route fork + `ProjectRoute`
+- `src/lib/audio.ts` — drop `Tone.start()` from `init()`, add
+  `unlockAudioOnFirstGesture()`
+- `src/main.tsx` — register unlock listeners
+- `wrangler.jsonc` — SPA fallback
+- `e2e/project-route.spec.ts` — deep link opens project; bogus id
+  redirects to `/`
+
+## Status
+
+- Implemented in worktree `toy-midi-project-route` (branch `project-route`)
+- Static verify only so far (`pnpm lint`); e2e not yet run

--- a/e2e/project-route.spec.ts
+++ b/e2e/project-route.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+import { clickNewProject, evaluateStore } from "./helpers";
+
+test.describe("Project Route", () => {
+  test("deep link opens project directly without startup screen", async ({
+    page,
+  }) => {
+    // Create a project with recognizable state
+    await page.goto("/");
+    await clickNewProject(page);
+    await evaluateStore(page, (store) => {
+      store.getState().addNote({
+        id: "note-deep-link",
+        pitch: 62,
+        start: 0,
+        duration: 1,
+        velocity: 100,
+      });
+      store.getState().setTempo(140);
+    });
+    await page.waitForTimeout(600);
+
+    const projectId = await page.evaluate(() =>
+      window.__e2e!.projectStorage.getLastProjectId(),
+    );
+    expect(projectId).not.toBeNull();
+
+    // Open via URL directly
+    await page.goto(`/project/${projectId}`);
+    await expect(page.getByTestId("transport")).toBeVisible();
+    await expect(page.getByTestId("startup-screen")).not.toBeVisible();
+
+    const notes = await evaluateStore(page, (store) => store.getState().notes);
+    expect(notes).toHaveLength(1);
+    expect(notes[0].pitch).toBe(62);
+    const tempo = await evaluateStore(page, (store) => store.getState().tempo);
+    expect(tempo).toBe(140);
+  });
+
+  test("unknown project id shows error", async ({ page }) => {
+    await page.goto("/project/does-not-exist");
+    await expect(
+      page.getByText("Project does-not-exist metadata not found"),
+    ).toBeVisible();
+  });
+});

--- a/e2e/project-route.spec.ts
+++ b/e2e/project-route.spec.ts
@@ -18,7 +18,7 @@ test.describe("Project Route", () => {
       });
       store.getState().setTempo(140);
     });
-    await page.waitForTimeout(600);
+    await page.evaluate(() => window.__e2e!.flushAutoSave());
 
     const projectId = await page.evaluate(() =>
       window.__e2e!.projectStorage.getLastProjectId(),

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { Github, Pencil, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -17,6 +17,44 @@ import { openProjectSession } from "./lib/project-session";
 import { type ProjectMetadata, projectStorage } from "./lib/project-storage";
 
 export function App() {
+  const match = window.location.pathname.match(/^\/project\/([^/]+)$/);
+  if (match) {
+    return <ProjectRoute projectId={match[1]} />;
+  }
+  return <StartupApp />;
+}
+
+// Deep-link entry: load the project named by the URL directly, no startup
+// screen. Audio inits on a suspended context (see unlockAudioOnFirstGesture).
+function ProjectRoute({ projectId }: { projectId: string }) {
+  const sessionQuery = useQuery({
+    queryKey: ["project-session", projectId],
+    queryFn: async () => {
+      await audioManager.init();
+      return await openProjectSession({ projectId });
+    },
+    staleTime: Infinity,
+    gcTime: Infinity,
+    retry: false,
+  });
+
+  if (!sessionQuery.isSuccess) {
+    return (
+      <div className="fixed inset-0 bg-neutral-900 flex items-center justify-center text-neutral-400">
+        {String(sessionQuery.error ?? "")}
+      </div>
+    );
+  }
+
+  return (
+    <Editor
+      projectId={sessionQuery.data.projectId}
+      initialProjectName={sessionQuery.data.projectName}
+    />
+  );
+}
+
+function StartupApp() {
   const initMutation = useMutation({
     mutationFn: async (options: { projectId?: string }) => {
       await audioManager.init();

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -191,8 +191,6 @@ class AudioManager {
   private metronomeChannel!: Tone.Channel;
 
   async init(): Promise<void> {
-    await Tone.start(); // Resume audio context (browser autoplay policy)
-
     const context = Tone.getContext();
 
     // OxiSynth (Rust/WASM) for SF2 playback
@@ -432,6 +430,20 @@ class AudioTrackPlayback {
 }
 
 export const audioManager = new AudioManager();
+
+// Browser autoplay policy blocks AudioContext.resume() outside a user
+// gesture, but everything else in init() works on a suspended context.
+// Resume on the first interaction anywhere; capture phase so that even
+// "click play as the very first interaction" resumes within that gesture.
+export function unlockAudioOnFirstGesture(): void {
+  const unlock = () => {
+    Tone.start();
+    window.removeEventListener("pointerdown", unlock, true);
+    window.removeEventListener("keydown", unlock, true);
+  };
+  window.addEventListener("pointerdown", unlock, true);
+  window.addEventListener("keydown", unlock, true);
+}
 
 // Derive POINTS_PER_SECOND from max zoom level we want to support
 // Goal: 1 point per pixel at max zoom

--- a/src/lib/project-session.ts
+++ b/src/lib/project-session.ts
@@ -28,12 +28,11 @@ export async function openProjectSession(options: {
   } else {
     projectId = projectStorage.createNew();
   }
-  projectStorage.setLastProjectId(projectId);
-
   const metadata = projectStorage.getMetadata(projectId);
   if (!metadata) {
     throw new Error(`Project ${projectId} metadata not found`);
   }
+  projectStorage.setLastProjectId(projectId);
   const data = projectStorage.load(projectId);
   useProjectStore.setState(fromSavedProject(data));
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import "./index.css";
 import oxisynthWasmUrl from "./assets/oxisynth/oxisynth.wasm?url";
 import oxisynthWorkletUrl from "./assets/oxisynth/worklet.js?url";
 import soundfontUrl from "./assets/soundfonts/A320U.sf2?url";
+import { unlockAudioOnFirstGesture } from "./lib/audio";
 import { projectStorage, seedProjectV1 } from "./lib/project-storage";
 import { useProjectStore } from "./stores/project-store";
 
@@ -22,6 +23,8 @@ function main() {
       return;
     }
   }
+
+  unlockAudioOnFirstGesture();
 
   const queryClient = new QueryClient({
     defaultOptions: {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,5 +4,6 @@
   "compatibility_date": "2026-01-14",
   "assets": {
     "directory": "dist",
+    "not_found_handling": "single-page-application",
   },
 }


### PR DESCRIPTION
Part of #152, scoped down to the product goal only: each project gets a real URL — bookmarkable, reload lands back in the same project, e2e can `goto` directly. No client-side navigation/router; switching projects remains a full page load. The `/` startup flow is unchanged.

## Changes

- **`src/app.tsx`**: `App` forks on `location.pathname` — `/project/:id` renders new `ProjectRoute` (loads via `useQuery`: `audioManager.init()` + `openProjectSession`), everything else renders the existing startup flow (`StartupApp`, renamed only). Unknown/deleted id renders the error in place.
- **`src/lib/audio.ts`**: audio-unlock split. Browser autoplay policy only blocks `AudioContext.resume()` (`Tone.start()`); everything else in `init()` works on a suspended context. `init()` no longer calls `Tone.start()`; new `unlockAudioOnFirstGesture()` resumes on the first capture-phase `pointerdown`/`keydown` anywhere — deep links init eagerly with no gate, and "click play as the very first interaction" resumes within that same gesture.
- **`src/lib/project-session.ts`**: fix — `setLastProjectId` was written before validating the project exists, so a bogus deep link would corrupt it and break the Continue button; now written after the metadata check.
- **`wrangler.jsonc`**: `not_found_handling: single-page-application` so production serves index.html for `/project/:id` (vite dev already does).
- **`e2e/project-route.spec.ts`**: deep link opens project directly; unknown id shows error.

Task doc: `docs/2026-07-05-project-route.md`

## Testing

Static verify only so far (`pnpm lint`: format/lint/dead-code/typecheck pass). E2E not yet run; manual check of the unlock path (deep link → play as first interaction → sound) recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)