### PR TITLE
docs: define top-down function ordering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Planned work and known bugs live in GitHub issues, minor code-level nits as inli
 - Commit messages: use Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`); add `!` for breaking changes
 - File names: kebab-case
 - Keep cohesive implementation together, and split files only for reuse or a clear module boundary
+- Order functions by reading flow, with primary entry points and callers before their implementation helpers
 - Prefer `undefined` over `null`
 - Prefer optional properties (`{ x?: T }`) over explicit undefined (`{ x: T | undefined }`)
 - Make props/params required when all call sites always pass them

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Planned work and known bugs live in GitHub issues, minor code-level nits as inli
 
 - Commit messages: use Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`); add `!` for breaking changes
 - File names: kebab-case
+- Prefer the smallest correct change, and avoid speculative abstractions or compatibility paths
 - Keep cohesive implementation together, and split files only for reuse or a clear module boundary
 - Order functions by reading flow, with primary entry points and callers before their implementation helpers
 - Prefer `undefined` over `null`


### PR DESCRIPTION
## Summary

- document the repository preference for reading-flow function order
- put primary entry points and callers before implementation helpers

## Testing

- `pnpm lint`