### PR TITLE
feat: rework project settings modal

### DIFF
--- a/e2e/copy-paste.spec.ts
+++ b/e2e/copy-paste.spec.ts
@@ -86,7 +86,8 @@ test.describe("Copy/Paste", () => {
     page,
   }) => {
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
-    await page.getByTestId("help-button").click();
+    await page.getByTestId("app-menu-button").click();
+    await page.getByTestId("help-menu-item").click();
     await page.getByText("Quick Reference").selectText();
 
     await page.keyboard.press("Control+c");

--- a/e2e/help-overlay.spec.ts
+++ b/e2e/help-overlay.spec.ts
@@ -11,8 +11,9 @@ test.describe("Help Overlay", () => {
     // Help should not be visible initially
     await expect(page.getByTestId("help-overlay")).not.toBeVisible();
 
-    // Click help button to show help
-    await page.getByTestId("help-button").click();
+    // Open help from the application menu
+    await page.getByTestId("app-menu-button").click();
+    await page.getByTestId("help-menu-item").click();
     await expect(page.getByTestId("help-overlay")).toBeVisible();
 
     // Check structure: title and category headers
@@ -45,7 +46,8 @@ test.describe("Help Overlay", () => {
     await expect(page.getByTestId("help-overlay")).not.toBeVisible();
 
     // Open again and close with Escape
-    await page.getByTestId("help-button").click();
+    await page.getByTestId("app-menu-button").click();
+    await page.getByTestId("help-menu-item").click();
     await expect(page.getByTestId("help-overlay")).toBeVisible();
     await page.keyboard.press("Escape");
     await expect(page.getByTestId("help-overlay")).not.toBeVisible();
@@ -57,5 +59,15 @@ test.describe("Help Overlay", () => {
     // Toggle closed with ? shortcut
     await page.keyboard.press("?");
     await expect(page.getByTestId("help-overlay")).not.toBeVisible();
+  });
+
+  test("returns to all projects from the application menu", async ({
+    page,
+  }) => {
+    await page.getByTestId("app-menu-button").click();
+    await page.getByTestId("all-projects-menu-item").click();
+
+    await expect(page).toHaveURL("/");
+    await expect(page.getByTestId("startup-screen")).toBeVisible();
   });
 });

--- a/e2e/settings-export.spec.ts
+++ b/e2e/settings-export.spec.ts
@@ -59,7 +59,7 @@ test.describe("Settings Dialog - Project Export", () => {
     await evaluateStore(page, (store) => {
       store.getState().addNote({
         id: "existing-note",
-        pitch: 60,
+        pitch: 61,
         start: 0,
         duration: 1,
         velocity: 100,
@@ -89,10 +89,7 @@ test.describe("Settings Dialog - Project Export", () => {
       tempo: store.getState().tempo,
       timeSignature: store.getState().timeSignature,
     }));
-    expect(imported.notes.length).toBeGreaterThan(0);
-    expect(imported.notes.every((note) => note.id !== "existing-note")).toBe(
-      true,
-    );
+    expect(imported.notes.map((note) => note.pitch)).toEqual([60, 64, 67, 60]);
     expect(imported.tempo).toBe(120);
     expect(imported.timeSignature).toEqual({ numerator: 4, denominator: 4 });
   });

--- a/e2e/settings-export.spec.ts
+++ b/e2e/settings-export.spec.ts
@@ -64,6 +64,8 @@ test.describe("Settings Dialog - Project Export", () => {
         duration: 1,
         velocity: 100,
       });
+      store.getState().setTempo(90);
+      store.getState().setTimeSignature({ numerator: 3, denominator: 4 });
     });
     await openSettings(page);
 
@@ -82,9 +84,17 @@ test.describe("Settings Dialog - Project Export", () => {
     await expect(
       page.getByText(/Imported \d+ notes from MIDI file/),
     ).toBeVisible();
-    const notes = await evaluateStore(page, (store) => store.getState().notes);
-    expect(notes.length).toBeGreaterThan(0);
-    expect(notes.every((note) => note.id !== "existing-note")).toBe(true);
+    const imported = await evaluateStore(page, (store) => ({
+      notes: store.getState().notes,
+      tempo: store.getState().tempo,
+      timeSignature: store.getState().timeSignature,
+    }));
+    expect(imported.notes.length).toBeGreaterThan(0);
+    expect(imported.notes.every((note) => note.id !== "existing-note")).toBe(
+      true,
+    );
+    expect(imported.tempo).toBe(120);
+    expect(imported.timeSignature).toEqual({ numerator: 4, denominator: 4 });
   });
 
   test("export and import .toymidi restores project data", async ({ page }) => {

--- a/e2e/settings-export.spec.ts
+++ b/e2e/settings-export.spec.ts
@@ -55,9 +55,7 @@ test.describe("Settings Dialog - Project Export", () => {
     await expect(page.getByTestId("export-project-button")).toBeEnabled();
   });
 
-  test("MIDI import confirms before replacing existing notes", async ({
-    page,
-  }) => {
+  test("MIDI import confirms and replaces existing notes", async ({ page }) => {
     await evaluateStore(page, (store) => {
       store.getState().addNote({
         id: "existing-note",
@@ -73,7 +71,7 @@ test.describe("Settings Dialog - Project Export", () => {
     page.once("dialog", async (dialog) => {
       expect(dialog.type()).toBe("confirm");
       confirmationMessage = dialog.message();
-      await dialog.dismiss();
+      await dialog.accept();
     });
     await page
       .getByTestId("midi-file-input")
@@ -81,9 +79,12 @@ test.describe("Settings Dialog - Project Export", () => {
 
     expect(confirmationMessage).toContain("Replace existing MIDI notes?");
 
+    await expect(
+      page.getByText(/Imported \d+ notes from MIDI file/),
+    ).toBeVisible();
     const notes = await evaluateStore(page, (store) => store.getState().notes);
-    expect(notes).toHaveLength(1);
-    expect(notes[0].id).toBe("existing-note");
+    expect(notes.length).toBeGreaterThan(0);
+    expect(notes.every((note) => note.id !== "existing-note")).toBe(true);
   });
 
   test("export and import .toymidi restores project data", async ({ page }) => {

--- a/e2e/settings-export.spec.ts
+++ b/e2e/settings-export.spec.ts
@@ -55,22 +55,6 @@ test.describe("Settings Dialog - Project Export", () => {
     await expect(page.getByTestId("export-project-button")).toBeEnabled();
   });
 
-  test("MIDI import confirms for an empty project", async ({ page }) => {
-    await openSettings(page);
-
-    let confirmationMessage: string | undefined;
-    page.once("dialog", async (dialog) => {
-      expect(dialog.type()).toBe("confirm");
-      confirmationMessage = dialog.message();
-      await dialog.dismiss();
-    });
-    await page
-      .getByTestId("midi-file-input")
-      .setInputFiles("e2e/fixtures/test-midi.mid");
-
-    expect(confirmationMessage).toContain("Import MIDI file?");
-  });
-
   test("MIDI import confirms and replaces existing notes", async ({ page }) => {
     await evaluateStore(page, (store) => {
       store.getState().addNote({

--- a/e2e/settings-export.spec.ts
+++ b/e2e/settings-export.spec.ts
@@ -55,6 +55,22 @@ test.describe("Settings Dialog - Project Export", () => {
     await expect(page.getByTestId("export-project-button")).toBeEnabled();
   });
 
+  test("MIDI import confirms for an empty project", async ({ page }) => {
+    await openSettings(page);
+
+    let confirmationMessage: string | undefined;
+    page.once("dialog", async (dialog) => {
+      expect(dialog.type()).toBe("confirm");
+      confirmationMessage = dialog.message();
+      await dialog.dismiss();
+    });
+    await page
+      .getByTestId("midi-file-input")
+      .setInputFiles("e2e/fixtures/test-midi.mid");
+
+    expect(confirmationMessage).toContain("Import MIDI file?");
+  });
+
   test("MIDI import confirms and replaces existing notes", async ({ page }) => {
     await evaluateStore(page, (store) => {
       store.getState().addNote({
@@ -79,7 +95,7 @@ test.describe("Settings Dialog - Project Export", () => {
       .getByTestId("midi-file-input")
       .setInputFiles("e2e/fixtures/test-midi.mid");
 
-    expect(confirmationMessage).toContain("Replace existing MIDI notes?");
+    expect(confirmationMessage).toContain("Import MIDI file?");
 
     await expect(
       page.getByText(/Imported \d+ notes from MIDI file/),

--- a/e2e/settings-export.spec.ts
+++ b/e2e/settings-export.spec.ts
@@ -55,6 +55,37 @@ test.describe("Settings Dialog - Project Export", () => {
     await expect(page.getByTestId("export-project-button")).toBeEnabled();
   });
 
+  test("MIDI import confirms before replacing existing notes", async ({
+    page,
+  }) => {
+    await evaluateStore(page, (store) => {
+      store.getState().addNote({
+        id: "existing-note",
+        pitch: 60,
+        start: 0,
+        duration: 1,
+        velocity: 100,
+      });
+    });
+    await openSettings(page);
+
+    let confirmationMessage: string | undefined;
+    page.once("dialog", async (dialog) => {
+      expect(dialog.type()).toBe("confirm");
+      confirmationMessage = dialog.message();
+      await dialog.dismiss();
+    });
+    await page
+      .getByTestId("midi-file-input")
+      .setInputFiles("e2e/fixtures/test-midi.mid");
+
+    expect(confirmationMessage).toContain("Replace existing MIDI notes?");
+
+    const notes = await evaluateStore(page, (store) => store.getState().notes);
+    expect(notes).toHaveLength(1);
+    expect(notes[0].id).toBe("existing-note");
+  });
+
   test("export and import .toymidi restores project data", async ({ page }) => {
     await evaluateStore(page, (store) => {
       store.getState().addNote({

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -1,5 +1,7 @@
 import {
   CircleHelpIcon,
+  FolderIcon,
+  MoreVerticalIcon,
   SettingsIcon,
   SlidersHorizontalIcon,
   SparklesIcon,
@@ -17,6 +19,12 @@ import { Settings } from "./settings";
 import { Transport } from "./transport";
 import { Button } from "./ui/button";
 import { Dialog } from "./ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
 import { FloatingPanel } from "./ui/floating-panel";
 import { cn } from "./ui/utils";
 
@@ -72,7 +80,7 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
             <Button
               data-testid="settings-button"
               onClick={() => setIsSettingsOpen(true)}
-              title="Settings"
+              title="Project"
               className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
             >
               <SettingsIcon className="size-5" />
@@ -90,14 +98,33 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
             >
               <SlidersHorizontalIcon className="size-5" />
             </Button>
-            <Button
-              data-testid="help-button"
-              onClick={() => setIsHelpOpen(true)}
-              title="Show keyboard shortcuts (?)"
-              className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
-            >
-              <CircleHelpIcon className="size-5" />
-            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  data-testid="app-menu-button"
+                  title="More"
+                  aria-label="More"
+                  className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+                >
+                  <MoreVerticalIcon className="size-5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem asChild>
+                  <a href="/" data-testid="all-projects-menu-item">
+                    <FolderIcon />
+                    All Projects
+                  </a>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  data-testid="help-menu-item"
+                  onSelect={() => setIsHelpOpen(true)}
+                >
+                  <CircleHelpIcon />
+                  Help &amp; Shortcuts
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </>
         }
       />
@@ -133,7 +160,7 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
       <Dialog
         isOpen={isSettingsOpen}
         onClose={() => setIsSettingsOpen(false)}
-        title="Settings"
+        title="Project"
         testId="settings-dialog"
       >
         <Settings

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -258,7 +258,7 @@ export function Settings({
             data-testid="load-audio-button"
             disabled={loadAudioMutation.isPending}
             inputProps={{ "data-testid": "audio-file-input" }}
-            className="h-8 w-full justify-start gap-1.5 rounded-none border-0 px-3 bg-background text-sm text-emerald-300 shadow-xs hover:bg-accent hover:text-accent-foreground data-[drag-over=true]:bg-emerald-950/30 dark:bg-input/30 dark:hover:bg-input/50 disabled:opacity-50"
+            className="h-8 w-full justify-start gap-1.5 rounded-none border-0 px-3 bg-background text-sm text-neutral-300 shadow-xs hover:bg-accent hover:text-accent-foreground data-[drag-over=true]:bg-emerald-950/30 dark:bg-input/30 dark:hover:bg-input/50 disabled:opacity-50"
             onFile={(file) => loadAudioMutation.mutate(file)}
           >
             <UploadIcon className="size-4" />

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -97,9 +97,8 @@ export function Settings({
 
   const handleImportMidi = (file: File) => {
     if (
-      notes.length > 0 &&
       !window.confirm(
-        "Replace existing MIDI notes? Importing this file will replace all notes and may update the tempo and time signature.",
+        "Import MIDI file? This will replace all notes and may update the tempo and time signature.",
       )
     ) {
       return;

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -1,7 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import {
   DownloadIcon,
-  SettingsIcon,
   SparklesIcon,
   Trash2Icon,
   UploadIcon,
@@ -96,6 +95,18 @@ export function Settings({
     },
   });
 
+  const handleImportMidi = (file: File) => {
+    if (
+      notes.length > 0 &&
+      !window.confirm(
+        "Replace existing MIDI notes? Importing this file will replace all notes in the current project.",
+      )
+    ) {
+      return;
+    }
+    importMidiMutation.mutate(file);
+  };
+
   const loadAudioMutation = useMutation({
     mutationFn: async (input: File) => {
       const files = await resolveAudioFiles(input);
@@ -170,141 +181,21 @@ export function Settings({
 
   return (
     <div className="space-y-6">
-      {/* Project Section */}
       <section className="space-y-3">
-        <h3 className="text-sm font-semibold text-neutral-200 flex items-center gap-2">
-          <SettingsIcon className="size-4" />
-          Project
-        </h3>
-        <div className="pl-6 space-y-2">
-          <div>
-            <label
-              htmlFor="settings-project-name"
-              className="block text-xs text-neutral-400 mb-1"
-            >
-              Project Name
-            </label>
-            <input
-              id="settings-project-name"
-              type="text"
-              {...projectNameInput.props}
-              className="w-full h-8 px-2 text-sm bg-neutral-900 border border-neutral-600 rounded text-neutral-100 focus:outline-none focus:border-neutral-500"
-              placeholder="Enter project name"
-            />
-          </div>
-        </div>
-      </section>
-
-      {/* Audio Section */}
-      <section className="space-y-3">
-        <h3 className="text-sm font-semibold text-neutral-200 flex items-center gap-2">
-          <UploadIcon className="size-4" />
-          Audio
-          <span className="text-xs font-normal text-neutral-500">
-            ({audioTracks.length})
-          </span>
-        </h3>
-        <div className="pl-6 space-y-2">
-          {audioTracks.map((track) => (
-            <div key={track.id} className="flex items-center gap-2">
-              <div className="flex-1 text-sm text-neutral-200 truncate">
-                {track.fileName}
-              </div>
-              <Button
-                data-testid="audio-to-midi-button"
-                onClick={() => onAudioToMidiClick(track.id)}
-                title={`Transcribe ${track.fileName} to MIDI notes`}
-                className="h-8 gap-1.5 px-3 bg-background text-sm shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
-              >
-                <SparklesIcon className="size-4" />
-                To MIDI
-              </Button>
-              <Button
-                data-testid="remove-audio-button"
-                onClick={() => handleRemoveAudio(track)}
-                title={`Remove ${track.fileName}`}
-                className="h-8 gap-1.5 px-3 bg-background text-sm shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
-              >
-                <Trash2Icon className="size-4" />
-                Remove
-              </Button>
-            </div>
-          ))}
-          <FileDropInput
-            accept="audio/*,.zip,application/zip"
-            data-testid="load-audio-button"
-            disabled={loadAudioMutation.isPending}
-            inputProps={{ "data-testid": "audio-file-input" }}
-            className="h-8 w-full justify-start gap-1.5 px-3 bg-background text-sm shadow-xs hover:bg-accent hover:text-accent-foreground data-[drag-over=true]:border-emerald-500/60 data-[drag-over=true]:bg-emerald-950/30 dark:bg-input/30 dark:border-input dark:hover:bg-input/50 disabled:opacity-50"
-            onFile={(file) => loadAudioMutation.mutate(file)}
-          >
-            <UploadIcon className="size-4" />
-            {loadAudioMutation.isPending ? "Loading..." : "Load Audio"}
-          </FileDropInput>
-        </div>
-      </section>
-
-      {/* MIDI Import Section */}
-      <section className="space-y-3">
-        <h3 className="text-sm font-semibold text-neutral-200 flex items-center gap-2">
-          <UploadIcon className="size-4" />
-          Import MIDI
-        </h3>
-        <div className="pl-6 space-y-2">
-          <FileDropInput
-            accept=".mid,.midi"
-            data-testid="import-midi-button"
-            disabled={importMidiMutation.isPending}
-            inputProps={{ "data-testid": "midi-file-input" }}
-            className="h-8 w-full justify-start gap-1.5 px-3 bg-background text-sm shadow-xs hover:bg-accent hover:text-accent-foreground data-[drag-over=true]:border-emerald-500/60 data-[drag-over=true]:bg-emerald-950/30 dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
-            onFile={(file) => importMidiMutation.mutate(file)}
-          >
-            <UploadIcon className="size-4" />
-            {importMidiMutation.isPending ? "Importing..." : "Import MIDI File"}
-          </FileDropInput>
-          <p className="text-xs text-neutral-500">
-            Import notes from MIDI file (replaces existing notes)
-          </p>
-        </div>
-      </section>
-
-      {/* Export Section */}
-      <section className="space-y-3">
-        <h3 className="text-sm font-semibold text-neutral-200 flex items-center gap-2">
-          <DownloadIcon className="size-4" />
-          Export
-        </h3>
-        <div className="pl-6 space-y-2">
-          <Button
-            data-testid="export-project-button"
-            onClick={() => exportProjectMutation.mutate()}
-            disabled={exportProjectMutation.isPending}
-            className="h-8 w-full justify-start gap-1.5 px-3 bg-background text-sm shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
-          >
-            <DownloadIcon className="size-4" />
-            {exportProjectMutation.isPending
-              ? "Exporting..."
-              : "Export Project"}
-          </Button>
-          <Button
-            data-testid="export-midi-button"
-            onClick={handleExportMidi}
-            disabled={notes.length === 0}
-            className="h-8 w-full justify-start gap-1.5 px-3 bg-background text-sm shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
-          >
-            <DownloadIcon className="size-4" />
-            Export MIDI
-          </Button>
-        </div>
-      </section>
-
-      {/* Preferences Section */}
-      <section className="space-y-3">
-        <h3 className="text-sm font-semibold text-neutral-200 flex items-center gap-2">
-          <SettingsIcon className="size-4" />
-          Preferences
-        </h3>
-        <div className="pl-6 space-y-2">
+        <label
+          htmlFor="settings-project-name"
+          className="block text-xs text-neutral-400 mb-1"
+        >
+          Name
+        </label>
+        <input
+          id="settings-project-name"
+          type="text"
+          {...projectNameInput.props}
+          className="w-full h-8 px-2 text-sm bg-neutral-900 border border-neutral-600 rounded text-neutral-100 focus:outline-none focus:border-neutral-500"
+          placeholder="Enter project name"
+        />
+        <div className="space-y-2 pt-1">
           <label className="flex items-center gap-2 cursor-pointer">
             <input
               type="checkbox"
@@ -313,7 +204,8 @@ export function Settings({
               className="size-4 rounded border-neutral-600 bg-neutral-900 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-0"
             />
             <span className="text-sm text-neutral-300">
-              Auto-scroll <span className="text-xs text-neutral-500">(F)</span>
+              Auto-scroll during playback{" "}
+              <span className="text-xs text-neutral-500">(F)</span>
             </span>
           </label>
           <label className="flex items-center gap-2 cursor-pointer">
@@ -325,6 +217,92 @@ export function Settings({
             />
             <span className="text-sm text-neutral-300">Link audio offsets</span>
           </label>
+        </div>
+      </section>
+
+      <section className="space-y-2 border-t border-neutral-700 pt-5">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-400">
+          Audio Sources
+        </h3>
+        <div className="overflow-hidden rounded-md border border-neutral-600">
+          {audioTracks.map((track) => (
+            <div
+              key={track.id}
+              className="flex items-center gap-2 border-b border-neutral-600 p-2"
+            >
+              <div className="flex-1 text-sm text-neutral-200 truncate">
+                {track.fileName}
+              </div>
+              <Button
+                data-testid="audio-to-midi-button"
+                onClick={() => onAudioToMidiClick(track.id)}
+                title={`Transcribe ${track.fileName} to MIDI notes`}
+                className="h-7 gap-1.5 px-2 bg-background text-xs shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
+              >
+                <SparklesIcon className="size-4" />
+                To MIDI
+              </Button>
+              <Button
+                data-testid="remove-audio-button"
+                onClick={() => handleRemoveAudio(track)}
+                title={`Remove ${track.fileName}`}
+                className="h-7 gap-1.5 px-2 bg-background text-xs shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
+              >
+                <Trash2Icon className="size-4" />
+                Remove
+              </Button>
+            </div>
+          ))}
+          <FileDropInput
+            accept="audio/*,.zip,application/zip"
+            data-testid="load-audio-button"
+            disabled={loadAudioMutation.isPending}
+            inputProps={{ "data-testid": "audio-file-input" }}
+            className="h-8 w-full justify-start gap-1.5 rounded-none border-0 px-3 bg-background text-sm text-emerald-300 shadow-xs hover:bg-accent hover:text-accent-foreground data-[drag-over=true]:bg-emerald-950/30 dark:bg-input/30 dark:hover:bg-input/50 disabled:opacity-50"
+            onFile={(file) => loadAudioMutation.mutate(file)}
+          >
+            <UploadIcon className="size-4" />
+            {loadAudioMutation.isPending ? "Loading..." : "Add Audio Source"}
+          </FileDropInput>
+        </div>
+      </section>
+
+      <section className="space-y-2 border-t border-neutral-700 pt-5">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+          Files
+        </h3>
+        <div className="space-y-2">
+          <FileDropInput
+            accept=".mid,.midi"
+            data-testid="import-midi-button"
+            disabled={importMidiMutation.isPending}
+            inputProps={{ "data-testid": "midi-file-input" }}
+            className="h-8 w-full justify-start gap-1.5 px-3 bg-background text-sm shadow-xs hover:bg-accent hover:text-accent-foreground data-[drag-over=true]:border-emerald-500/60 data-[drag-over=true]:bg-emerald-950/30 dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
+            onFile={handleImportMidi}
+          >
+            <UploadIcon className="size-4" />
+            {importMidiMutation.isPending ? "Importing..." : "Import MIDI"}
+          </FileDropInput>
+          <Button
+            data-testid="export-midi-button"
+            onClick={handleExportMidi}
+            disabled={notes.length === 0}
+            className="h-8 w-full justify-start gap-1.5 px-3 bg-background text-sm shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
+          >
+            <DownloadIcon className="size-4" />
+            Export MIDI
+          </Button>
+          <Button
+            data-testid="export-project-button"
+            onClick={() => exportProjectMutation.mutate()}
+            disabled={exportProjectMutation.isPending}
+            className="h-8 w-full justify-start gap-1.5 px-3 bg-background text-sm shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
+          >
+            <DownloadIcon className="size-4" />
+            {exportProjectMutation.isPending
+              ? "Exporting..."
+              : "Export Project Archive"}
+          </Button>
         </div>
       </section>
     </div>

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -99,7 +99,7 @@ export function Settings({
     if (
       notes.length > 0 &&
       !window.confirm(
-        "Replace existing MIDI notes? Importing this file will replace all notes in the current project.",
+        "Replace existing MIDI notes? Importing this file will replace all notes and may update the tempo and time signature.",
       )
     ) {
       return;

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -221,50 +221,54 @@ export function Settings({
       </section>
 
       <section className="space-y-2 border-t border-neutral-700 pt-5">
-        <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-400">
-          Audio Sources
-        </h3>
-        <div className="overflow-hidden rounded-md border border-neutral-600">
-          {audioTracks.map((track) => (
-            <div
-              key={track.id}
-              className="flex items-center gap-2 border-b border-neutral-600 p-2"
-            >
-              <div className="flex-1 text-sm text-neutral-200 truncate">
-                {track.fileName}
-              </div>
-              <Button
-                data-testid="audio-to-midi-button"
-                onClick={() => onAudioToMidiClick(track.id)}
-                title={`Transcribe ${track.fileName} to MIDI notes`}
-                className="h-7 gap-1.5 px-2 bg-background text-xs shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
-              >
-                <SparklesIcon className="size-4" />
-                To MIDI
-              </Button>
-              <Button
-                data-testid="remove-audio-button"
-                onClick={() => handleRemoveAudio(track)}
-                title={`Remove ${track.fileName}`}
-                className="h-7 gap-1.5 px-2 bg-background text-xs shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
-              >
-                <Trash2Icon className="size-4" />
-                Remove
-              </Button>
-            </div>
-          ))}
+        <div className="flex items-center justify-between gap-3">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-400">
+            Audio Sources
+          </h3>
           <FileDropInput
             accept="audio/*,.zip,application/zip"
             data-testid="load-audio-button"
             disabled={loadAudioMutation.isPending}
             inputProps={{ "data-testid": "audio-file-input" }}
-            className="h-8 w-full justify-start gap-1.5 rounded-none border-0 px-3 bg-background text-sm text-neutral-300 shadow-xs hover:bg-accent hover:text-accent-foreground data-[drag-over=true]:bg-emerald-950/30 dark:bg-input/30 dark:hover:bg-input/50 disabled:opacity-50"
+            className="h-7 gap-1.5 px-2 bg-background text-xs text-neutral-300 shadow-xs hover:bg-accent hover:text-accent-foreground data-[drag-over=true]:border-emerald-500/60 data-[drag-over=true]:bg-emerald-950/30 dark:bg-input/30 dark:border-input dark:hover:bg-input/50 disabled:opacity-50"
             onFile={(file) => loadAudioMutation.mutate(file)}
           >
             <UploadIcon className="size-4" />
-            {loadAudioMutation.isPending ? "Loading..." : "Add Audio Source"}
+            {loadAudioMutation.isPending ? "Loading..." : "Add audio"}
           </FileDropInput>
         </div>
+        {audioTracks.length > 0 && (
+          <div className="overflow-hidden rounded-md border border-neutral-600">
+            {audioTracks.map((track) => (
+              <div
+                key={track.id}
+                className="flex items-center gap-2 border-b border-neutral-600 p-2 last:border-b-0"
+              >
+                <div className="flex-1 text-sm text-neutral-200 truncate">
+                  {track.fileName}
+                </div>
+                <Button
+                  data-testid="audio-to-midi-button"
+                  onClick={() => onAudioToMidiClick(track.id)}
+                  title={`Transcribe ${track.fileName} to MIDI notes`}
+                  className="h-7 gap-1.5 px-2 bg-background text-xs shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
+                >
+                  <SparklesIcon className="size-4" />
+                  To MIDI
+                </Button>
+                <Button
+                  data-testid="remove-audio-button"
+                  onClick={() => handleRemoveAudio(track)}
+                  title={`Remove ${track.fileName}`}
+                  className="h-7 gap-1.5 px-2 bg-background text-xs shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
+                >
+                  <Trash2Icon className="size-4" />
+                  Remove
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
       </section>
 
       <section className="space-y-2 border-t border-neutral-700 pt-5">

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -1,7 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import {
   DownloadIcon,
-  FolderIcon,
   SettingsIcon,
   SparklesIcon,
   Trash2Icon,
@@ -24,7 +23,7 @@ import {
   useProjectStore,
 } from "../lib/project-store";
 import { FileDropInput } from "./file-drop-input";
-import { Button, LinkButton } from "./ui/button";
+import { Button } from "./ui/button";
 
 type SettingsProps = {
   // Project section
@@ -193,13 +192,6 @@ export function Settings({
               placeholder="Enter project name"
             />
           </div>
-          <LinkButton
-            href="/"
-            className="h-8 w-full justify-start gap-1.5 px-3 bg-background text-sm shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"
-          >
-            <FolderIcon className="size-4" />
-            Manage Projects
-          </LinkButton>
         </div>
       </section>
 

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -238,11 +238,11 @@ export function Settings({
           </FileDropInput>
         </div>
         {audioTracks.length > 0 && (
-          <div className="overflow-hidden rounded-md border border-neutral-600">
+          <div>
             {audioTracks.map((track) => (
               <div
                 key={track.id}
-                className="flex items-center gap-2 border-b border-neutral-600 p-2 last:border-b-0"
+                className="flex items-center gap-2 py-1.5 pl-2"
               >
                 <div className="flex-1 text-sm text-neutral-200 truncate">
                   {track.fileName}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -13,7 +13,3 @@ export function Button({
     <button type={type} className={cn(buttonClassName, className)} {...props} />
   );
 }
-
-export function LinkButton({ className, ...props }: React.ComponentProps<"a">) {
-  return <a className={cn(buttonClassName, className)} {...props} />;
-}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -40,6 +40,22 @@ export function DropdownMenuContent({
   );
 }
 
+export function DropdownMenuItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item>) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
 export function DropdownMenuRadioGroup({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {


### PR DESCRIPTION
We've been extending the settings modal capability and it's becoming cluttered. This PR overhauls the structure for consistent and intuitive UI/UX.

- Left: main, Right: this PR

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9d629d7d-d2d6-4df1-8fb6-89caeddf36ea" />
