### PR TITLE
fix: preserve native copy for selected text

### DIFF
--- a/e2e/copy-paste.spec.ts
+++ b/e2e/copy-paste.spec.ts
@@ -81,6 +81,22 @@ test.describe("Copy/Paste", () => {
     expect(Math.abs(note2Box.y - note1Box.y)).toBeLessThan(2);
   });
 
+  test("copies selected text outside the piano roll", async ({
+    context,
+    page,
+  }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    await page.getByTestId("help-button").click();
+    await page.getByText("Quick Reference").selectText();
+
+    await page.keyboard.press("Control+c");
+
+    const copiedText = await page.evaluate(() =>
+      navigator.clipboard.readText(),
+    );
+    expect(copiedText).toBe("Quick Reference");
+  });
+
   test("paste snaps to grid", async ({ page }) => {
     const grid = page.getByTestId("piano-roll-grid");
     const gridBox = await grid.boundingBox();

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -26,6 +26,7 @@ type EditorProps = {
 };
 
 export function Editor({ projectId, initialProjectName }: EditorProps) {
+  const [isPianoRollActive, setIsPianoRollActive] = useState(true);
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isMixerOpen, setIsMixerOpen] = useState(false);
@@ -64,7 +65,15 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
   });
 
   return (
-    <div className="h-screen flex flex-col bg-neutral-900">
+    <div
+      className="h-screen flex flex-col bg-neutral-900"
+      onPointerDownCapture={(e) => {
+        setIsPianoRollActive(
+          e.target instanceof Element &&
+            e.target.closest("[data-piano-roll]") !== null,
+        );
+      }}
+    >
       <Transport
         projectName={projectName}
         controls={
@@ -101,7 +110,7 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
           </>
         }
       />
-      <PianoRoll />
+      <PianoRoll isShortcutContextActive={isPianoRollActive} />
       <HelpOverlay isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} />
       {isMixerOpen && (
         <FloatingPanel

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -26,7 +26,6 @@ type EditorProps = {
 };
 
 export function Editor({ projectId, initialProjectName }: EditorProps) {
-  const [isPianoRollActive, setIsPianoRollActive] = useState(true);
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isMixerOpen, setIsMixerOpen] = useState(false);
@@ -65,15 +64,7 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
   });
 
   return (
-    <div
-      className="h-screen flex flex-col bg-neutral-900"
-      onPointerDownCapture={(e) => {
-        setIsPianoRollActive(
-          e.target instanceof Element &&
-            e.target.closest("[data-piano-roll]") !== null,
-        );
-      }}
-    >
+    <div className="h-screen flex flex-col bg-neutral-900">
       <Transport
         projectName={projectName}
         controls={
@@ -110,7 +101,7 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
           </>
         }
       />
-      <PianoRoll isShortcutContextActive={isPianoRollActive} />
+      <PianoRoll />
       <HelpOverlay isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} />
       {isMixerOpen && (
         <FloatingPanel

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -107,11 +107,7 @@ type DragMode =
       currentY: number;
     };
 
-type PianoRollProps = {
-  isShortcutContextActive: boolean;
-};
-
-export function PianoRoll({ isShortcutContextActive }: PianoRollProps) {
+export function PianoRoll() {
   const {
     notes,
     selectedNoteIds,
@@ -174,7 +170,9 @@ export function PianoRoll({ isShortcutContextActive }: PianoRollProps) {
   const position = useAudio((state) => state.position);
 
   const gridRef = useRef<HTMLDivElement>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const wasLastPointerDownInsideRef = useRef(true);
   const [dragMode, setDragMode] = useState<DragMode>({ type: "none" });
 
   // Track viewport size
@@ -289,8 +287,13 @@ export function PianoRoll({ isShortcutContextActive }: PianoRollProps) {
   }, [stopPreviewNote]);
 
   // Handle keyboard events
+  useWindowEvent("pointerdown", (e) => {
+    wasLastPointerDownInsideRef.current =
+      e.target instanceof Node && rootRef.current?.contains(e.target) === true;
+  });
+
   useWindowEvent("keydown", (e) => {
-    if (!isShortcutContextActive) {
+    if (!wasLastPointerDownInsideRef.current) {
       return;
     }
 
@@ -937,7 +940,7 @@ export function PianoRoll({ isShortcutContextActive }: PianoRollProps) {
 
   return (
     <div
-      data-piano-roll
+      ref={rootRef}
       className="flex flex-col flex-1 bg-neutral-900 text-neutral-100 select-none overflow-hidden"
     >
       {/* Main content area - fixed layout, no native scroll */}

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -107,7 +107,11 @@ type DragMode =
       currentY: number;
     };
 
-export function PianoRoll() {
+type PianoRollProps = {
+  isShortcutContextActive: boolean;
+};
+
+export function PianoRoll({ isShortcutContextActive }: PianoRollProps) {
   const {
     notes,
     selectedNoteIds,
@@ -286,6 +290,10 @@ export function PianoRoll() {
 
   // Handle keyboard events
   useWindowEvent("keydown", (e) => {
+    if (!isShortcutContextActive) {
+      return;
+    }
+
     // Don't trigger shortcuts if typing in an input
     if (isShortcutTextInputTarget(e.target)) {
       return;
@@ -928,7 +936,10 @@ export function PianoRoll() {
   };
 
   return (
-    <div className="flex flex-col flex-1 bg-neutral-900 text-neutral-100 select-none overflow-hidden">
+    <div
+      data-piano-roll
+      className="flex flex-col flex-1 bg-neutral-900 text-neutral-100 select-none overflow-hidden"
+    >
       {/* Main content area - fixed layout, no native scroll */}
       <div ref={containerRef} className="flex-1 flex overflow-hidden">
         {/* Left column: track controls + keyboard labels */}

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -286,6 +286,8 @@ export function PianoRoll() {
     return () => stopPreviewNote();
   }, [stopPreviewNote]);
 
+  // Preserve native shortcuts outside the piano roll, such as Ctrl+C/Ctrl+V
+  // for text selected in the help overlay.
   useWindowEvent("pointerdown", (e) => {
     wasLastPointerDownInsideRef.current =
       e.target instanceof Node && rootRef.current?.contains(e.target) === true;

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -286,12 +286,12 @@ export function PianoRoll() {
     return () => stopPreviewNote();
   }, [stopPreviewNote]);
 
-  // Handle keyboard events
   useWindowEvent("pointerdown", (e) => {
     wasLastPointerDownInsideRef.current =
       e.target instanceof Node && rootRef.current?.contains(e.target) === true;
   });
 
+  // Handle keyboard events
   useWindowEvent("keydown", (e) => {
     if (!wasLastPointerDownInsideRef.current) {
       return;

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -170,9 +170,7 @@ export function PianoRoll() {
   const position = useAudio((state) => state.position);
 
   const gridRef = useRef<HTMLDivElement>(null);
-  const rootRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const wasLastPointerDownInsideRef = useRef(true);
   const [dragMode, setDragMode] = useState<DragMode>({ type: "none" });
 
   // Track viewport size
@@ -286,19 +284,8 @@ export function PianoRoll() {
     return () => stopPreviewNote();
   }, [stopPreviewNote]);
 
-  // Preserve native shortcuts outside the piano roll, such as Ctrl+C/Ctrl+V
-  // for text selected in the help overlay.
-  useWindowEvent("pointerdown", (e) => {
-    wasLastPointerDownInsideRef.current =
-      e.target instanceof Node && rootRef.current?.contains(e.target) === true;
-  });
-
   // Handle keyboard events
   useWindowEvent("keydown", (e) => {
-    if (!wasLastPointerDownInsideRef.current) {
-      return;
-    }
-
     // Don't trigger shortcuts if typing in an input
     if (isShortcutTextInputTarget(e.target)) {
       return;
@@ -319,6 +306,10 @@ export function PianoRoll() {
       selectLocator(undefined);
       selectAudioTrack(undefined);
     } else if (matchKeyboardEvent(e, "Ctrl+C")) {
+      // Let the browser copy selected UI text, such as help overlay content.
+      if (window.getSelection()?.isCollapsed === false) {
+        return;
+      }
       // Ctrl+C: Copy
       e.preventDefault();
       copyNotes();
@@ -941,10 +932,7 @@ export function PianoRoll() {
   };
 
   return (
-    <div
-      ref={rootRef}
-      className="flex flex-col flex-1 bg-neutral-900 text-neutral-100 select-none overflow-hidden"
-    >
+    <div className="flex flex-col flex-1 bg-neutral-900 text-neutral-100 select-none overflow-hidden">
       {/* Main content area - fixed layout, no native scroll */}
       <div ref={containerRef} className="flex-1 flex overflow-hidden">
         {/* Left column: track controls + keyboard labels */}


### PR DESCRIPTION
- related? https://github.com/hi-ogawa/toy-midi/issues/205

Piano roll keyboard shortcuts are handled globally, so `Ctrl+C` prevents native browser copy even when text outside the editor is selected, such as content in the help overlay.

This PR preserves native copy when there is an active text selection and adds an e2e test for copying text from the help overlay.