### PR TITLE
test: flush auto-save deterministically in e2e instead of timing waits

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -54,6 +54,14 @@ export async function loadAudioFile(
 }
 
 /**
+ * Force a pending auto-save to run immediately instead of waiting out the
+ * debounce.
+ */
+export async function flushAutoSave(page: Page): Promise<void> {
+  await page.evaluate(() => window.__e2e!.flushAutoSave());
+}
+
+/**
  * Evaluate a function against the Zustand store in the browser context.
  * Only available in dev mode where window.__store is exposed.
  *

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -57,7 +57,7 @@ export async function loadAudioFile(
  * Force a pending auto-save to run immediately instead of waiting out the
  * debounce.
  */
-export async function flushAutoSave(page: Page): Promise<void> {
+export async function evaluateFlushAutoSave(page: Page): Promise<void> {
   await page.evaluate(() => window.__e2e!.flushAutoSave());
 }
 

--- a/e2e/multiple-projects.spec.ts
+++ b/e2e/multiple-projects.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
-import { clickNewProject, evaluateStore } from "./helpers";
+import { clickNewProject, evaluateStore, flushAutoSave } from "./helpers";
 
 async function getLastProjectId(page: Page) {
   return page.evaluate(() => window.__e2e!.projectStorage.getLastProjectId());
@@ -33,8 +33,7 @@ test.describe("Multiple Projects", () => {
       store.getState().setTempo(140);
     });
 
-    // Wait for auto-save
-    await page.waitForTimeout(100);
+    await flushAutoSave(page);
 
     // Get first project ID
     const project1Id = await getLastProjectId(page);
@@ -65,7 +64,7 @@ test.describe("Multiple Projects", () => {
       store.getState().setTempo(120);
     });
 
-    await page.waitForTimeout(600);
+    await flushAutoSave(page);
 
     const project2Id = await getLastProjectId(page);
     expect(project2Id).not.toBeNull();
@@ -92,7 +91,7 @@ test.describe("Multiple Projects", () => {
         velocity: 100,
       });
     });
-    await page.waitForTimeout(600);
+    await flushAutoSave(page);
 
     const project1Id = await getLastProjectId(page);
 
@@ -108,7 +107,7 @@ test.describe("Multiple Projects", () => {
         velocity: 80,
       });
     });
-    await page.waitForTimeout(600);
+    await flushAutoSave(page);
 
     const project2Id = await getLastProjectId(page);
 
@@ -146,7 +145,7 @@ test.describe("Multiple Projects", () => {
       });
       store.getState().setTempo(130);
     });
-    await page.waitForTimeout(600);
+    await flushAutoSave(page);
 
     // Reload and use "Continue Last" button
     await page.reload();
