### PR TITLE
refactor: compose editor controls into transport

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,12 @@
 import { useMutation } from "@tanstack/react-query";
-import { Github, Pencil, Trash2 } from "lucide-react";
+import {
+  CircleHelpIcon,
+  Github,
+  Pencil,
+  SettingsIcon,
+  SlidersHorizontalIcon,
+  Trash2,
+} from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { HelpOverlay } from "./components/help-overlay";
@@ -7,6 +14,7 @@ import { Mixer } from "./components/mixer";
 import { PianoRoll } from "./components/piano-roll";
 import { Settings } from "./components/settings";
 import { Transport } from "./components/transport";
+import { Button } from "./components/ui/button";
 import { Dialog } from "./components/ui/dialog";
 import { useDraftTextInput } from "./hooks/use-draft-text-input";
 import { useWindowEvent } from "./hooks/use-window-event";
@@ -142,10 +150,35 @@ function Editor({ projectId, initialProjectName }: EditorProps) {
   return (
     <div className="h-screen flex flex-col bg-neutral-900">
       <Transport
-        onSettingsClick={() => setIsSettingsOpen(true)}
-        onHelpClick={() => setIsHelpOpen(true)}
-        onMixerClick={() => setIsMixerOpen(true)}
         projectName={projectName}
+        controls={
+          <>
+            <Button
+              data-testid="settings-button"
+              onClick={() => setIsSettingsOpen(true)}
+              title="Settings"
+              className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+            >
+              <SettingsIcon className="size-5" />
+            </Button>
+            <Button
+              data-testid="mixer-button"
+              onClick={() => setIsMixerOpen(true)}
+              title="Mixer"
+              className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+            >
+              <SlidersHorizontalIcon className="size-5" />
+            </Button>
+            <Button
+              data-testid="help-button"
+              onClick={() => setIsHelpOpen(true)}
+              title="Show keyboard shortcuts (?)"
+              className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+            >
+              <CircleHelpIcon className="size-5" />
+            </Button>
+          </>
+        }
       />
       <PianoRoll />
       <HelpOverlay isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} />

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -1,13 +1,10 @@
 import {
   CheckIcon,
   ChevronsUpDownIcon,
-  CircleHelpIcon,
   PauseIcon,
   PlayIcon,
-  SettingsIcon,
-  SlidersHorizontalIcon,
 } from "lucide-react";
-import { useRef, useState } from "react";
+import { type ReactNode, useRef, useState } from "react";
 import { useAudio } from "../hooks/use-audio";
 import { useDraftInput } from "../hooks/use-draft-input";
 import { useWindowEvent } from "../hooks/use-window-event";
@@ -179,18 +176,11 @@ function InstrumentCombobox({
 }
 
 type TransportProps = {
-  onSettingsClick: () => void;
-  onHelpClick: () => void;
-  onMixerClick: () => void;
   projectName: string;
+  controls: ReactNode;
 };
 
-export function Transport({
-  onSettingsClick,
-  onHelpClick,
-  onMixerClick,
-  projectName,
-}: TransportProps) {
+export function Transport({ projectName, controls }: TransportProps) {
   const {
     tempo,
     timeSignature,
@@ -411,35 +401,7 @@ export function Transport({
       {/* Divider */}
       <div className="w-px h-5 bg-border" />
 
-      {/* Settings button */}
-      <Button
-        data-testid="settings-button"
-        onClick={onSettingsClick}
-        title="Settings"
-        className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
-      >
-        <SettingsIcon className="size-5" />
-      </Button>
-
-      {/* Mixer button */}
-      <Button
-        data-testid="mixer-button"
-        onClick={onMixerClick}
-        title="Mixer"
-        className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
-      >
-        <SlidersHorizontalIcon className="size-5" />
-      </Button>
-
-      {/* Help button */}
-      <Button
-        data-testid="help-button"
-        onClick={onHelpClick}
-        title="Show keyboard shortcuts (?)"
-        className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
-      >
-        <CircleHelpIcon className="size-5" />
-      </Button>
+      {controls}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- replace Transport’s settings, mixer, and help callbacks with a named `controls` slot
- let Editor choose and render editor-level feature controls
- keep Transport responsible only for transport-specific behavior and control placement
- preserve existing overlay state, Escape handling, and UI behavior

## Verification

- `pnpm lint`
- `pnpm test-e2e e2e/help-overlay.spec.ts e2e/transport.spec.ts`