### PR TITLE
feat: quantize selected notes to grid

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,6 +96,8 @@ Serialization lives next to the store: `SavedProject` (version 2), `toSavedProje
 
 Undo/redo: `historyStore` is a plain object holding note-operation entries (`add/delete/update`, max 50), used only by project-store actions, so React never subscribes to it. Only note operations are undoable; locators, audio tracks, tempo, and mixer are not.
 
+Selected notes can be quantized with `Q`; the command snaps their starts and durations to the active grid as one undoable batch update, with a minimum duration of one grid unit.
+
 ## Audio Layer
 
 `AudioManager` (`lib/audio.ts`, singleton `audioManager`) owns the Tone.js graph: an OxiSynth SF2 worklet behind a `Tone.Channel` for MIDI, one `Tone.Player` + `Tone.Channel` per audio track, and a raw Web Audio metronome driven by a `Tone.Sequence`.

--- a/e2e/quantize.spec.ts
+++ b/e2e/quantize.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+import { clickNewProject, evaluateStore } from "./helpers";
+
+test("quantizes selected notes to the current grid and can undo", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await clickNewProject(page);
+
+  await evaluateStore(page, (store) => {
+    store.setState({
+      gridSnap: "1/8",
+      notes: [
+        { id: "n1", pitch: 60, start: 0.3, duration: 0.2, velocity: 100 },
+        { id: "n2", pitch: 64, start: 1.2, duration: 0.8, velocity: 100 },
+      ],
+      selectedNoteIds: new Set(["n1", "n2"]),
+    });
+  });
+
+  await page.keyboard.press("q");
+
+  expect(
+    await evaluateStore(page, (store) =>
+      store
+        .getState()
+        .notes.map(({ start, duration }) => ({ start, duration })),
+    ),
+  ).toEqual([
+    { start: 0.5, duration: 0.5 },
+    { start: 1, duration: 1 },
+  ]);
+
+  await page.keyboard.press("Control+z");
+
+  expect(
+    await evaluateStore(page, (store) =>
+      store
+        .getState()
+        .notes.map(({ start, duration }) => ({ start, duration })),
+    ),
+  ).toEqual([
+    { start: 0.3, duration: 0.2 },
+    { start: 1.2, duration: 0.8 },
+  ]);
+});

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -254,6 +254,7 @@ export function PianoRoll() {
     autoScrollEnabled,
     addNote,
     updateNote,
+    quantizeSelectedNotes,
     deleteNotes,
     selectNotes,
     deselectAll,
@@ -466,6 +467,8 @@ export function PianoRoll() {
       if (canUndo()) {
         undo();
       }
+    } else if (matchKeyboardEvent(e, "Q")) {
+      quantizeSelectedNotes();
     } else if (matchKeyboardEvent(e, "L")) {
       // L: Add locator at current playhead position
       const playheadBeat = secondsToBeats(position, tempo);

--- a/src/lib/keybindings.ts
+++ b/src/lib/keybindings.ts
@@ -78,6 +78,11 @@ export const KEYBOARD_SHORTCUTS: KeyBinding[] = [
     category: "editing",
   },
   {
+    key: "Q",
+    description: "Quantize selected notes",
+    category: "editing",
+  },
+  {
     key: "L",
     description: "Add locator at playhead",
     category: "editing",

--- a/src/stores/project-store.ts
+++ b/src/stores/project-store.ts
@@ -281,17 +281,20 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   quantizeSelectedNotes: () => {
     const state = get();
     const gridSize = GRID_SNAP_VALUES[state.gridSnap];
-    const updates = state.notes.flatMap((note) => {
+    const updates: {
+      id: string;
+      changes: Partial<Omit<Note, "id">>;
+    }[] = [];
+    for (const note of state.notes) {
       if (!state.selectedNoteIds.has(note.id)) {
-        return [];
+        continue;
       }
       const start = snapToGrid(note.start, gridSize);
       const duration = Math.max(gridSize, snapToGrid(note.duration, gridSize));
-      if (start === note.start && duration === note.duration) {
-        return [];
+      if (start !== note.start || duration !== note.duration) {
+        updates.push({ id: note.id, changes: { start, duration } });
       }
-      return [{ id: note.id, changes: { start, duration } }];
-    });
+    }
     if (updates.length > 0) {
       state.updateNotes(updates);
     }

--- a/src/stores/project-store.ts
+++ b/src/stores/project-store.ts
@@ -1,6 +1,13 @@
 import { create } from "zustand";
 import type { AudioView } from "../lib/audio-view";
-import type { GridSnap, Locator, Note, TimeSignature } from "../types";
+import { snapToGrid } from "../lib/music";
+import {
+  GRID_SNAP_VALUES,
+  type GridSnap,
+  type Locator,
+  type Note,
+  type TimeSignature,
+} from "../types";
 import { historyStore } from "./history-store";
 
 export interface ProjectState {
@@ -55,6 +62,7 @@ export interface ProjectState {
     updates: { id: string; changes: Partial<Omit<Note, "id">> }[],
   ) => void; // Batch update for history tracking
   deleteNotes: (ids: string[]) => void;
+  quantizeSelectedNotes: () => void;
   selectNotes: (ids: string[], exclusive?: boolean) => void;
   deselectAll: () => void;
   setGridSnap: (snap: GridSnap) => void;
@@ -268,6 +276,25 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         selectedNoteIds: newSelected,
       };
     });
+  },
+
+  quantizeSelectedNotes: () => {
+    const state = get();
+    const gridSize = GRID_SNAP_VALUES[state.gridSnap];
+    const updates = state.notes.flatMap((note) => {
+      if (!state.selectedNoteIds.has(note.id)) {
+        return [];
+      }
+      const start = snapToGrid(note.start, gridSize);
+      const duration = Math.max(gridSize, snapToGrid(note.duration, gridSize));
+      if (start === note.start && duration === note.duration) {
+        return [];
+      }
+      return [{ id: note.id, changes: { start, duration } }];
+    });
+    if (updates.length > 0) {
+      state.updateNotes(updates);
+    }
   },
 
   selectNotes: (ids, exclusive = true) =>


### PR DESCRIPTION
## Summary

- add an undoable store action that quantizes selected note starts and durations to the active grid
- bind the command to Q and include it in the keyboard shortcut help
- cover quantization and undo in one focused E2E scenario

## Testing

- pnpm lint
- pnpm test-e2e e2e/quantize.spec.ts --timeout 5000 -x

Closes #177