@@ -170,7 +169,7 @@ test.describe("Multiple Projects", () => {
     await evaluateStore(page, (store) => {
       store.getState().setTempo(100);
     });
-    await page.waitForTimeout(600);
+    await flushAutoSave(page);
     const project1Id = await getLastProjectId(page);
 
     // Create second project (will be more recent)
@@ -180,7 +179,7 @@ test.describe("Multiple Projects", () => {
     await evaluateStore(page, (store) => {
       store.getState().setTempo(120);
     });
-    await page.waitForTimeout(600);
+    await flushAutoSave(page);
     const project2Id = await getLastProjectId(page);
 
     // Reload to see project list
@@ -211,7 +210,7 @@ test.describe("Multiple Projects", () => {
     await evaluateStore(page, (store) => {
       store.getState().setTempo(115);
     });
-    await page.waitForTimeout(600);
+    await flushAutoSave(page);
 
     // Reload and press Space
     await page.reload();
@@ -346,7 +345,7 @@ test.describe("Multiple Projects", () => {
     await evaluateStore(page, (store) => {
       store.getState().setTempo(130);
     });
-    await page.waitForTimeout(600);
+    await flushAutoSave(page);
 
     const projectId = await getLastProjectId(page);
 

--- a/e2e/multiple-projects.spec.ts
+++ b/e2e/multiple-projects.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test, type Page } from "@playwright/test";
-import { clickNewProject, evaluateStore, flushAutoSave } from "./helpers";
+import {
+  clickNewProject,
+  evaluateStore,
+  evaluateFlushAutoSave,
+} from "./helpers";
 
 async function getLastProjectId(page: Page) {
   return page.evaluate(() => window.__e2e!.projectStorage.getLastProjectId());
@@ -33,7 +37,7 @@ test.describe("Multiple Projects", () => {
       store.getState().setTempo(140);
     });
 
-    await flushAutoSave(page);
+    await evaluateFlushAutoSave(page);
 
     // Get first project ID
     const project1Id = await getLastProjectId(page);
@@ -64,7 +68,7 @@ test.describe("Multiple Projects", () => {
       store.getState().setTempo(120);
     });
 
-    await flushAutoSave(page);
+    await evaluateFlushAutoSave(page);
 
     const project2Id = await getLastProjectId(page);
     expect(project2Id).not.toBeNull();
@@ -91,7 +95,7 @@ test.describe("Multiple Projects", () => {
         velocity: 100,
       });
     });
-    await flushAutoSave(page);
+    await evaluateFlushAutoSave(page);
 
     const project1Id = await getLastProjectId(page);
 
@@ -107,7 +111,7 @@ test.describe("Multiple Projects", () => {
         velocity: 80,
       });
     });
-    await flushAutoSave(page);
+    await evaluateFlushAutoSave(page);
 
     const project2Id = await getLastProjectId(page);
 
@@ -145,7 +149,7 @@ test.describe("Multiple Projects", () => {
       });
       store.getState().setTempo(130);
     });
-    await flushAutoSave(page);
+    await evaluateFlushAutoSave(page);
 
     // Reload and use "Continue Last" button
     await page.reload();
@@ -169,7 +173,7 @@ test.describe("Multiple Projects", () => {
     await evaluateStore(page, (store) => {
       store.getState().setTempo(100);
     });
-    await flushAutoSave(page);
+    await evaluateFlushAutoSave(page);
     const project1Id = await getLastProjectId(page);
 
     // Create second project (will be more recent)
@@ -179,7 +183,7 @@ test.describe("Multiple Projects", () => {
     await evaluateStore(page, (store) => {
       store.getState().setTempo(120);
     });
-    await flushAutoSave(page);
+    await evaluateFlushAutoSave(page);
     const project2Id = await getLastProjectId(page);
 
     // Reload to see project list
@@ -210,7 +214,7 @@ test.describe("Multiple Projects", () => {
     await evaluateStore(page, (store) => {
       store.getState().setTempo(115);
     });
-    await flushAutoSave(page);
+    await evaluateFlushAutoSave(page);
 
     // Reload and press Space
     await page.reload();
@@ -345,7 +349,7 @@ test.describe("Multiple Projects", () => {
     await evaluateStore(page, (store) => {
       store.getState().setTempo(130);
     });
-    await flushAutoSave(page);
+    await evaluateFlushAutoSave(page);
 
     const projectId = await getLastProjectId(page);
 

--- a/e2e/persistence.spec.ts
+++ b/e2e/persistence.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "@playwright/test";
-import { clickContinue, clickNewProject, flushAutoSave } from "./helpers";
+import {
+  clickContinue,
+  clickNewProject,
+  evaluateFlushAutoSave,
+} from "./helpers";
 
 // Constants matching piano-roll.tsx
 const BEAT_WIDTH = 80;
@@ -36,7 +40,7 @@ test.describe("Project Persistence", () => {
 
     // Wait out the real debounce (50ms via VITE_AUTO_SAVE_DEBOUNCE_MS). This
     // test intentionally covers the debounced auto-save path end-to-end;
-    // other tests use flushAutoSave() instead.
+    // other tests use evaluateFlushAutoSave() instead.
     await page.waitForTimeout(100);
 
     // Reload the page and click Continue to restore
@@ -98,7 +102,7 @@ test.describe("Project Persistence", () => {
     // Verify 3 notes exist
     await expect(page.locator("[data-testid^='note-']")).toHaveCount(3);
 
-    await flushAutoSave(page);
+    await evaluateFlushAutoSave(page);
 
     // Reload and click Continue to restore
     await page.reload();
@@ -125,7 +129,7 @@ test.describe("Project Persistence", () => {
     const waveform = page.locator(".bg-emerald-700, .bg-emerald-600").first();
     await expect(waveform).toBeVisible();
 
-    await flushAutoSave(page);
+    await evaluateFlushAutoSave(page);
 
     // Reload and click Continue to restore
     await page.reload();
@@ -158,7 +162,7 @@ test.describe("Project Persistence", () => {
     await metronomeToggle.click();
     await expect(metronomeToggle).toHaveAttribute("aria-pressed", "false");
 
-    await flushAutoSave(page);
+    await evaluateFlushAutoSave(page);
 
     // Reload and click Continue to restore
     await page.reload();
@@ -210,7 +214,7 @@ test.describe("Project Persistence", () => {
       throw new Error("Note not found after move");
     }
 
-    await flushAutoSave(page);
+    await evaluateFlushAutoSave(page);
 
     // Reload and click Continue to restore
     await page.reload();
@@ -266,7 +270,7 @@ test.describe("Project Persistence", () => {
     await page.keyboard.press("Delete");
     await expect(page.locator("[data-testid^='note-']")).toHaveCount(1);
 
-    await flushAutoSave(page);
+    await evaluateFlushAutoSave(page);
 
     // Reload and click Continue to restore
     await page.reload();
@@ -294,7 +298,7 @@ test.describe("Project Persistence", () => {
     const note = page.locator("[data-testid^='note-']").first();
     await expect(note).toHaveAttribute("data-selected", "true");
 
-    await flushAutoSave(page);
+    await evaluateFlushAutoSave(page);
 
     // Reload and click Continue to restore
     await page.reload();
@@ -331,7 +335,7 @@ test.describe("Project Persistence", () => {
     );
     expect(changedScrollX).toBe(25);
 
-    await flushAutoSave(page);
+    await evaluateFlushAutoSave(page);
 
     // Reload and click Continue to restore
     await page.reload();

--- a/e2e/persistence.spec.ts
+++ b/e2e/persistence.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { clickContinue, clickNewProject } from "./helpers";
+import { clickContinue, clickNewProject, flushAutoSave } from "./helpers";
 
 // Constants matching piano-roll.tsx
 const BEAT_WIDTH = 80;
@@ -34,7 +34,9 @@ test.describe("Project Persistence", () => {
     const note = page.locator("[data-testid^='note-']");
     await expect(note).toHaveCount(1);
 
-    // Wait for auto-save
+    // Wait out the real debounce (50ms via VITE_AUTO_SAVE_DEBOUNCE_MS). This
+    // test intentionally covers the debounced auto-save path end-to-end;
+    // other tests use flushAutoSave() instead.
     await page.waitForTimeout(100);
 
     // Reload the page and click Continue to restore
@@ -96,8 +98,7 @@ test.describe("Project Persistence", () => {
     // Verify 3 notes exist
     await expect(page.locator("[data-testid^='note-']")).toHaveCount(3);
 
-    // Wait for auto-save
-    await page.waitForTimeout(100);
+    await flushAutoSave(page);
 
     // Reload and click Continue to restore
     await page.reload();
@@ -124,8 +125,7 @@ test.describe("Project Persistence", () => {
     const waveform = page.locator(".bg-emerald-700, .bg-emerald-600").first();
     await expect(waveform).toBeVisible();
 
-    // Wait for auto-save
-    await page.waitForTimeout(100);
+    await flushAutoSave(page);
 
     // Reload and click Continue to restore
     await page.reload();
@@ -158,8 +158,7 @@ test.describe("Project Persistence", () => {
     await metronomeToggle.click();
     await expect(metronomeToggle).toHaveAttribute("aria-pressed", "false");
 
-    // Wait for auto-save
-    await page.waitForTimeout(100);
+    await flushAutoSave(page);
 
     // Reload and click Continue to restore
     await page.reload();
@@ -211,8 +210,7 @@ test.describe("Project Persistence", () => {
       throw new Error("Note not found after move");
     }
 
-    // Wait for auto-save
-    await page.waitForTimeout(100);
+    await flushAutoSave(page);
 
     // Reload and click Continue to restore
     await page.reload();
@@ -268,8 +266,7 @@ test.describe("Project Persistence", () => {
     await page.keyboard.press("Delete");
     await expect(page.locator("[data-testid^='note-']")).toHaveCount(1);
 
-    // Wait for auto-save
-    await page.waitForTimeout(100);
+    await flushAutoSave(page);
 
     // Reload and click Continue to restore
     await page.reload();
@@ -297,8 +294,7 @@ test.describe("Project Persistence", () => {
     const note = page.locator("[data-testid^='note-']").first();
     await expect(note).toHaveAttribute("data-selected", "true");
 
-    // Wait for auto-save
-    await page.waitForTimeout(100);
+    await flushAutoSave(page);
 
     // Reload and click Continue to restore
     await page.reload();
@@ -335,8 +331,7 @@ test.describe("Project Persistence", () => {
     );
     expect(changedScrollX).toBe(25);
 
-    // Wait for auto-save
-    await page.waitForTimeout(100);
+    await flushAutoSave(page);
 
     // Reload and click Continue to restore
     await page.reload();

--- a/e2e/startup-screen.spec.ts
+++ b/e2e/startup-screen.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { evaluateStore } from "./helpers";
+import { evaluateStore, flushAutoSave } from "./helpers";
 
 test.describe("Startup Screen", () => {
   test.beforeEach(async ({ page }) => {
@@ -57,8 +57,7 @@ test.describe("Startup Screen", () => {
       store.getState().setTempo(140);
     });
 
-    // Wait for auto-save
-    await page.waitForTimeout(100);
+    await flushAutoSave(page);
 
     // Reload - continue button should now be visible
     await page.reload();
@@ -93,7 +92,7 @@ test.describe("Startup Screen", () => {
         velocity: 90,
       });
     });
-    await page.waitForTimeout(600);
+    await flushAutoSave(page);
 
     // With saved project, Space should continue
     await page.reload();

--- a/e2e/startup-screen.spec.ts
+++ b/e2e/startup-screen.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { evaluateStore, flushAutoSave } from "./helpers";
+import { evaluateStore, evaluateFlushAutoSave } from "./helpers";
 
 test.describe("Startup Screen", () => {
   test.beforeEach(async ({ page }) => {
@@ -57,7 +57,7 @@ test.describe("Startup Screen", () => {
       store.getState().setTempo(140);
     });
 
-    await flushAutoSave(page);
+    await evaluateFlushAutoSave(page);
 
     // Reload - continue button should now be visible
     await page.reload();
@@ -92,7 +92,7 @@ test.describe("Startup Screen", () => {
         velocity: 90,
       });
     });
-    await flushAutoSave(page);
+    await evaluateFlushAutoSave(page);
 
     // With saved project, Space should continue
     await page.reload();

--- a/e2e/undo-redo.spec.ts
+++ b/e2e/undo-redo.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { clickNewProject, flushAutoSave } from "./helpers";
+import { clickNewProject, evaluateFlushAutoSave } from "./helpers";
 
 // Constants matching piano-roll.tsx
 const BEAT_WIDTH = 80;
@@ -316,7 +316,7 @@ test.describe("Undo/Redo", () => {
     await page.mouse.up();
     await expect(note).toHaveCount(1);
 
-    await flushAutoSave(page);
+    await evaluateFlushAutoSave(page);
 
     // Reload page (which will load project from localStorage)
     await page.reload();

--- a/e2e/undo-redo.spec.ts
+++ b/e2e/undo-redo.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { clickNewProject } from "./helpers";
+import { clickNewProject, flushAutoSave } from "./helpers";
 
 // Constants matching piano-roll.tsx
 const BEAT_WIDTH = 80;
@@ -316,8 +316,7 @@ test.describe("Undo/Redo", () => {
     await page.mouse.up();
     await expect(note).toHaveCount(1);
 
-    // Wait for auto-save (debounced at 500ms)
-    await page.waitForTimeout(600);
+    await flushAutoSave(page);
 
     // Reload page (which will load project from localStorage)
     await page.reload();

--- a/src/e2e.d.ts
+++ b/src/e2e.d.ts
@@ -1,3 +1,4 @@
+import type { flushAutoSave } from "./lib/project-session";
 import type { projectStorage, seedProjectV1 } from "./lib/project-storage";
 import type { useProjectStore } from "./stores/project-store";
 
@@ -7,6 +8,7 @@ declare global {
       useProjectStore: typeof useProjectStore;
       projectStorage: typeof projectStorage;
       seedProjectV1: typeof seedProjectV1;
+      flushAutoSave: typeof flushAutoSave;
     };
   }
 }

--- a/src/lib/project-session.ts
+++ b/src/lib/project-session.ts
@@ -15,6 +15,14 @@ export interface ProjectSession {
   dispose: () => void;
 }
 
+// Auto-save debouncer of the active session, so e2e tests can force a save
+// instead of waiting out the debounce.
+let activeSaveDebouncer: { flush: () => void } | undefined;
+
+export function flushAutoSave() {
+  activeSaveDebouncer?.flush();
+}
+
 // Open a project as the active document: hydrate the store, load audio
 // assets, and wire project-scoped subscriptions. dispose() undoes the wiring
 // so another project can be opened without a page reload.
@@ -77,6 +85,7 @@ export async function openProjectSession(options: {
     }
   }, autoSaveDebounceMs);
   const unsubscribeAutoSave = useProjectStore.subscribe(saveDebouncer.schedule);
+  activeSaveDebouncer = saveDebouncer;
 
   return {
     projectId,
@@ -85,6 +94,7 @@ export async function openProjectSession(options: {
       unsubscribeAudioSync();
       unsubscribeAutoSave();
       saveDebouncer.flush();
+      activeSaveDebouncer = undefined;
       historyStore.clearHistory();
     },
   };

--- a/src/lib/project-session.ts
+++ b/src/lib/project-session.ts
@@ -15,14 +15,6 @@ export interface ProjectSession {
   dispose: () => void;
 }
 
-// Auto-save debouncer of the active session, so e2e tests can force a save
-// instead of waiting out the debounce.
-let activeSaveDebouncer: { flush: () => void } | undefined;
-
-export function flushAutoSave() {
-  activeSaveDebouncer?.flush();
-}
-
 // Open a project as the active document: hydrate the store, load audio
 // assets, and wire project-scoped subscriptions. dispose() undoes the wiring
 // so another project can be opened without a page reload.
@@ -98,4 +90,12 @@ export async function openProjectSession(options: {
       historyStore.clearHistory();
     },
   };
+}
+
+// Auto-save debouncer of the active session, so e2e tests can force a save
+// instead of waiting out the debounce.
+let activeSaveDebouncer: ReturnType<typeof debounce> | undefined;
+
+export function flushAutoSave() {
+  activeSaveDebouncer?.flush();
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import "./index.css";
 import oxisynthWasmUrl from "./assets/oxisynth/oxisynth.wasm?url";
 import oxisynthWorkletUrl from "./assets/oxisynth/worklet.js?url";
 import soundfontUrl from "./assets/soundfonts/A320U.sf2?url";
+import { flushAutoSave } from "./lib/project-session";
 import { projectStorage, seedProjectV1 } from "./lib/project-storage";
 import { useProjectStore } from "./stores/project-store";
 
@@ -17,6 +18,7 @@ function main() {
       useProjectStore,
       projectStorage,
       seedProjectV1,
+      flushAutoSave,
     };
     if (window.location.pathname.startsWith("/__e2e__/")) {
       return;


### PR DESCRIPTION
## Summary

E2E specs had stale `waitForTimeout(600)` calls sized for the old 500ms auto-save debounce — the debounce has been 50ms in e2e since #39 (`VITE_AUTO_SAVE_DEBOUNCE_MS`), so each wait burned ~550ms for nothing (~5-6s per run across 10 call sites).

- Expose `flushAutoSave()` on `window.__e2e` (backed by a module-level ref to the active session's save debouncer in `project-session.ts`) so tests force the pending save instead of sleeping
- Add `evaluateFlushAutoSave(page)` helper (named after the existing `evaluateStore` pattern) and replace the 600ms waits plus most 100ms auto-save waits with it
- Keep one real timing wait in `persistence.spec.ts` ("notes persist after reload") so the debounced auto-save path stays covered end-to-end
- Non-auto-save waits (audio load, timestamp spacing, rename UI) untouched

## Test plan

- [x] `pnpm lint`
- [x] `pnpm test` (35 passed)
- [x] `pnpm test-e2e` (92 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)