### PR TITLE
fix: show audio offset label with millisecond precision

### DIFF
--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -1993,7 +1993,7 @@ function WaveformArea({
           <div className="absolute left-1 top-0.5 text-[10px] text-emerald-200 whitespace-nowrap z-10">
             {audioFileName && <span className="mr-1.5">{audioFileName}</span>}
             {audioOffset > 0 && (
-              <span className="opacity-75">+{audioOffset.toFixed(1)}s</span>
+              <span className="opacity-75">+{audioOffset.toFixed(3)}s</span>
             )}
           </div>
         </div>


### PR DESCRIPTION
The audio track offset label rendered with `toFixed(1)`, so it only showed 100ms granularity while the stored offset is a full-precision float. That is too coarse for audio alignment, and a small offset like 0.04s displayed as a confusing `+0.0s`.

Render the label with `toFixed(3)` instead, e.g. `+1.237s`.

Display-only change, because playback and waveform positioning already use the raw float. E2E tests assert offsets via store state rather than the label text, so no test updates are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)