### PR TITLE
refactor: simplify BPM label

### DIFF
--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -169,7 +169,7 @@ export function Transport({ projectName, controls }: TransportProps) {
 
       {/* Tempo: BPM input + tap button + time signature */}
       <div className="flex items-center gap-1.5">
-        <span className="text-muted-foreground">BPM:</span>
+        <span className="text-muted-foreground">BPM</span>
         <input
           data-testid="tempo-input"
           type="text"


### PR DESCRIPTION
Remove the redundant colon from the editor transport BPM label for cleaner control labeling.
