### PR TITLE
feat: add master output control

### DIFF
--- a/e2e/persistence.spec.ts
+++ b/e2e/persistence.spec.ts
@@ -3,6 +3,7 @@ import {
   waitForEditor,
   clickNewProject,
   evaluateFlushAutoSave,
+  evaluateStore,
 } from "./helpers";
 
 // Constants matching piano-roll.tsx
@@ -162,6 +163,15 @@ test.describe("Project Persistence", () => {
     await metronomeToggle.click();
     await expect(metronomeToggle).toHaveAttribute("aria-pressed", "false");
 
+    // Change master volume
+    await evaluateStore(page, (store) => {
+      store.getState().setMasterVolume(0.75);
+    });
+    await expect(page.getByTestId("master-volume-slider")).toHaveAttribute(
+      "data-slot",
+      "slider",
+    );
+
     await evaluateFlushAutoSave(page);
 
     // Reload and click Continue to restore
@@ -175,6 +185,9 @@ test.describe("Project Persistence", () => {
       "aria-pressed",
       "false",
     );
+    expect(
+      await evaluateStore(page, (store) => store.getState().masterVolume),
+    ).toBe(0.75);
   });
 
   test("note edits persist after reload", async ({ page }) => {

--- a/e2e/persistence.spec.ts
+++ b/e2e/persistence.spec.ts
@@ -159,9 +159,9 @@ test.describe("Project Persistence", () => {
 
     // Enable metronome
     const metronomeToggle = page.getByTestId("metronome-mute-toggle");
-    await expect(metronomeToggle).toHaveAttribute("aria-pressed", "true");
-    await metronomeToggle.click();
     await expect(metronomeToggle).toHaveAttribute("aria-pressed", "false");
+    await metronomeToggle.click();
+    await expect(metronomeToggle).toHaveAttribute("aria-pressed", "true");
 
     // Change master volume
     await evaluateStore(page, (store) => {
@@ -183,7 +183,7 @@ test.describe("Project Persistence", () => {
     await expect(page.getByTestId("grid-snap-select")).toContainText("1/16");
     await expect(page.getByTestId("metronome-mute-toggle")).toHaveAttribute(
       "aria-pressed",
-      "false",
+      "true",
     );
     expect(
       await evaluateStore(page, (store) => store.getState().masterVolume),

--- a/e2e/transport.spec.ts
+++ b/e2e/transport.spec.ts
@@ -70,16 +70,16 @@ test.describe("Transport Controls", () => {
   test("metronome toggle", async ({ page }) => {
     const metronomeToggle = page.getByTestId("metronome-mute-toggle");
 
-    // Toggle is "pressed" when muted. Metronome starts muted.
-    await expect(metronomeToggle).toHaveAttribute("aria-pressed", "true");
-
-    // Unmute
-    await metronomeToggle.click();
+    // Metronome starts disabled.
     await expect(metronomeToggle).toHaveAttribute("aria-pressed", "false");
 
-    // Mute
+    // Enable
     await metronomeToggle.click();
     await expect(metronomeToggle).toHaveAttribute("aria-pressed", "true");
+
+    // Disable
+    await metronomeToggle.click();
+    await expect(metronomeToggle).toHaveAttribute("aria-pressed", "false");
   });
 
   test("mixer dB input", async ({ page }) => {

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -249,10 +249,9 @@ export function PianoRoll() {
     timeSignature,
     audioTracks,
     selectedAudioTrackId,
+    masterVolume,
     midiVolume,
-    metronomeVolume,
     midiMuted,
-    metronomeEnabled,
     showDebug,
     autoScrollEnabled,
     addNote,
@@ -289,10 +288,9 @@ export function PianoRoll() {
     setPixelsPerBeat,
     setPixelsPerKey,
     setWaveformHeight,
+    setMasterVolume,
     setMidiVolume,
-    setMetronomeVolume,
     setMidiMuted,
-    setMetronomeEnabled,
   } = useProjectStore();
 
   // Total height of all stacked waveform lanes (each lane uses waveformHeight)
@@ -1085,31 +1083,13 @@ export function PianoRoll() {
             className="shrink-0 flex flex-col"
             style={{ width: TRACK_CONTROL_WIDTH }}
           >
-            {/* Metronome controls */}
+            {/* Master controls */}
             <div
               className="shrink-0 border-b border-neutral-700 p-2 flex flex-col gap-3"
               style={{ height: TIMELINE_HEIGHT }}
             >
               <div className="flex items-center justify-between text-[11px] text-neutral-400">
-                <span className="uppercase tracking-wide">Metro</span>
-                <Toggle
-                  data-testid="metronome-mute-toggle"
-                  value={!metronomeEnabled}
-                  onChange={(muted) => setMetronomeEnabled(!muted)}
-                  aria-label="Toggle metronome mute"
-                  title={
-                    metronomeEnabled
-                      ? "Mute metronome (M)"
-                      : "Unmute metronome (M)"
-                  }
-                  className={cn(
-                    "size-4.5",
-                    !metronomeEnabled &&
-                      "bg-red-900/50 border-red-700 text-red-300 hover:bg-red-900/70 hover:text-red-200",
-                  )}
-                >
-                  M
-                </Toggle>
+                <span className="uppercase tracking-wide">Master</span>
               </div>
               <div className="relative">
                 <div
@@ -1117,8 +1097,9 @@ export function PianoRoll() {
                   style={{ left: `${zeroDbPercent}%` }}
                 />
                 <Slider
-                  value={[gainToPercent(metronomeVolume)]}
-                  onValueChange={([v]) => setMetronomeVolume(percentToGain(v))}
+                  data-testid="master-volume-slider"
+                  value={[gainToPercent(masterVolume)]}
+                  onValueChange={([v]) => setMasterVolume(percentToGain(v))}
                   max={100}
                   step={1}
                 />

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -16,6 +16,7 @@ import { GM_PROGRAMS } from "../lib/general-midi";
 import { isShortcutTextInputTarget, matchKeyboardEvent } from "../lib/keyboard";
 import { useProjectStore } from "../lib/project-store";
 import { COMMON_TIME_SIGNATURES, type GridSnap } from "../types";
+import { MetronomeIcon } from "./icons";
 import { Button } from "./ui/button";
 import {
   Command,
@@ -33,6 +34,7 @@ import {
   DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
+import { Toggle } from "./ui/toggle";
 import { cn } from "./ui/utils";
 
 function formatTimeCompact(seconds: number): string {
@@ -286,6 +288,22 @@ export function Transport({
     >
       {/* Play/Pause button */}
       <PlayPauseButton />
+
+      {/* Metronome mute */}
+      <Toggle
+        data-testid="metronome-mute-toggle"
+        value={!metronomeEnabled}
+        onChange={(muted) => setMetronomeEnabled(!muted)}
+        aria-label="Toggle metronome mute"
+        title={metronomeEnabled ? "Mute metronome (M)" : "Unmute metronome (M)"}
+        className={cn(
+          "size-9",
+          !metronomeEnabled &&
+            "bg-red-900/50 border-red-700 text-red-300 hover:bg-red-900/70 hover:text-red-200",
+        )}
+      >
+        <MetronomeIcon className="size-5" />
+      </Toggle>
 
       {/* Divider */}
       <div className="w-px h-5 bg-border" />

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -34,7 +34,6 @@ import {
   DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
-import { Toggle } from "./ui/toggle";
 import { cn } from "./ui/utils";
 
 function formatTimeCompact(seconds: number): string {
@@ -289,21 +288,21 @@ export function Transport({
       {/* Play/Pause button */}
       <PlayPauseButton />
 
-      {/* Metronome mute */}
-      <Toggle
+      {/* Metronome toggle */}
+      <Button
         data-testid="metronome-mute-toggle"
-        value={!metronomeEnabled}
-        onChange={(muted) => setMetronomeEnabled(!muted)}
-        aria-label="Toggle metronome mute"
-        title={metronomeEnabled ? "Mute metronome (M)" : "Unmute metronome (M)"}
+        onClick={() => setMetronomeEnabled(!metronomeEnabled)}
+        aria-pressed={metronomeEnabled}
+        title="Toggle metronome (M)"
         className={cn(
           "size-9",
-          !metronomeEnabled &&
-            "bg-red-900/50 border-red-700 text-red-300 hover:bg-red-900/70 hover:text-red-200",
+          metronomeEnabled
+            ? "bg-primary text-primary-foreground hover:bg-primary/90"
+            : "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         )}
       >
         <MetronomeIcon className="size-5" />
-      </Toggle>
+      </Button>
 
       {/* Divider */}
       <div className="w-px h-5 bg-border" />

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -42,6 +42,7 @@ export type AudioState = {
  * - Components should update store, not call AudioManager directly
  */
 class AudioManager {
+  private masterChannel!: Tone.Channel;
   private midiSynth!: OxiSynthSynth;
   private midiChannel!: Tone.Channel;
   private midiPart!: Tone.Part;
@@ -74,6 +75,8 @@ class AudioManager {
   private async initInner(): Promise<void> {
     const context = Tone.getContext();
 
+    this.masterChannel = new Tone.Channel(0).toDestination();
+
     // OxiSynth (Rust/WASM) for SF2 playback
     this.midiSynth = new OxiSynthSynth(context);
     await this.midiSynth.init({
@@ -87,7 +90,7 @@ class AudioManager {
     );
 
     // Connect synth output to Channel for volume control
-    this.midiChannel = new Tone.Channel(0).toDestination();
+    this.midiChannel = new Tone.Channel(0).connect(this.masterChannel);
     this.midiSynth.output.connect(this.midiChannel);
 
     this.midiPart = new Tone.Part<{ pitch: number; duration: number }[]>(
@@ -110,7 +113,7 @@ class AudioManager {
 
     // Metronome click generator with native Web Audio nodes.
     this.metronome = new Metronome(context);
-    this.metronomeChannel = new Tone.Channel(0.5).toDestination();
+    this.metronomeChannel = new Tone.Channel(0.5).connect(this.masterChannel);
     Tone.connect(this.metronome.output, this.metronomeChannel);
 
     // Metronome sequence (4/4 with accent on beat 1)
@@ -135,6 +138,7 @@ class AudioManager {
       return;
     }
     // Cheap operations - always apply
+    this.setMasterVolume(state.masterVolume);
     this.setMidiVolume(state.midiVolume);
     this.setMidiMuted(state.midiMuted);
     this.setMetronomeVolume(state.metronomeVolume);
@@ -198,7 +202,7 @@ class AudioManager {
   getAudioTrack(id: string): AudioTrackPlayback {
     let entry = this.audioTracks.get(id);
     if (!entry) {
-      entry = new AudioTrackPlayback();
+      entry = new AudioTrackPlayback(this.masterChannel);
       this.audioTracks.set(id, entry);
     }
     return entry;
@@ -275,6 +279,10 @@ class AudioManager {
   }
 
   // Volume controls (linear gain)
+  setMasterVolume(volume: number): void {
+    this.masterChannel.volume.rampTo(Tone.gainToDb(clampGain(volume)));
+  }
+
   setMidiVolume(volume: number): void {
     this.midiChannel.volume.rampTo(Tone.gainToDb(clampGain(volume)));
   }
@@ -399,12 +407,13 @@ class AudioStateStore {
 
 class AudioTrackPlayback {
   readonly player = new Tone.Player();
-  readonly channel = new Tone.Channel({
-    volume: Tone.gainToDb(clampGain(0.8)),
-    channelCount: 2,
-  }).toDestination();
+  readonly channel: Tone.Channel;
 
-  constructor() {
+  constructor(output: Tone.InputNode) {
+    this.channel = new Tone.Channel({
+      volume: Tone.gainToDb(clampGain(0.8)),
+      channelCount: 2,
+    }).connect(output);
     this.player.connect(this.channel);
   }
 

--- a/src/lib/project-store.test.ts
+++ b/src/lib/project-store.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { type AudioTrack, useProjectStore } from "./project-store";
+import {
+  type AudioTrack,
+  createDefaultSavedProject,
+  fromSavedProject,
+  toSavedProject,
+  useProjectStore,
+} from "./project-store";
 
 function makeAudioTrack(id: string, offset: number): AudioTrack {
   return {
@@ -57,5 +63,20 @@ describe("moveAudioOffset", () => {
   it("ignores unknown track ids", () => {
     useProjectStore.getState().moveAudioOffset("audio-99", 7);
     expect(getOffsets()).toEqual([5, 2]);
+  });
+});
+
+describe("master volume persistence", () => {
+  it("serializes the master volume", () => {
+    useProjectStore.setState({ masterVolume: 0.75 });
+
+    expect(toSavedProject(useProjectStore.getState()).masterVolume).toBe(0.75);
+  });
+
+  it("defaults old projects to unity gain", () => {
+    const project = createDefaultSavedProject();
+    delete project.masterVolume;
+
+    expect(fromSavedProject(project).masterVolume).toBe(1);
   });
 });

--- a/src/lib/project-store.ts
+++ b/src/lib/project-store.ts
@@ -33,6 +33,7 @@ export interface ProjectState {
   selectedAudioTrackId?: string; // not persisted
 
   // Mixer state
+  masterVolume: number;
   midiVolume: number; // 0-1
   midiMuted: boolean;
   midiProgram: number; // GM program number 0-127
@@ -97,6 +98,7 @@ export interface ProjectState {
   moveAudioOffset: (id: string, offset: number) => void;
 
   // Mixer actions
+  setMasterVolume: (volume: number) => void;
   setMidiVolume: (volume: number) => void;
   setMidiMuted: (muted: boolean) => void;
   setMidiProgram: (program: number) => void;
@@ -169,6 +171,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   selectedAudioTrackId: undefined,
 
   // Mixer state
+  masterVolume: 1,
   midiVolume: 0.8,
   midiMuted: false,
   midiProgram: 0, // Acoustic Grand Piano
@@ -400,6 +403,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   },
 
   // Mixer actions
+  setMasterVolume: (volume) => set({ masterVolume: volume }),
   setMidiVolume: (volume) => set({ midiVolume: volume }),
   setMidiMuted: (muted) => set({ midiMuted: muted }),
   setMidiProgram: (program) => set({ midiProgram: program }),
@@ -584,6 +588,7 @@ export interface SavedProject {
   gridSnap: GridSnap;
   locators?: Locator[]; // Optional for backward compatibility
   audioTracks: SavedAudioTrack[];
+  masterVolume?: number;
   midiVolume: number;
   midiMuted?: boolean; // Optional for backward compatibility
   midiProgram?: number; // Optional for backward compatibility
@@ -621,6 +626,7 @@ const DEFAULTS: Omit<SavedProject, "version"> = {
   gridSnap: "1/8",
   locators: [],
   audioTracks: [],
+  masterVolume: 1,
   midiVolume: 0.8,
   midiMuted: false,
   midiProgram: 0,
@@ -653,6 +659,7 @@ export function toSavedProject(state: ProjectState): SavedProject {
       // Strip transient waveform data
       ({ audioWaveform: _audioWaveform, ...track }) => track,
     ),
+    masterVolume: state.masterVolume,
     midiVolume: state.midiVolume,
     midiMuted: state.midiMuted,
     midiProgram: state.midiProgram,
@@ -736,6 +743,7 @@ export function fromSavedProject(data: AnySavedProject): Partial<ProjectState> {
       ...t,
       audioWaveform: { status: "pending" as const },
     })),
+    masterVolume: merged.masterVolume ?? DEFAULTS.masterVolume,
     midiVolume: merged.midiVolume,
     midiMuted: merged.midiMuted ?? DEFAULTS.midiMuted,
     midiProgram: merged.midiProgram ?? DEFAULTS.midiProgram,


### PR DESCRIPTION
## Summary

- move the metronome mute toggle back beside Play/Pause
- replace the upper-left Metro strip with a persisted Master gain slider
