### PR TITLE
feat: show mixer in floating panel

### DIFF
--- a/e2e/transport.spec.ts
+++ b/e2e/transport.spec.ts
@@ -84,8 +84,15 @@ test.describe("Transport Controls", () => {
 
   test("mixer dB input", async ({ page }) => {
     await page.getByTestId("mixer-button").click();
-    const mixerDialog = page.getByTestId("mixer-dialog");
-    const midiDbInput = mixerDialog.getByLabel("MIDI level in dB");
+    const mixerPanel = page.getByTestId("mixer-panel");
+    const midiDbInput = mixerPanel.getByLabel("MIDI level in dB");
+
+    await expect(mixerPanel).toBeVisible();
+
+    // The panel is non-modal, so transport controls remain usable.
+    await page.getByTestId("play-pause-button").click();
+    await expect(page.getByTestId("pause-icon")).toBeVisible();
+    await page.getByTestId("play-pause-button").click();
 
     await midiDbInput.fill("-12.0");
     await midiDbInput.press("Enter");
@@ -98,6 +105,9 @@ test.describe("Transport Controls", () => {
     await midiDbInput.fill("-100");
     await midiDbInput.press("Enter");
     await expect(midiDbInput).toHaveValue("-60.0");
+
+    await mixerPanel.getByRole("button", { name: "Close Mixer" }).click();
+    await expect(mixerPanel).not.toBeVisible();
   });
 
   test("auto-scroll toggle", async ({ page }) => {

--- a/e2e/transport.spec.ts
+++ b/e2e/transport.spec.ts
@@ -91,6 +91,14 @@ test.describe("Transport Controls", () => {
 
     await expect(mixerPanel).toBeVisible();
     await expect(mixerButton).toHaveAttribute("aria-pressed", "true");
+    await expect(
+      mixerPanel.locator("label").allTextContents(),
+    ).resolves.toEqual(["Master", "MIDI", "Metro"]);
+
+    const masterDbInput = mixerPanel.getByLabel("Master level in dB");
+    await masterDbInput.fill("-6.0");
+    await masterDbInput.press("Enter");
+    await expect(masterDbInput).toHaveValue("-6.0");
 
     // The panel is non-modal, so transport controls remain usable.
     await page.getByTestId("play-pause-button").click();

--- a/e2e/transport.spec.ts
+++ b/e2e/transport.spec.ts
@@ -83,11 +83,14 @@ test.describe("Transport Controls", () => {
   });
 
   test("mixer dB input", async ({ page }) => {
-    await page.getByTestId("mixer-button").click();
+    const mixerButton = page.getByTestId("mixer-button");
+    await expect(mixerButton).toHaveAttribute("aria-pressed", "false");
+    await mixerButton.click();
     const mixerPanel = page.getByTestId("mixer-panel");
     const midiDbInput = mixerPanel.getByLabel("MIDI level in dB");
 
     await expect(mixerPanel).toBeVisible();
+    await expect(mixerButton).toHaveAttribute("aria-pressed", "true");
 
     // The panel is non-modal, so transport controls remain usable.
     await page.getByTestId("play-pause-button").click();
@@ -106,8 +109,9 @@ test.describe("Transport Controls", () => {
     await midiDbInput.press("Enter");
     await expect(midiDbInput).toHaveValue("-60.0");
 
-    await mixerPanel.getByRole("button", { name: "Close Mixer" }).click();
+    await mixerButton.click();
     await expect(mixerPanel).not.toBeVisible();
+    await expect(mixerButton).toHaveAttribute("aria-pressed", "false");
   });
 
   test("auto-scroll toggle", async ({ page }) => {

--- a/e2e/transport.spec.ts
+++ b/e2e/transport.spec.ts
@@ -83,6 +83,8 @@ test.describe("Transport Controls", () => {
   });
 
   test("mixer dB input", async ({ page }) => {
+    await loadAudioFile(page);
+
     const mixerButton = page.getByTestId("mixer-button");
     await expect(mixerButton).toHaveAttribute("aria-pressed", "false");
     await mixerButton.click();
@@ -91,14 +93,22 @@ test.describe("Transport Controls", () => {
 
     await expect(mixerPanel).toBeVisible();
     await expect(mixerButton).toHaveAttribute("aria-pressed", "true");
-    await expect(
-      mixerPanel.locator("label").allTextContents(),
-    ).resolves.toEqual(["Master", "MIDI", "Metro"]);
+    await expect(mixerPanel.locator("label")).toHaveText([
+      "Master",
+      "Audio",
+      "MIDI",
+      "Metro",
+    ]);
 
     const masterDbInput = mixerPanel.getByLabel("Master level in dB");
     await masterDbInput.fill("-6.0");
     await masterDbInput.press("Enter");
     await expect(masterDbInput).toHaveValue("-6.0");
+
+    const audioDbInput = mixerPanel.getByLabel("Audio level in dB");
+    await audioDbInput.fill("-9.0");
+    await audioDbInput.press("Enter");
+    await expect(audioDbInput).toHaveValue("-9.0");
 
     // The panel is non-modal, so transport controls remain usable.
     await page.getByTestId("play-pause-button").click();

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -8,6 +8,7 @@ import { PianoRoll } from "./components/piano-roll";
 import { Settings } from "./components/settings";
 import { Transport } from "./components/transport";
 import { Dialog } from "./components/ui/dialog";
+import { FloatingPanel } from "./components/ui/floating-panel";
 import { useDraftTextInput } from "./hooks/use-draft-text-input";
 import { useWindowEvent } from "./hooks/use-window-event";
 import { isShortcutTextInputTarget, matchKeyboardEvent } from "./lib/keyboard";
@@ -149,14 +150,15 @@ function Editor({ projectId, initialProjectName }: EditorProps) {
       />
       <PianoRoll />
       <HelpOverlay isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} />
-      <Dialog
-        isOpen={isMixerOpen}
-        onClose={() => setIsMixerOpen(false)}
-        title="Mixer"
-        testId="mixer-dialog"
-      >
-        <Mixer />
-      </Dialog>
+      {isMixerOpen && (
+        <FloatingPanel
+          onClose={() => setIsMixerOpen(false)}
+          title="Mixer"
+          testId="mixer-panel"
+        >
+          <Mixer />
+        </FloatingPanel>
+      )}
       <Dialog
         isOpen={isSettingsOpen}
         onClose={() => setIsSettingsOpen(false)}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -17,6 +17,7 @@ import { Transport } from "./components/transport";
 import { Button } from "./components/ui/button";
 import { Dialog } from "./components/ui/dialog";
 import { FloatingPanel } from "./components/ui/floating-panel";
+import { cn } from "./components/ui/utils";
 import { useDraftTextInput } from "./hooks/use-draft-text-input";
 import { useWindowEvent } from "./hooks/use-window-event";
 import { isShortcutTextInputTarget, matchKeyboardEvent } from "./lib/keyboard";
@@ -164,9 +165,14 @@ function Editor({ projectId, initialProjectName }: EditorProps) {
             </Button>
             <Button
               data-testid="mixer-button"
-              onClick={() => setIsMixerOpen(true)}
+              onClick={() => setIsMixerOpen((open) => !open)}
+              aria-pressed={isMixerOpen}
               title="Mixer"
-              className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+              className={cn(
+                "size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+                isMixerOpen &&
+                  "bg-primary text-primary-foreground hover:bg-primary/90",
+              )}
             >
               <SlidersHorizontalIcon className="size-5" />
             </Button>

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -50,7 +50,7 @@ export function Mixer() {
   });
 
   return (
-    <div className="flex justify-center gap-8 py-4">
+    <div className="flex justify-center gap-8 py-1">
       {/* MIDI Channel */}
       <div className="flex flex-col items-center gap-3 min-w-24">
         <div className="flex items-center gap-2">

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -1,4 +1,4 @@
-import { MusicIcon, Volume2Icon, VolumeXIcon } from "lucide-react";
+import { GaugeIcon, MusicIcon, Volume2Icon, VolumeXIcon } from "lucide-react";
 import { useCallback } from "react";
 import { useDraftInput } from "../hooks/use-draft-input";
 import {
@@ -18,11 +18,13 @@ import { cn } from "./ui/utils";
 
 export function Mixer() {
   const {
+    masterVolume,
     midiVolume,
     metronomeVolume,
     midiMuted,
     metronomeEnabled,
     audioTracks,
+    setMasterVolume,
     setMidiVolume,
     setMetronomeVolume,
     setMidiMuted,
@@ -30,6 +32,15 @@ export function Mixer() {
   } = useProjectStore();
   const zeroDbPercent = dbToPercent(0);
   const formatDb = useCallback((value: number) => value.toFixed(1), []);
+  const masterDbInput = useDraftInput({
+    value: gainToDb(masterVolume),
+    onCommit: (db) => setMasterVolume(dbToGain(db)),
+    min: MIN_DB,
+    max: MAX_DB,
+    step: 0.5,
+    parse: "float",
+    format: formatDb,
+  });
   const midiDbInput = useDraftInput({
     value: gainToDb(midiVolume),
     onCommit: (db) => setMidiVolume(dbToGain(db)),
@@ -51,6 +62,51 @@ export function Mixer() {
 
   return (
     <div className="flex justify-center gap-8 py-1">
+      {/* Master Channel */}
+      <div className="flex flex-col items-center gap-3 min-w-24">
+        <div className="flex items-center gap-2">
+          <GaugeIcon className="size-4 text-muted-foreground" />
+          <label className="text-xs font-medium text-neutral-300">Master</label>
+        </div>
+        <div className="relative h-48">
+          <div
+            className="pointer-events-none absolute left-1/2 h-px w-3 -translate-x-1/2 bg-neutral-500/70"
+            style={{ bottom: `${zeroDbPercent}%` }}
+          />
+          <Slider
+            data-testid="mixer-master-volume-slider"
+            value={[gainToPercent(masterVolume)]}
+            onValueChange={([v]) => setMasterVolume(percentToGain(v))}
+            max={100}
+            step={1}
+            orientation="vertical"
+            className="h-48"
+          />
+        </div>
+        <div className="flex items-center gap-1 text-xs text-muted-foreground tabular-nums">
+          <input
+            type="text"
+            inputMode="decimal"
+            aria-label="Master level in dB"
+            className="w-12 h-6 px-1 text-xs font-mono bg-input border border-border rounded text-center text-foreground"
+            {...masterDbInput.props}
+          />
+          <span>dB</span>
+        </div>
+        <div className="h-8" />
+      </div>
+
+      {/* Audio Channels (one per loaded track) */}
+      {audioTracks.map((track, index) => (
+        <AudioMixerChannel
+          key={track.id}
+          track={track}
+          label={audioTracks.length > 1 ? `Audio ${index + 1}` : "Audio"}
+          zeroDbPercent={zeroDbPercent}
+          formatDb={formatDb}
+        />
+      ))}
+
       {/* MIDI Channel */}
       <div className="flex flex-col items-center gap-3 min-w-24">
         <div className="flex items-center gap-2">
@@ -96,19 +152,8 @@ export function Mixer() {
         </Toggle>
       </div>
 
-      {/* Audio Channels (one per loaded track) */}
-      {audioTracks.map((track, index) => (
-        <AudioMixerChannel
-          key={track.id}
-          track={track}
-          label={audioTracks.length > 1 ? `Audio ${index + 1}` : "Audio"}
-          zeroDbPercent={zeroDbPercent}
-          formatDb={formatDb}
-        />
-      ))}
-
       {/* Metronome Channel */}
-      <div className="flex flex-col items-center gap-3 min-w-24">
+      <div className="flex min-w-24 flex-col items-center gap-3 border-l border-neutral-700 pl-8">
         <div className="flex items-center gap-2">
           <MetronomeIcon className="size-4 text-muted-foreground" />
           <label className="text-xs font-medium text-neutral-300">Metro</label>

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -1,5 +1,5 @@
 import { GaugeIcon, MusicIcon, Volume2Icon, VolumeXIcon } from "lucide-react";
-import { useCallback } from "react";
+import { type ComponentProps, type ReactNode, useCallback } from "react";
 import { useDraftInput } from "../hooks/use-draft-input";
 import {
   MAX_DB,
@@ -62,39 +62,15 @@ export function Mixer() {
 
   return (
     <div className="flex justify-center gap-8 py-1">
-      {/* Master Channel */}
-      <div className="flex flex-col items-center gap-3 min-w-24">
-        <div className="flex items-center gap-2">
-          <GaugeIcon className="size-4 text-muted-foreground" />
-          <label className="text-xs font-medium text-neutral-300">Master</label>
-        </div>
-        <div className="relative h-48">
-          <div
-            className="pointer-events-none absolute left-1/2 h-px w-3 -translate-x-1/2 bg-neutral-500/70"
-            style={{ bottom: `${zeroDbPercent}%` }}
-          />
-          <Slider
-            data-testid="mixer-master-volume-slider"
-            value={[gainToPercent(masterVolume)]}
-            onValueChange={([v]) => setMasterVolume(percentToGain(v))}
-            max={100}
-            step={1}
-            orientation="vertical"
-            className="h-48"
-          />
-        </div>
-        <div className="flex items-center gap-1 text-xs text-muted-foreground tabular-nums">
-          <input
-            type="text"
-            inputMode="decimal"
-            aria-label="Master level in dB"
-            className="w-12 h-6 px-1 text-xs font-mono bg-input border border-border rounded text-center text-foreground"
-            {...masterDbInput.props}
-          />
-          <span>dB</span>
-        </div>
-        <div className="h-8" />
-      </div>
+      <MixerChannel
+        icon={<GaugeIcon className="size-4 text-muted-foreground" />}
+        label="Master"
+        volume={masterVolume}
+        onVolumeChange={setMasterVolume}
+        dbInputProps={masterDbInput.props}
+        sliderTestId="mixer-master-volume-slider"
+        zeroDbPercent={zeroDbPercent}
+      />
 
       {/* Audio Channels (one per loaded track) */}
       {audioTracks.map((track, index) => (
@@ -107,95 +83,54 @@ export function Mixer() {
         />
       ))}
 
-      {/* MIDI Channel */}
-      <div className="flex flex-col items-center gap-3 min-w-24">
-        <div className="flex items-center gap-2">
-          <MusicIcon className="size-4 text-muted-foreground" />
-          <label className="text-xs font-medium text-neutral-300">MIDI</label>
-        </div>
-        <div className="relative h-48">
-          <div
-            className="pointer-events-none absolute left-1/2 h-px w-3 -translate-x-1/2 bg-neutral-500/70"
-            style={{ bottom: `${zeroDbPercent}%` }}
-          />
-          <Slider
-            value={[gainToPercent(midiVolume)]}
-            onValueChange={([v]) => setMidiVolume(percentToGain(v))}
-            max={100}
-            step={1}
-            orientation="vertical"
-            className="h-48"
-          />
-        </div>
-        <div className="flex items-center gap-1 text-xs text-muted-foreground tabular-nums">
-          <input
-            type="text"
-            inputMode="decimal"
-            aria-label="MIDI level in dB"
-            className="w-12 h-6 px-1 text-xs font-mono bg-input border border-border rounded text-center text-foreground"
-            {...midiDbInput.props}
-          />
-          <span>dB</span>
-        </div>
-        <Toggle
-          value={midiMuted}
-          onChange={setMidiMuted}
-          aria-label="Toggle MIDI mute"
-          title={midiMuted ? "Unmute MIDI" : "Mute MIDI"}
-          className={cn(
-            "h-8 min-w-8 px-1.5",
-            midiMuted &&
-              "bg-red-900/50 border-red-700 text-red-400 hover:bg-red-900/70 hover:text-red-300",
-          )}
-        >
-          <VolumeXIcon className="size-4" />
-        </Toggle>
-      </div>
+      <MixerChannel
+        icon={<MusicIcon className="size-4 text-muted-foreground" />}
+        label="MIDI"
+        volume={midiVolume}
+        onVolumeChange={setMidiVolume}
+        dbInputProps={midiDbInput.props}
+        zeroDbPercent={zeroDbPercent}
+        action={
+          <Toggle
+            value={midiMuted}
+            onChange={setMidiMuted}
+            aria-label="Toggle MIDI mute"
+            title={midiMuted ? "Unmute MIDI" : "Mute MIDI"}
+            className={cn(
+              "h-8 min-w-8 px-1.5",
+              midiMuted &&
+                "bg-red-900/50 border-red-700 text-red-400 hover:bg-red-900/70 hover:text-red-300",
+            )}
+          >
+            <VolumeXIcon className="size-4" />
+          </Toggle>
+        }
+      />
 
-      {/* Metronome Channel */}
-      <div className="flex min-w-24 flex-col items-center gap-3 border-l border-neutral-700 pl-8">
-        <div className="flex items-center gap-2">
-          <MetronomeIcon className="size-4 text-muted-foreground" />
-          <label className="text-xs font-medium text-neutral-300">Metro</label>
-        </div>
-        <div className="relative h-48">
-          <div
-            className="pointer-events-none absolute left-1/2 h-px w-3 -translate-x-1/2 bg-neutral-500/70"
-            style={{ bottom: `${zeroDbPercent}%` }}
-          />
-          <Slider
-            value={[gainToPercent(metronomeVolume)]}
-            onValueChange={([v]) => setMetronomeVolume(percentToGain(v))}
-            max={100}
-            step={1}
-            orientation="vertical"
-            className="h-48"
-          />
-        </div>
-        <div className="flex items-center gap-1 text-xs text-muted-foreground tabular-nums">
-          <input
-            type="text"
-            inputMode="decimal"
-            aria-label="Metronome level in dB"
-            className="w-12 h-6 px-1 text-xs font-mono bg-input border border-border rounded text-center text-foreground"
-            {...metronomeDbInput.props}
-          />
-          <span>dB</span>
-        </div>
-        <Toggle
-          value={!metronomeEnabled}
-          onChange={(muted) => setMetronomeEnabled(!muted)}
-          aria-label="Toggle metronome mute"
-          title={metronomeEnabled ? "Mute metronome" : "Unmute metronome"}
-          className={cn(
-            "h-8 min-w-8 px-1.5",
-            !metronomeEnabled &&
-              "bg-red-900/50 border-red-700 text-red-400 hover:bg-red-900/70 hover:text-red-300",
-          )}
-        >
-          <VolumeXIcon className="size-4" />
-        </Toggle>
-      </div>
+      <MixerChannel
+        icon={<MetronomeIcon className="size-4 text-muted-foreground" />}
+        label="Metro"
+        volume={metronomeVolume}
+        onVolumeChange={setMetronomeVolume}
+        dbInputProps={metronomeDbInput.props}
+        zeroDbPercent={zeroDbPercent}
+        className="border-l border-neutral-700 pl-8"
+        action={
+          <Toggle
+            value={!metronomeEnabled}
+            onChange={(muted) => setMetronomeEnabled(!muted)}
+            aria-label="Toggle metronome mute"
+            title={metronomeEnabled ? "Mute metronome" : "Unmute metronome"}
+            className={cn(
+              "h-8 min-w-8 px-1.5",
+              !metronomeEnabled &&
+                "bg-red-900/50 border-red-700 text-red-400 hover:bg-red-900/70 hover:text-red-300",
+            )}
+          >
+            <VolumeXIcon className="size-4" />
+          </Toggle>
+        }
+      />
     </div>
   );
 }
@@ -224,12 +159,63 @@ function AudioMixerChannel({
   });
 
   return (
-    <div className="flex flex-col items-center gap-3 min-w-24">
+    <MixerChannel
+      icon={<Volume2Icon className="size-4 text-muted-foreground" />}
+      label={label}
+      labelTitle={track.fileName}
+      volume={track.volume}
+      onVolumeChange={(volume) => updateAudioTrack(track.id, { volume })}
+      dbInputProps={dbInput.props}
+      zeroDbPercent={zeroDbPercent}
+      action={
+        <Toggle
+          value={track.muted}
+          onChange={(muted) => updateAudioTrack(track.id, { muted })}
+          aria-label={`Toggle ${label} mute`}
+          title={track.muted ? `Unmute ${label}` : `Mute ${label}`}
+          className={cn(
+            "h-8 min-w-8 px-1.5",
+            track.muted &&
+              "bg-red-900/50 border-red-700 text-red-400 hover:bg-red-900/70 hover:text-red-300",
+          )}
+        >
+          <VolumeXIcon className="size-4" />
+        </Toggle>
+      }
+    />
+  );
+}
+
+function MixerChannel({
+  icon,
+  label,
+  labelTitle,
+  volume,
+  onVolumeChange,
+  dbInputProps,
+  zeroDbPercent,
+  action,
+  sliderTestId,
+  className,
+}: {
+  icon: ReactNode;
+  label: string;
+  labelTitle?: string;
+  volume: number;
+  onVolumeChange: (volume: number) => void;
+  dbInputProps: ComponentProps<"input">;
+  zeroDbPercent: number;
+  action?: ReactNode;
+  sliderTestId?: string;
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex min-w-24 flex-col items-center gap-3", className)}>
       <div className="flex items-center gap-2">
-        <Volume2Icon className="size-4 text-muted-foreground" />
+        {icon}
         <label
-          className="text-xs font-medium text-neutral-300 max-w-24 truncate"
-          title={track.fileName}
+          className="max-w-24 truncate text-xs font-medium text-neutral-300"
+          title={labelTitle}
         >
           {label}
         </label>
@@ -240,10 +226,9 @@ function AudioMixerChannel({
           style={{ bottom: `${zeroDbPercent}%` }}
         />
         <Slider
-          value={[gainToPercent(track.volume)]}
-          onValueChange={([v]) =>
-            updateAudioTrack(track.id, { volume: percentToGain(v) })
-          }
+          data-testid={sliderTestId}
+          value={[gainToPercent(volume)]}
+          onValueChange={([value]) => onVolumeChange(percentToGain(value))}
           max={100}
           step={1}
           orientation="vertical"
@@ -254,25 +239,13 @@ function AudioMixerChannel({
         <input
           type="text"
           inputMode="decimal"
-          aria-label={`${label} level in dB`}
+          aria-label={`${label === "Metro" ? "Metronome" : label} level in dB`}
           className="w-12 h-6 px-1 text-xs font-mono bg-input border border-border rounded text-center text-foreground"
-          {...dbInput.props}
+          {...dbInputProps}
         />
         <span>dB</span>
       </div>
-      <Toggle
-        value={track.muted}
-        onChange={(muted) => updateAudioTrack(track.id, { muted })}
-        aria-label={`Toggle ${label} mute`}
-        title={track.muted ? `Unmute ${label}` : `Mute ${label}`}
-        className={cn(
-          "h-8 min-w-8 px-1.5",
-          track.muted &&
-            "bg-red-900/50 border-red-700 text-red-400 hover:bg-red-900/70 hover:text-red-300",
-        )}
-      >
-        <VolumeXIcon className="size-4" />
-      </Toggle>
+      {action ?? <div className="h-8" />}
     </div>
   );
 }

--- a/src/components/ui/floating-panel.tsx
+++ b/src/components/ui/floating-panel.tsx
@@ -17,7 +17,7 @@ export function FloatingPanel({
   return (
     <section
       data-testid={testId}
-      className="fixed bottom-4 right-4 z-40 rounded-lg border border-neutral-700 bg-neutral-800 shadow-2xl"
+      className="fixed bottom-4 right-4 z-40 max-w-[calc(100vw-2rem)] rounded-lg border border-neutral-700 bg-neutral-800 shadow-2xl"
     >
       <div className="flex items-center justify-between border-b border-neutral-700 px-4 py-3">
         <h2 className="text-sm font-semibold text-neutral-100">{title}</h2>
@@ -29,7 +29,7 @@ export function FloatingPanel({
           <XIcon className="size-5" />
         </button>
       </div>
-      <div className="px-4 py-3">{children}</div>
+      <div className="overflow-x-auto px-4 py-3">{children}</div>
     </section>
   );
 }

--- a/src/components/ui/floating-panel.tsx
+++ b/src/components/ui/floating-panel.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+
+type FloatingPanelProps = {
+  title: string;
+  onClose: () => void;
+  children: ReactNode;
+  testId?: string;
+};
+
+export function FloatingPanel({
+  title,
+  onClose,
+  children,
+  testId,
+}: FloatingPanelProps) {
+  return (
+    <section
+      data-testid={testId}
+      className="fixed bottom-4 right-4 z-40 rounded-lg border border-neutral-700 bg-neutral-800 shadow-2xl"
+    >
+      <div className="flex items-center justify-between border-b border-neutral-700 px-4 py-3">
+        <h2 className="text-sm font-semibold text-neutral-100">{title}</h2>
+        <button
+          onClick={onClose}
+          className="text-xl leading-none text-neutral-400 hover:text-neutral-200"
+          aria-label={`Close ${title}`}
+        >
+          ×
+        </button>
+      </div>
+      <div className="px-4 py-3">{children}</div>
+    </section>
+  );
+}

--- a/src/components/ui/floating-panel.tsx
+++ b/src/components/ui/floating-panel.tsx
@@ -1,3 +1,4 @@
+import { XIcon } from "lucide-react";
 import type { ReactNode } from "react";
 
 type FloatingPanelProps = {
@@ -22,10 +23,10 @@ export function FloatingPanel({
         <h2 className="text-sm font-semibold text-neutral-100">{title}</h2>
         <button
           onClick={onClose}
-          className="text-xl leading-none text-neutral-400 hover:text-neutral-200"
+          className="text-neutral-400 hover:text-neutral-200"
           aria-label={`Close ${title}`}
         >
-          ×
+          <XIcon className="size-5" />
         </button>
       </div>
       <div className="px-4 py-3">{children}</div>


### PR DESCRIPTION
## Summary

- add a reusable floating panel shell for editor tools
- move the mixer from a blocking dialog into the floating panel
- keep transport controls usable while mixing and cover that behavior in E2E
- leave Help and Settings as modal overlays

This also gives #174 a shared shell for its Audio-to-MIDI panel once the branches meet.
