### PR TITLE
fix: import projects with multiple audio tracks

### DIFF
--- a/src/lib/idb.ts
+++ b/src/lib/idb.ts
@@ -16,11 +16,11 @@ export class IdbStore<T> {
   }
 
   async put(value: T): Promise<void> {
-    await this.write((store) => store.put(value));
+    await this.request("readwrite", (store) => store.put(value));
   }
 
   async delete(key: string): Promise<void> {
-    await this.write((store) => store.delete(key));
+    await this.request("readwrite", (store) => store.delete(key));
   }
 
   private openDB(): Promise<IDBDatabase> {
@@ -60,21 +60,7 @@ export class IdbStore<T> {
       const tx = db.transaction(this.options.storeName, mode);
       const request = run(tx.objectStore(this.options.storeName));
 
-      request.onsuccess = () => resolve(request.result);
-      request.onerror = () => reject(request.error);
-    });
-  }
-
-  private async write(
-    run: (store: IDBObjectStore) => IDBRequest,
-  ): Promise<void> {
-    const db = await this.openDB();
-
-    return new Promise((resolve, reject) => {
-      const tx = db.transaction(this.options.storeName, "readwrite");
-      run(tx.objectStore(this.options.storeName));
-
-      tx.oncomplete = () => resolve();
+      tx.oncomplete = () => resolve(request.result);
       tx.onerror = () => reject(tx.error);
       tx.onabort = () => reject(tx.error);
     });

--- a/src/lib/idb.ts
+++ b/src/lib/idb.ts
@@ -16,11 +16,11 @@ export class IdbStore<T> {
   }
 
   async put(value: T): Promise<void> {
-    await this.request("readwrite", (store) => store.put(value));
+    await this.write((store) => store.put(value));
   }
 
   async delete(key: string): Promise<void> {
-    await this.request("readwrite", (store) => store.delete(key));
+    await this.write((store) => store.delete(key));
   }
 
   private openDB(): Promise<IDBDatabase> {
@@ -62,6 +62,21 @@ export class IdbStore<T> {
 
       request.onsuccess = () => resolve(request.result);
       request.onerror = () => reject(request.error);
+    });
+  }
+
+  private async write(
+    run: (store: IDBObjectStore) => IDBRequest,
+  ): Promise<void> {
+    const db = await this.openDB();
+
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(this.options.storeName, "readwrite");
+      run(tx.objectStore(this.options.storeName));
+
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error);
     });
   }
 }


### PR DESCRIPTION
Importing a project with multiple audio tracks could immediately report the final track's asset as missing. The previous flow was racy:

```text
put final audio asset
  -> IDBRequest succeeds
  -> import treats the write as finished
  -> app navigates to the imported project
  -> write transaction has not committed yet and is interrupted
  -> project restore cannot find the final asset and clears the track
```

This was observed consistently in Chromium, but the incorrect transaction boundary was in the app. Request success only means the operation succeeded within its transaction; the write is complete when the transaction fires `complete`.

This PR makes the shared IndexedDB helper resolve on transaction completion instead. The import therefore waits for every audio asset to commit before navigation. Reads still return the request result, while transaction errors and aborts propagate to callers.