### PR TITLE
refactor: use named Playwright page types

### DIFF
--- a/e2e/copy-paste.spec.ts
+++ b/e2e/copy-paste.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import { clickNewProject } from "./helpers";
 
 // Constants matching piano-roll.tsx
@@ -8,10 +8,7 @@ const ROW_HEIGHT = 20;
 // TODO: consolidate into fewer user-flow tests (combine paste/snap/preserve/selection)
 
 // Helper to seek playhead by clicking on timeline
-async function seekTobeat(
-  page: import("@playwright/test").Page,
-  beat: number,
-): Promise<void> {
+async function seekTobeat(page: Page, beat: number): Promise<void> {
   const timeline = page.getByTestId("timeline");
   const timelineBox = await timeline.boundingBox();
   if (!timelineBox) {

--- a/e2e/settings-export.spec.ts
+++ b/e2e/settings-export.spec.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import { clickNewProject, evaluateStore } from "./helpers";
 
 // Constants matching piano-roll.tsx
@@ -15,7 +15,7 @@ test.describe("Settings Dialog - Project Export", () => {
     await clickNewProject(page);
   });
 
-  async function openSettings(page: import("@playwright/test").Page) {
+  async function openSettings(page: Page) {
     await page.getByTestId("settings-button").click();
     await page.getByTestId("settings-dialog").waitFor({ state: "visible" });
   }


### PR DESCRIPTION
Use named type-only `Page` imports in the two E2E specs that referenced Playwright types through inline import expressions. This matches the convention used by the rest of the E2E suite and keeps the imports type-only.\n\nTested with `pnpm lint`.