### PR TITLE
feat: model per-track waveform state as a discriminated union

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,7 +80,13 @@ interface AudioTrack {
   offset: number; // seconds
   volume: number;
   muted: boolean;
-  audioView: AudioView | null; // transient, not persisted
+  // transient, not persisted: pending → pale region; ready → waveform;
+  // unavailable → no waveform, still plays (too-long bailout); error → dead
+  audioWaveform:
+    | { status: "pending" }
+    | { status: "ready"; view: AudioView }
+    | { status: "unavailable" }
+    | { status: "error" };
 }
 ```
 

--- a/e2e/audio-tracks.spec.ts
+++ b/e2e/audio-tracks.spec.ts
@@ -166,9 +166,8 @@ test.describe("Multiple Audio Tracks", () => {
       });
     });
 
-    await expect(page.getByTestId("audio-track-region")).toHaveAttribute(
-      "title",
-      "Audio failed to load",
-    );
+    const region = page.getByTestId("audio-track-region");
+    await expect(region).toContainText("failed to load");
+    await expect(region).toHaveAttribute("title", "Audio failed to load");
   });
 });

--- a/e2e/audio-tracks.spec.ts
+++ b/e2e/audio-tracks.spec.ts
@@ -153,4 +153,22 @@ test.describe("Multiple Audio Tracks", () => {
       "bass.wav",
     ]);
   });
+
+  test("renders a failed audio restore as a dead region", async ({ page }) => {
+    await loadAudioFile(page, "test-audio.wav");
+
+    // Force the error state directly; a real decode failure is not
+    // reproducible deterministically in e2e
+    await evaluateStore(page, (store) => {
+      const track = store.getState().audioTracks[0];
+      store.getState().updateAudioTrack(track.id, {
+        audioWaveform: { status: "error" },
+      });
+    });
+
+    await expect(page.getByTestId("audio-track-region")).toHaveAttribute(
+      "title",
+      "Audio failed to load",
+    );
+  });
 });

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -2005,9 +2005,16 @@ function WaveformArea({
                 pixelWidth={Math.max(1, Math.round(audioWidth))}
               />
             )}
-          {/* File name and offset indicator */}
+          {/* File name, status, and offset indicator (pending is indicated
+              by the pale region color alone) */}
           <div className="absolute left-1 top-0.5 text-[10px] text-emerald-200 whitespace-nowrap z-10">
             {audioFileName && <span className="mr-1.5">{audioFileName}</span>}
+            {audioWaveform.status === "error" && (
+              <span className="mr-1.5 text-red-300">failed to load</span>
+            )}
+            {audioWaveform.status === "unavailable" && (
+              <span className="mr-1.5 opacity-75">no waveform</span>
+            )}
             {audioOffset > 0 && (
               <span className="opacity-75">+{audioOffset.toFixed(3)}s</span>
             )}

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -25,6 +25,7 @@ import { dbToPercent, gainToPercent, percentToGain } from "../lib/volume";
 import { historyStore } from "../stores/history-store";
 import {
   beatsToSeconds,
+  type AudioWaveform,
   generateLocatorId,
   generateNoteId,
   secondsToBeats,
@@ -1264,7 +1265,7 @@ export function PianoRoll() {
               audioFileName={track.fileName}
               tempo={tempo}
               playheadBeat={secondsToBeats(position, tempo)}
-              audioView={track.audioView}
+              audioWaveform={track.audioWaveform}
               height={waveformHeight}
               beatsPerBar={beatsPerBar}
               isSelected={selectedAudioTrackId === track.id}
@@ -1824,7 +1825,7 @@ function WaveformArea({
   audioFileName,
   tempo,
   playheadBeat,
-  audioView,
+  audioWaveform,
   height,
   beatsPerBar,
   isSelected,
@@ -1842,7 +1843,7 @@ function WaveformArea({
   audioFileName: string | null;
   tempo: number;
   playheadBeat: number;
-  audioView: AudioView | null;
+  audioWaveform: AudioWaveform;
   height: number;
   beatsPerBar: number;
   isSelected: boolean;
@@ -1966,19 +1967,26 @@ function WaveformArea({
       className="relative shrink-0 border-b border-neutral-700 overflow-hidden"
       style={{ height, ...gridBackgroundStyle }}
     >
-      {/* Audio region block. Pale while audioView is null (asset not
-          restored yet); EMPTY_AUDIO_VIEW renders normal color with no
-          waveform (too-long bailout or failed restore, see #182). */}
+      {/* Audio region block: pale while pending (asset restoring), reddish
+          when the restore failed (dead track), normal color with no waveform
+          when unavailable (too-long bailout, still playable). */}
       {audioDuration > 0 && (
         <div
           data-testid="audio-track-region"
           data-track-id={trackId}
+          title={
+            audioWaveform.status === "error"
+              ? "Audio failed to load"
+              : undefined
+          }
           className={`absolute top-1 bottom-1 rounded cursor-ew-resize overflow-hidden opacity-75 ${
-            audioView === null
+            audioWaveform.status === "pending"
               ? "bg-emerald-800/40"
-              : isDragging
-                ? "bg-emerald-600"
-                : "bg-emerald-700 hover:bg-emerald-600"
+              : audioWaveform.status === "error"
+                ? "bg-red-900/30"
+                : isDragging
+                  ? "bg-emerald-600"
+                  : "bg-emerald-700 hover:bg-emerald-600"
           } ${isSelected ? "ring-2 ring-sky-400" : ""}`}
           style={{
             left: audioStartX,
@@ -1987,15 +1995,16 @@ function WaveformArea({
           onMouseDown={handleMouseDown}
         >
           {/* Waveform SVG */}
-          {audioView && audioView.data.length > 0 && (
-            <Waveform
-              audioView={audioView}
-              audioDuration={audioDuration}
-              visibleStart={audioVisibleStart}
-              visibleEnd={audioVisibleEnd}
-              pixelWidth={Math.max(1, Math.round(audioWidth))}
-            />
-          )}
+          {audioWaveform.status === "ready" &&
+            audioWaveform.view.data.length > 0 && (
+              <Waveform
+                audioView={audioWaveform.view}
+                audioDuration={audioDuration}
+                visibleStart={audioVisibleStart}
+                visibleEnd={audioVisibleEnd}
+                pixelWidth={Math.max(1, Math.round(audioWidth))}
+              />
+            )}
           {/* File name and offset indicator */}
           <div className="absolute left-1 top-0.5 text-[10px] text-emerald-200 whitespace-nowrap z-10">
             {audioFileName && <span className="mr-1.5">{audioFileName}</span>}

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -112,7 +112,9 @@ export function Settings({ projectName, onProjectNameChange }: SettingsProps) {
           offset: 0,
           volume: 0.8,
           muted: false,
-          audioView,
+          audioWaveform: audioView
+            ? { status: "ready", view: audioView }
+            : { status: "unavailable" },
         });
       }
     },

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -5,11 +5,7 @@ import oxisynthWorkletUrl from "../assets/oxisynth/worklet.js?url";
 import soundfontUrl from "../assets/soundfonts/A320U.sf2?url";
 import type { AudioTrack, ProjectState } from "../stores/project-store";
 import type { Note } from "../types";
-import {
-  type AudioView,
-  createAudioView,
-  EMPTY_AUDIO_VIEW,
-} from "./audio-view";
+import { type AudioView, createAudioView } from "./audio-view";
 import { Metronome } from "./metronome";
 import { OxiSynthSynth } from "./oxisynth-synth";
 import { clampGain } from "./volume";
@@ -538,10 +534,12 @@ const POINTS_PER_SECOND = 800;
 // At 48kHz, 60 min = 172.8M samples → ~300-600ms extraction (too slow)
 const MAX_AUDIO_DURATION_SECONDS = 600; // 10 minutes
 
-// Load audio file and create AudioView for waveform display
+// Load audio file and create AudioView for waveform display.
+// audioView is null when the waveform is skipped (too-long bailout); callers
+// map that to AudioWaveform "unavailable".
 export async function loadAudioFile(file: File): Promise<{
   buffer: Tone.ToneAudioBuffer;
-  audioView: AudioView;
+  audioView: AudioView | null;
   duration: number;
 }> {
   const url = URL.createObjectURL(file);
@@ -555,7 +553,7 @@ export async function loadAudioFile(file: File): Promise<{
       );
       return {
         buffer,
-        audioView: EMPTY_AUDIO_VIEW,
+        audioView: null,
         duration: buffer.duration,
       };
     }

--- a/src/lib/project-session.ts
+++ b/src/lib/project-session.ts
@@ -9,7 +9,6 @@ import {
 } from "../stores/project-store";
 import { debounce } from "../utils/timing";
 import { audioManager, loadAudioFile } from "./audio";
-import { EMPTY_AUDIO_VIEW } from "./audio-view";
 import { isShortcutTextInputTarget, matchKeyboardEvent } from "./keyboard";
 import { projectStorage } from "./project-storage";
 
@@ -163,11 +162,9 @@ async function restoreAudioTracks(
   for (const { track, loaded } of loads) {
     if (loaded === "failed") {
       toast.error(`Failed to load audio "${track.fileName}".`);
-      // Mark the waveform unavailable so `audioView === null` stays
-      // pending-only and the region doesn't read as loading forever.
-      // TODO(#182): model restore failure explicitly (distinct from the
-      // too-long waveform bailout) so the region can render the track as dead.
-      project.updateAudioTrack(track.id, { audioView: EMPTY_AUDIO_VIEW });
+      project.updateAudioTrack(track.id, {
+        audioWaveform: { status: "error" },
+      });
     } else if (!loaded) {
       toast.warning(
         `Audio asset not found for "${track.fileName}". The track will be cleared.`,
@@ -175,7 +172,11 @@ async function restoreAudioTracks(
       project.deleteAudioTrack(track.id);
     } else {
       audioManager.attachTrackBuffer(track.id, loaded.buffer, track.offset);
-      project.updateAudioTrack(track.id, { audioView: loaded.audioView });
+      project.updateAudioTrack(track.id, {
+        audioWaveform: loaded.audioView
+          ? { status: "ready", view: loaded.audioView }
+          : { status: "unavailable" },
+      });
     }
   }
 }

--- a/src/stores/project-store.test.ts
+++ b/src/stores/project-store.test.ts
@@ -10,7 +10,7 @@ function makeAudioTrack(id: string, offset: number): AudioTrack {
     offset,
     volume: 1,
     muted: false,
-    audioView: null,
+    audioWaveform: { status: "pending" },
   };
 }
 

--- a/src/stores/project-store.ts
+++ b/src/stores/project-store.ts
@@ -116,6 +116,15 @@ export interface ProjectState {
   setWaveformHeight: (height: number) => void;
 }
 
+// Transient per-track waveform state, not persisted. "unavailable" means the
+// waveform is intentionally skipped (too-long bailout) but the track plays;
+// "error" means asset restore failed and the track is unplayable.
+export type AudioWaveform =
+  | { status: "pending" }
+  | { status: "ready"; view: AudioView }
+  | { status: "unavailable" }
+  | { status: "error" };
+
 export interface AudioTrack {
   id: string;
   fileName: string;
@@ -124,7 +133,7 @@ export interface AudioTrack {
   offset: number; // in seconds - timeline position where audio starts (>= 0)
   volume: number; // 0-1
   muted: boolean;
-  audioView: AudioView | null; // Pre-computed waveform data (not persisted)
+  audioWaveform: AudioWaveform;
 }
 
 let noteIdCounter = 0;
@@ -588,7 +597,7 @@ export interface SavedProject {
   waveformHeight?: number;
 }
 
-export type SavedAudioTrack = Omit<AudioTrack, "audioView">;
+export type SavedAudioTrack = Omit<AudioTrack, "audioWaveform">;
 
 export type SavedProjectV1 = Omit<SavedProject, "version" | "audioTracks"> & {
   version: 1;
@@ -640,7 +649,7 @@ export function toSavedProject(state: ProjectState): SavedProject {
     locators: state.locators,
     audioTracks: state.audioTracks.map(
       // Strip transient waveform data
-      ({ audioView: _audioView, ...track }) => track,
+      ({ audioWaveform: _audioWaveform, ...track }) => track,
     ),
     midiVolume: state.midiVolume,
     midiMuted: state.midiMuted,
@@ -721,7 +730,10 @@ export function fromSavedProject(data: AnySavedProject): Partial<ProjectState> {
     gridSnap: merged.gridSnap,
     locators: merged.locators ?? DEFAULTS.locators,
     // Reattach transient waveform data slot (loaded lazily on project open)
-    audioTracks: merged.audioTracks.map((t) => ({ ...t, audioView: null })),
+    audioTracks: merged.audioTracks.map((t) => ({
+      ...t,
+      audioWaveform: { status: "pending" as const },
+    })),
     midiVolume: merged.midiVolume,
     midiMuted: merged.midiMuted ?? DEFAULTS.midiMuted,
     midiProgram: merged.midiProgram ?? DEFAULTS.midiProgram,


### PR DESCRIPTION
Closes #182. Follow-up to #181.

## What

Replaces `AudioTrack.audioView`'s nullable-plus-sentinel encoding (three values carrying four semantic states) with one discriminated union field:

```ts
audioWaveform:
  | { status: "pending" }      // asset restoring → pale region
  | { status: "ready"; view }  // waveform renders
  | { status: "unavailable" }  // too-long bailout: no waveform, still plays
  | { status: "error" }        // restore failed: dead reddish region + tooltip
```

- Invalid combinations are unrepresentable; the region render is a status switch.
- `loadAudioFile` returns `audioView: null` on the too-long bailout, and call sites (upload, session restore) map it to `unavailable`; `EMPTY_AUDIO_VIEW` is no longer used as a state signal (it remains `audio-view.ts`-internal for empty-input semantics).
- A failed restore now renders visually dead (`bg-red-900/30`, "Audio failed to load" tooltip) instead of looking identical to a healthy long track. Pale stays reserved for pending.
- Transient as before: stripped in `toSavedProject`, reattached as `pending` in `fromSavedProject`.

## Testing

- New e2e: forces `{ status: "error" }` via the typed `__e2e` store (a real decode failure isn't deterministically reproducible) and asserts the dead-region tooltip.
- Full suite: lint/typecheck, 41 unit, 99 e2e passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)