### PR TITLE
feat: render score videos offline

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint-dead-code": "fallow dead-code --unused-exports --unused-types",
     "test": "vitest",
     "test-e2e": "playwright test",
-    "basic-pitch": "node tools/basic-pitch.mjs"
+    "basic-pitch": "node tools/basic-pitch.mjs",
+    "render-score-video": "node tools/render-score-video.mjs"
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -37,6 +38,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
+    "@resvg/resvg-js": "^2.6.2",
     "@tailwindcss/vite": "^4.1.18",
     "@types/node": "^25.0.3",
     "@types/react": "^19.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
+      '@resvg/resvg-js':
+        specifier: ^2.6.2
+        version: 2.6.2
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
@@ -1006,6 +1009,82 @@ packages:
 
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    resolution: {integrity: sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    resolution: {integrity: sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@resvg/resvg-js-darwin-arm64@2.6.2':
+    resolution: {integrity: sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    resolution: {integrity: sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    resolution: {integrity: sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
+    resolution: {integrity: sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
+    resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
+    resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-x64-musl@2.6.2':
+    resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
+    resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    resolution: {integrity: sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
+    resolution: {integrity: sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@resvg/resvg-js@2.6.2':
+    resolution: {integrity: sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==}
+    engines: {node: '>= 10'}
 
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
@@ -3268,6 +3347,57 @@ snapshots:
       '@types/react': 19.2.7
 
   '@radix-ui/rect@1.1.1': {}
+
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-musl@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js@2.6.2':
+    optionalDependencies:
+      '@resvg/resvg-js-android-arm-eabi': 2.6.2
+      '@resvg/resvg-js-android-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-x64': 2.6.2
+      '@resvg/resvg-js-linux-arm-gnueabihf': 2.6.2
+      '@resvg/resvg-js-linux-arm64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-arm64-musl': 2.6.2
+      '@resvg/resvg-js-linux-x64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-x64-musl': 2.6.2
+      '@resvg/resvg-js-win32-arm64-msvc': 2.6.2
+      '@resvg/resvg-js-win32-ia32-msvc': 2.6.2
+      '@resvg/resvg-js-win32-x64-msvc': 2.6.2
 
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -31,7 +31,7 @@ export type ScoreSource = {
  * system ends let the cursor finish a row before jumping to the next system.
  * Playback interpolates horizontally between adjacent anchors in one system.
  */
-type CursorPosition = {
+export type CursorPosition = {
   /** Score time in whole-note units, matching OSMD's Fraction.RealValue. */
   time: number;
   /** Horizontal cursor position in CSS pixels within the rendered score. */
@@ -42,6 +42,15 @@ type CursorPosition = {
   height: number;
   /** OSMD system identity, used to avoid interpolation across wrapped rows. */
   systemId: number;
+};
+
+export type ScoreVideoScene = {
+  cursorPositions: CursorPosition[];
+  duration: number;
+  scoreHeight: number;
+  scoreSvg: string;
+  scoreWidth: number;
+  tempo: number;
 };
 
 // OSMD reads its layout width from the container's offsetWidth. This value was
@@ -185,6 +194,25 @@ export class ScoreViewerRuntime {
 
   seek(scoreTime: number) {
     this.#clock.seek(scoreTimeToSeconds(scoreTime, this.#state.tempo));
+  }
+
+  exportVideoScene(): ScoreVideoScene {
+    if (!this.#state.isReady || this.#positions.length < 2) {
+      throw new Error("Load a score before exporting video scene data");
+    }
+    const scoreSvg = this.#container.querySelector("svg");
+    if (!scoreSvg) {
+      throw new Error("OSMD did not render an SVG score");
+    }
+    const lastPosition = this.#positions.at(-1)!;
+    return {
+      cursorPositions: this.#positions,
+      duration: scoreTimeToSeconds(lastPosition.time, this.#state.tempo),
+      scoreHeight: Math.ceil(this.#container.getBoundingClientRect().height),
+      scoreSvg: new XMLSerializer().serializeToString(scoreSvg),
+      scoreWidth: SCORE_LAYOUT_WIDTH,
+      tempo: this.#state.tempo,
+    };
   }
 
   dispose() {

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -19,6 +19,7 @@ import { FileDropInput } from "./file-drop-input";
 import {
   type ScoreLayout,
   type ScoreSource,
+  type ScoreVideoScene,
   ScoreViewerRuntime,
 } from "./score-viewer-runtime";
 import { Button } from "./ui/button";
@@ -49,6 +50,24 @@ export function ScoreViewer() {
     }
     runtime.attach(root);
     return () => runtime.dispose();
+  }, [runtime]);
+
+  useEffect(() => {
+    window.__toyMidiScoreVideo = {
+      exportScene: () => runtime.exportVideoScene(),
+      loadSample: async (id) => {
+        const sample = SCORE_VIEWER_SAMPLES.find((item) => item.id === id);
+        if (!sample) {
+          throw new Error(`Unknown score sample: ${id}`);
+        }
+        const nextScore = { name: sample.name, xml: sample.xml };
+        await runtime.load({ score: nextScore, layout: "continuous" });
+        setScore(nextScore);
+      },
+    };
+    return () => {
+      delete window.__toyMidiScoreVideo;
+    };
   }, [runtime]);
 
   const tempoInput = useDraftInput({
@@ -299,6 +318,15 @@ export function ScoreViewer() {
       />
     </main>
   );
+}
+
+declare global {
+  interface Window {
+    __toyMidiScoreVideo?: {
+      exportScene: () => ScoreVideoScene;
+      loadSample: (id: string) => Promise<void>;
+    };
+  }
 }
 
 function formatBarBeat(bar: number, beat: number) {

--- a/tools/render-score-video.mjs
+++ b/tools/render-score-video.mjs
@@ -1,0 +1,188 @@
+import { spawn } from "node:child_process";
+import { chromium } from "@playwright/test";
+import { Resvg } from "@resvg/resvg-js";
+
+async function main() {
+  const { fps, height, output, sampleId } = parseOptions(process.argv.slice(2));
+
+  const browser = await chromium.launch({ channel: "chromium" });
+  const page = await browser.newPage({ viewport: { width: 1110, height } });
+  await page.goto("http://localhost:5183/score-viewer");
+  await page.evaluate(async (id) => {
+    await window.__toyMidiScoreVideo.loadSample(id);
+  }, sampleId);
+  const scene = await page.evaluate(() =>
+    window.__toyMidiScoreVideo.exportScene(),
+  );
+  await browser.close();
+  const width = scene.scoreWidth;
+  const scorePixels = new Resvg(buildScoreSvg(scene)).render().pixels;
+
+  const ffmpeg = spawn(
+    "ffmpeg",
+    [
+      "-y",
+      "-f",
+      "rawvideo",
+      "-pixel_format",
+      "rgba",
+      "-video_size",
+      `${width}x${height}`,
+      "-framerate",
+      String(fps),
+      "-i",
+      "-",
+      "-an",
+      "-c:v",
+      "libx264",
+      "-pix_fmt",
+      "yuv420p",
+      output,
+    ],
+    { stdio: ["pipe", "inherit", "inherit"] },
+  );
+
+  const frameCount = Math.ceil(scene.duration * fps);
+  let viewportTop = 0;
+  for (let frame = 0; frame < frameCount; frame++) {
+    const scoreTime = (frame / fps) * (scene.tempo / 60 / 4);
+    const cursor = resolveCursor(scene.cursorPositions, scoreTime);
+    if (
+      cursor.top < viewportTop ||
+      cursor.top + cursor.height > viewportTop + height
+    ) {
+      viewportTop = Math.max(cursor.top - 24, 0);
+    }
+    const pixels = compositeFrame({
+      cursor,
+      height,
+      scene,
+      scorePixels,
+      viewportTop,
+      width,
+    });
+    if (!ffmpeg.stdin.write(pixels)) {
+      await new Promise((resolve) => ffmpeg.stdin.once("drain", resolve));
+    }
+  }
+  ffmpeg.stdin.end();
+  const exitCode = await new Promise((resolve) =>
+    ffmpeg.once("close", resolve),
+  );
+  if (exitCode !== 0) {
+    throw new Error(`ffmpeg exited with code ${exitCode}`);
+  }
+}
+
+function parseOptions(args) {
+  const positional = [];
+  const options = { fps: 30, height: 556 };
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index];
+    switch (argument) {
+      case "--height": {
+        options.height = parsePositiveInteger(argument, args[++index]);
+        if (options.height % 2 !== 0) {
+          throw new Error("--height must be even for H.264 YUV420 output");
+        }
+        break;
+      }
+      case "--fps": {
+        options.fps = parsePositiveInteger(argument, args[++index]);
+        break;
+      }
+      default: {
+        if (argument.startsWith("--")) {
+          throw new Error(`Unknown option: ${argument}`);
+        }
+        positional.push(argument);
+      }
+    }
+  }
+  if (positional.length > 2) {
+    throw new Error("Expected at most a sample id and output path");
+  }
+  return {
+    ...options,
+    sampleId: positional[0] ?? "cursor-wrapping",
+    output: positional[1] ?? ".tmp/score-video.mp4",
+  };
+}
+
+function parsePositiveInteger(option, value) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${option} requires a positive integer`);
+  }
+  return parsed;
+}
+
+function resolveCursor(positions, scoreTime) {
+  let nextIndex = positions.findIndex((position) => position.time > scoreTime);
+  if (nextIndex < 1) {
+    nextIndex = Math.min(Math.max(nextIndex, 1), positions.length - 1);
+  }
+  const current = positions[nextIndex - 1];
+  const next = positions[nextIndex];
+  const progress =
+    current.systemId === next.systemId
+      ? (scoreTime - current.time) / (next.time - current.time)
+      : 0;
+  return {
+    height: current.height,
+    top: current.top,
+    x: current.x + (next.x - current.x) * progress,
+  };
+}
+
+function buildScoreSvg(scene) {
+  const scoreSvg = scene.scoreSvg
+    .replace(/^<svg[^>]*>/, "")
+    .replace(/<\/svg>\s*$/, "");
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${scene.scoreWidth}" height="${scene.scoreHeight}" viewBox="0 0 ${scene.scoreWidth} ${scene.scoreHeight}">
+      <rect width="100%" height="100%" fill="white"/>
+      ${scoreSvg}
+    </svg>`;
+}
+
+function compositeFrame({
+  cursor,
+  height,
+  scene,
+  scorePixels,
+  viewportTop,
+  width,
+}) {
+  const pixels = Buffer.alloc(width * height * 4, 0xff);
+  for (let index = 3; index < pixels.length; index += 4) {
+    pixels[index] = 0xff;
+  }
+
+  const destinationX = 0;
+  const sourceY = Math.max(Math.floor(viewportTop - 24), 0);
+  const destinationY = Math.max(Math.floor(24 - viewportTop), 0);
+  const rows = Math.min(scene.scoreHeight - sourceY, height - destinationY);
+  for (let row = 0; row < rows; row++) {
+    const sourceStart = (sourceY + row) * scene.scoreWidth * 4;
+    const destinationStart = ((destinationY + row) * width + destinationX) * 4;
+    pixels.set(
+      scorePixels.subarray(sourceStart, sourceStart + scene.scoreWidth * 4),
+      destinationStart,
+    );
+  }
+
+  const cursorX = Math.round(destinationX + cursor.x);
+  const cursorTop = Math.round(24 + cursor.top - viewportTop);
+  const cursorBottom = Math.min(Math.round(cursorTop + cursor.height), height);
+  for (let y = Math.max(cursorTop, 0); y < cursorBottom; y++) {
+    for (let x = cursorX; x < cursorX + 3; x++) {
+      pixels.set([0x3b, 0x82, 0xf6, 0xff], (y * width + x) * 4);
+    }
+  }
+  return pixels;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
The score viewer currently has to play in real time while its viewport is screen-recorded for the Kdenlive score layer. This adds a data-oriented offline renderer that reuses OSMD layout and the existing piecewise cursor geometry without taking browser screenshots.

The browser renders and exports the static score SVG and cursor anchors once. The CLI rasterizes that SVG once with resvg, composites deterministic viewport crops and cursor positions into raw RGBA frames, and streams them directly to FFmpeg. Output uses the fixed 1110px score layout, a configurable even viewport height, and the same cursor-containment scrolling rule as interactive playback.

Example:

```sh
pnpm dev --port 5183
pnpm render-score-video long-score .tmp/score-video.mp4 --height 556
```

Validated with the 64-measure sample at 1110x556 and 30 fps. The 2:19 video rendered in about 8 seconds locally.

Tests: `pnpm lint`, `pnpm test -- --run`

Part of #224.