### PR TITLE
refactor: share export download helper

### DIFF
--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -9,10 +9,10 @@ import { toast } from "sonner";
 import { useDraftTextInput } from "../hooks/use-draft-text-input";
 import { audioManager, loadAudioFile } from "../lib/audio";
 import { resolveAudioFiles } from "../lib/audio-files";
-import { buildExportFileName } from "../lib/export-utils";
-import { downloadMidiFile, exportMidi } from "../lib/midi-export";
+import { buildExportFileName, downloadBlob } from "../lib/export-utils";
+import { exportMidi } from "../lib/midi-export";
 import { importMidiNotes, type MidiImportOptions } from "../lib/midi-import";
-import { downloadProjectFile, exportProjectFile } from "../lib/project-file";
+import { exportProjectFile } from "../lib/project-file";
 import { projectStorage } from "../lib/project-storage";
 import {
   type AudioTrack,
@@ -171,14 +171,21 @@ export function Settings({
       extension: ".mid",
     });
 
-    downloadMidiFile(midiData, fileName);
+    downloadBlob(
+      new Blob([midiData as BlobPart], { type: "audio/midi" }),
+      fileName,
+    );
   };
 
   const exportProjectMutation = useMutation({
     mutationFn: async () => {
       const projectData = toSavedProject(useProjectStore.getState());
       const blob = await exportProjectFile(projectName, projectData);
-      downloadProjectFile(blob, projectName);
+      const fileName = buildExportFileName({
+        baseName: projectName,
+        extension: ".toymidi",
+      });
+      downloadBlob(blob, fileName);
     },
     onError: (error) => {
       console.error("Failed to export project:", error);

--- a/src/lib/export-utils.ts
+++ b/src/lib/export-utils.ts
@@ -35,16 +35,14 @@ function sanitizeBaseName(baseName: string): string {
 type ExportFileNameOptions = {
   baseName: string;
   extension: string;
-  timestamp?: Date;
 };
 
 export function buildExportFileName({
   baseName,
   extension,
-  timestamp = new Date(),
 }: ExportFileNameOptions): string {
   const safeName = sanitizeBaseName(baseName);
   const normalizedExtension = normalizeExtension(extension);
-  const formattedTimestamp = formatTimestamp(timestamp);
+  const formattedTimestamp = formatTimestamp(new Date());
   return `${safeName}-${formattedTimestamp}${normalizedExtension}`;
 }

--- a/src/lib/export-utils.ts
+++ b/src/lib/export-utils.ts
@@ -9,29 +9,6 @@ export function downloadBlob(blob: Blob, fileName: string): void {
   URL.revokeObjectURL(url);
 }
 
-function formatTimestamp(timestamp: Date): string {
-  return timestamp
-    .toISOString()
-    .replace(/[T:]/g, "-")
-    .replace(/\.\d+Z$/, "");
-}
-
-function normalizeExtension(extension: string): string {
-  const trimmed = extension.trim().toLowerCase();
-  if (!trimmed) {
-    return "";
-  }
-  return trimmed.startsWith(".") ? trimmed : `.${trimmed}`;
-}
-
-function sanitizeBaseName(baseName: string): string {
-  const trimmed = baseName.trim();
-  if (!trimmed) {
-    return "toy-midi-export";
-  }
-  return trimmed.replace(/[^a-zA-Z0-9-_]/g, "_");
-}
-
 type ExportFileNameOptions = {
   baseName: string;
   extension: string;
@@ -45,4 +22,27 @@ export function buildExportFileName({
   const normalizedExtension = normalizeExtension(extension);
   const formattedTimestamp = formatTimestamp(new Date());
   return `${safeName}-${formattedTimestamp}${normalizedExtension}`;
+}
+
+function sanitizeBaseName(baseName: string): string {
+  const trimmed = baseName.trim();
+  if (!trimmed) {
+    return "toy-midi-export";
+  }
+  return trimmed.replace(/[^a-zA-Z0-9-_]/g, "_");
+}
+
+function normalizeExtension(extension: string): string {
+  const trimmed = extension.trim().toLowerCase();
+  if (!trimmed) {
+    return "";
+  }
+  return trimmed.startsWith(".") ? trimmed : `.${trimmed}`;
+}
+
+function formatTimestamp(timestamp: Date): string {
+  return timestamp
+    .toISOString()
+    .replace(/[T:]/g, "-")
+    .replace(/\.\d+Z$/, "");
 }

--- a/src/lib/export-utils.ts
+++ b/src/lib/export-utils.ts
@@ -1,9 +1,3 @@
-type ExportFileNameOptions = {
-  baseName: string;
-  extension: string;
-  timestamp?: Date;
-};
-
 export function downloadBlob(blob: Blob, fileName: string): void {
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
@@ -37,6 +31,12 @@ function sanitizeBaseName(baseName: string): string {
   }
   return trimmed.replace(/[^a-zA-Z0-9-_]/g, "_");
 }
+
+type ExportFileNameOptions = {
+  baseName: string;
+  extension: string;
+  timestamp?: Date;
+};
 
 export function buildExportFileName({
   baseName,

--- a/src/lib/export-utils.ts
+++ b/src/lib/export-utils.ts
@@ -4,6 +4,17 @@ type ExportFileNameOptions = {
   timestamp?: Date;
 };
 
+export function downloadBlob(blob: Blob, fileName: string): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
 function formatTimestamp(timestamp: Date): string {
   return timestamp
     .toISOString()

--- a/src/lib/midi-export.ts
+++ b/src/lib/midi-export.ts
@@ -55,26 +55,3 @@ export function exportMidi(options: MidiExportOptions): Uint8Array {
   // Convert to Uint8Array
   return midi.toArray();
 }
-
-/**
- * Download MIDI file to the user's computer
- * @param midiData - Uint8Array containing MIDI file data
- * @param fileName - Desired file name
- */
-export function downloadMidiFile(midiData: Uint8Array, fileName: string): void {
-  // Create a blob from the byte array
-  // Cast to any to avoid TypeScript issues with ArrayBufferLike vs ArrayBuffer
-  const blob = new Blob([midiData as any], { type: "audio/midi" });
-
-  // Create a download link and trigger it
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = fileName;
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-
-  // Clean up the URL
-  URL.revokeObjectURL(url);
-}

--- a/src/lib/project-file.ts
+++ b/src/lib/project-file.ts
@@ -1,5 +1,4 @@
 import JSZip from "jszip";
-import { buildExportFileName } from "./export-utils";
 import { projectStorage } from "./project-storage";
 import {
   type AnySavedProject,
@@ -116,25 +115,6 @@ export async function exportProjectFileV1(
   );
 
   return zip.generateAsync({ type: "blob", compression: "DEFLATE" });
-}
-
-/**
- * Download a .toymidi file
- */
-export function downloadProjectFile(blob: Blob, projectName: string): void {
-  const fileName = buildExportFileName({
-    baseName: projectName,
-    extension: ".toymidi",
-  });
-
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = fileName;
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-  URL.revokeObjectURL(url);
 }
 
 /**


### PR DESCRIPTION
MIDI and project archive exports duplicate the same object-URL and temporary-link lifecycle, while their format-specific wrappers are only used once.

This PR moves that browser download lifecycle into `downloadBlob` and keeps Blob construction and filename policy at the settings export call sites.