### PR TITLE
docs: clarify handling of existing test failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Planned work and known bugs live in GitHub issues, minor code-level nits as inli
 - Commit messages: use Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`); add `!` for breaking changes
 - File names: kebab-case
 - Prefer the smallest correct change, and avoid speculative abstractions or compatibility paths
+- When an existing test fails, first verify from first principles whether its expectation is correct. Do not compensate in the implementation merely to preserve an incorrect test.
 - Keep cohesive implementation together, and split files only for reuse or a clear module boundary
 - Order functions by reading flow, with primary entry points and callers before their implementation helpers
 - Prefer `undefined` over `null`


### PR DESCRIPTION
## Summary

- instruct agents to reassess failing test expectations from first principles
- discourage implementation compensation for incorrect tests

## Validation

- pnpm lint