### PR TITLE
refactor: use icons for modal close buttons

### DIFF
--- a/src/components/help-overlay.tsx
+++ b/src/components/help-overlay.tsx
@@ -1,3 +1,4 @@
+import { XIcon } from "lucide-react";
 import {
   CATEGORY_NAMES,
   KEYBOARD_SHORTCUTS,
@@ -73,10 +74,10 @@ export function HelpOverlay({ isOpen, onClose }: HelpOverlayProps) {
           </h2>
           <button
             onClick={onClose}
-            className="text-neutral-400 hover:text-neutral-200 text-2xl leading-none"
+            className="text-neutral-400 hover:text-neutral-200"
             aria-label="Close help"
           >
-            ×
+            <XIcon className="size-5" />
           </button>
         </div>
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,3 +1,4 @@
+import { XIcon } from "lucide-react";
 import type { ReactNode } from "react";
 
 type DialogProps = {
@@ -34,10 +35,10 @@ export function Dialog({
           <h2 className="text-lg font-semibold text-neutral-100">{title}</h2>
           <button
             onClick={onClose}
-            className="text-neutral-400 hover:text-neutral-200 text-2xl leading-none"
+            className="text-neutral-400 hover:text-neutral-200"
             aria-label="Close"
           >
-            ×
+            <XIcon className="size-5" />
           </button>
         </div>
 


### PR DESCRIPTION
## Summary

- replace the dialog close text glyph with Lucide’s `XIcon`
- replace the help overlay close text glyph with the same icon
- preserve existing accessible labels and behavior

## Verification

- `pnpm lint`
- `pnpm test-e2e e2e/help-overlay.spec.ts e2e/transport.spec.ts`