### PR TITLE
feat: render score videos offline

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint-dead-code": "fallow dead-code --unused-exports --unused-types",
     "test": "vitest",
     "test-e2e": "playwright test",
-    "basic-pitch": "node tools/basic-pitch.mjs"
+    "basic-pitch": "node tools/basic-pitch.mjs",
+    "render-score-video": "node tools/render-score-video.mjs"
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -37,6 +38,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
+    "@resvg/resvg-js": "^2.6.2",
     "@tailwindcss/vite": "^4.1.18",
     "@types/node": "^25.0.3",
     "@types/react": "^19.2.7",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "vitest",
     "test-e2e": "playwright test",
     "basic-pitch": "node tools/basic-pitch.mjs",
-    "render-score-video": "node tools/render-score-video.mjs"
+    "render-score-video": "tsx tools/render-score-video.ts"
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -46,6 +46,7 @@
     "@vitejs/plugin-react": "^5.1.2",
     "fallow": "^2.50.0",
     "tailwindcss": "^4.1.18",
+    "tsx": "^4.23.4",
     "typescript": "^5.9.3",
     "vite": "^7.3.1",
     "vite-plus": "^0.1.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
         version: 2.6.2
       '@tailwindcss/vite':
         specifier: ^4.1.18
-        version: 4.1.18(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+        version: 4.1.18(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.4)(yaml@2.8.2))
       '@types/node':
         specifier: ^25.0.3
         version: 25.0.3
@@ -80,25 +80,28 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react':
         specifier: ^5.1.2
-        version: 5.1.2(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+        version: 5.1.2(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.4)(yaml@2.8.2))
       fallow:
         specifier: ^2.50.0
         version: 2.75.0
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
+      tsx:
+        specifier: ^4.23.4
+        version: 4.23.4
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+        version: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.4)(yaml@2.8.2)
       vite-plus:
         specifier: ^0.1.16
-        version: 0.1.21(@types/node@25.0.3)(esbuild@0.27.2)(happy-dom@20.1.0)(jiti@2.6.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(yaml@2.8.2)
+        version: 0.1.21(@types/node@25.0.3)(esbuild@0.28.1)(happy-dom@20.1.0)(jiti@2.6.1)(tsx@4.23.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.4)(yaml@2.8.2))(yaml@2.8.2)
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@25.0.3)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+        version: 4.0.16(@types/node@25.0.3)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.4)(yaml@2.8.2)
 
 packages:
 
@@ -195,8 +198,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.2':
     resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -207,8 +222,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.2':
     resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -219,8 +246,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.2':
     resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -231,8 +270,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.2':
     resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -243,8 +294,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.2':
     resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -255,8 +318,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.2':
     resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -267,8 +342,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.2':
     resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -279,8 +366,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.2':
     resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -291,8 +390,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.2':
     resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -303,8 +414,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.2':
     resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -315,8 +438,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.2':
     resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -327,8 +462,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.2':
     resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -339,8 +486,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.2':
     resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1786,6 +1945,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -2400,6 +2564,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.23.4:
+    resolution: {integrity: sha512-ZiUQ8oT/KzN51mJUWPqARYqwFLFJZtGZipRkw1ynHMr9vy3eU77m5yfF3Gzm6meEg/beW+lUu3fHYgskTN2oVQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
@@ -2754,79 +2923,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.2':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
   '@esbuild/android-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm@0.27.2':
     optional: true
 
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
   '@esbuild/android-x64@0.27.2':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.2':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.2':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm64@0.27.2':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
   '@esbuild/linux-arm@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-ia32@0.27.2':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.2':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.2':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-x64@0.27.2':
     optional: true
 
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.2':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.2':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
   '@esbuild/sunos-x64@0.27.2':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
   '@esbuild/win32-ia32@0.27.2':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
   '@esbuild/win32-x64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@fallow-cli/darwin-arm64@2.75.0':
@@ -3547,12 +3794,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
 
-  '@tailwindcss/vite@4.1.18(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.1.18(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.4)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
-      vite: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.4)(yaml@2.8.2)
 
   '@tanstack/query-core@5.90.16': {}
 
@@ -3706,7 +3953,7 @@ snapshots:
       '@types/node': 25.9.2
     optional: true
 
-  '@vitejs/plugin-react@5.1.2(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
+  '@vitejs/plugin-react@5.1.2(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.4)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -3714,7 +3961,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.53
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.4)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -3727,13 +3974,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.16(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.16(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.4)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.16
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.4)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.16':
     dependencies:
@@ -3757,7 +4004,7 @@ snapshots:
       '@vitest/pretty-format': 4.0.16
       tinyrainbow: 3.0.3
 
-  '@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.2)':
+  '@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.4)(typescript@5.9.3)(yaml@2.8.2)':
     dependencies:
       '@oxc-project/runtime': 0.129.0
       '@oxc-project/types': 0.129.0
@@ -3765,9 +4012,10 @@ snapshots:
       postcss: 8.5.6
     optionalDependencies:
       '@types/node': 25.0.3
-      esbuild: 0.27.2
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.6.1
+      tsx: 4.23.4
       typescript: 5.9.3
       yaml: 2.8.2
 
@@ -3789,11 +4037,11 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.21':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.21(@types/node@25.0.3)(esbuild@0.27.2)(happy-dom@20.1.0)(jiti@2.6.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(yaml@2.8.2)':
+  '@voidzero-dev/vite-plus-test@0.1.21(@types/node@25.0.3)(esbuild@0.28.1)(happy-dom@20.1.0)(jiti@2.6.1)(tsx@4.23.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.4)(yaml@2.8.2))(yaml@2.8.2)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.21(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.2)
+      '@voidzero-dev/vite-plus-core': 0.1.21(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.4)(typescript@5.9.3)(yaml@2.8.2)
       es-module-lexer: 1.7.0
       obug: 2.1.1
       pixelmatch: 7.2.0
@@ -3803,7 +4051,7 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
-      vite: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.4)(yaml@2.8.2)
       ws: 8.19.0
     optionalDependencies:
       '@types/node': 25.0.3
@@ -4042,6 +4290,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.2
       '@esbuild/win32-ia32': 0.27.2
       '@esbuild/win32-x64': 0.27.2
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -4713,6 +4990,12 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.23.4:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -4757,11 +5040,11 @@ snapshots:
 
   vexflow@1.2.93: {}
 
-  vite-plus@0.1.21(@types/node@25.0.3)(esbuild@0.27.2)(happy-dom@20.1.0)(jiti@2.6.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(yaml@2.8.2):
+  vite-plus@0.1.21(@types/node@25.0.3)(esbuild@0.28.1)(happy-dom@20.1.0)(jiti@2.6.1)(tsx@4.23.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.4)(yaml@2.8.2))(yaml@2.8.2):
     dependencies:
       '@oxc-project/types': 0.129.0
-      '@voidzero-dev/vite-plus-core': 0.1.21(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.2)
-      '@voidzero-dev/vite-plus-test': 0.1.21(@types/node@25.0.3)(esbuild@0.27.2)(happy-dom@20.1.0)(jiti@2.6.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(yaml@2.8.2)
+      '@voidzero-dev/vite-plus-core': 0.1.21(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.4)(typescript@5.9.3)(yaml@2.8.2)
+      '@voidzero-dev/vite-plus-test': 0.1.21(@types/node@25.0.3)(esbuild@0.28.1)(happy-dom@20.1.0)(jiti@2.6.1)(tsx@4.23.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.4)(yaml@2.8.2))(yaml@2.8.2)
       oxfmt: 0.48.0
       oxlint: 1.63.0(oxlint-tsgolint@0.22.1)
       oxlint-tsgolint: 0.22.1
@@ -4805,7 +5088,7 @@ snapshots:
       - vite
       - yaml
 
-  vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2):
+  vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.4)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -4818,12 +5101,13 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2
+      tsx: 4.23.4
       yaml: 2.8.2
 
-  vitest@4.0.16(@types/node@25.0.3)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2):
+  vitest@4.0.16(@types/node@25.0.3)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.4)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.16
-      '@vitest/mocker': 4.0.16(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.16(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.4)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.16
       '@vitest/runner': 4.0.16
       '@vitest/snapshot': 4.0.16
@@ -4840,7 +5124,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.4)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
+      '@resvg/resvg-js':
+        specifier: ^2.6.2
+        version: 2.6.2
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
@@ -1006,6 +1009,82 @@ packages:
 
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    resolution: {integrity: sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    resolution: {integrity: sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@resvg/resvg-js-darwin-arm64@2.6.2':
+    resolution: {integrity: sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    resolution: {integrity: sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    resolution: {integrity: sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
+    resolution: {integrity: sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
+    resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
+    resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-x64-musl@2.6.2':
+    resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
+    resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    resolution: {integrity: sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
+    resolution: {integrity: sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@resvg/resvg-js@2.6.2':
+    resolution: {integrity: sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==}
+    engines: {node: '>= 10'}
 
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
@@ -3268,6 +3347,57 @@ snapshots:
       '@types/react': 19.2.7
 
   '@radix-ui/rect@1.1.1': {}
+
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-musl@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js@2.6.2':
+    optionalDependencies:
+      '@resvg/resvg-js-android-arm-eabi': 2.6.2
+      '@resvg/resvg-js-android-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-x64': 2.6.2
+      '@resvg/resvg-js-linux-arm-gnueabihf': 2.6.2
+      '@resvg/resvg-js-linux-arm64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-arm64-musl': 2.6.2
+      '@resvg/resvg-js-linux-x64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-x64-musl': 2.6.2
+      '@resvg/resvg-js-win32-arm64-msvc': 2.6.2
+      '@resvg/resvg-js-win32-ia32-msvc': 2.6.2
+      '@resvg/resvg-js-win32-x64-msvc': 2.6.2
 
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -31,7 +31,7 @@ export type ScoreSource = {
  * system ends let the cursor finish a row before jumping to the next system.
  * Playback interpolates horizontally between adjacent anchors in one system.
  */
-type CursorPosition = {
+export type CursorPosition = {
   /** Score time in whole-note units, matching OSMD's Fraction.RealValue. */
   time: number;
   /** Horizontal cursor position in CSS pixels within the rendered score. */
@@ -42,6 +42,15 @@ type CursorPosition = {
   height: number;
   /** OSMD system identity, used to avoid interpolation across wrapped rows. */
   systemId: number;
+};
+
+export type ScoreVideoScene = {
+  cursorPositions: CursorPosition[];
+  duration: number;
+  scoreHeight: number;
+  scoreSvg: string;
+  scoreWidth: number;
+  tempo: number;
 };
 
 // OSMD reads its layout width from the container's offsetWidth. This value was
@@ -185,6 +194,25 @@ export class ScoreViewerRuntime {
 
   seek(scoreTime: number) {
     this.#clock.seek(scoreTimeToSeconds(scoreTime, this.#state.tempo));
+  }
+
+  exportVideoScene(): ScoreVideoScene {
+    if (!this.#state.isReady || this.#positions.length < 2) {
+      throw new Error("Load a score before exporting video scene data");
+    }
+    const scoreSvg = this.#container.querySelector("svg");
+    if (!scoreSvg) {
+      throw new Error("OSMD did not render an SVG score");
+    }
+    const lastPosition = this.#positions.at(-1)!;
+    return {
+      cursorPositions: this.#positions,
+      duration: scoreTimeToSeconds(lastPosition.time, this.#state.tempo),
+      scoreHeight: Math.ceil(this.#container.getBoundingClientRect().height),
+      scoreSvg: new XMLSerializer().serializeToString(scoreSvg),
+      scoreWidth: SCORE_LAYOUT_WIDTH,
+      tempo: this.#state.tempo,
+    };
   }
 
   dispose() {

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -19,6 +19,7 @@ import { FileDropInput } from "./file-drop-input";
 import {
   type ScoreLayout,
   type ScoreSource,
+  type ScoreVideoScene,
   ScoreViewerRuntime,
 } from "./score-viewer-runtime";
 import { Button } from "./ui/button";
@@ -49,6 +50,24 @@ export function ScoreViewer() {
     }
     runtime.attach(root);
     return () => runtime.dispose();
+  }, [runtime]);
+
+  useEffect(() => {
+    window.__toyMidiScoreVideo = {
+      exportScene: () => runtime.exportVideoScene(),
+      loadSample: async (id) => {
+        const sample = SCORE_VIEWER_SAMPLES.find((item) => item.id === id);
+        if (!sample) {
+          throw new Error(`Unknown score sample: ${id}`);
+        }
+        const nextScore = { name: sample.name, xml: sample.xml };
+        await runtime.load({ score: nextScore, layout: "continuous" });
+        setScore(nextScore);
+      },
+    };
+    return () => {
+      delete window.__toyMidiScoreVideo;
+    };
   }, [runtime]);
 
   const tempoInput = useDraftInput({
@@ -299,6 +318,15 @@ export function ScoreViewer() {
       />
     </main>
   );
+}
+
+declare global {
+  interface Window {
+    __toyMidiScoreVideo?: {
+      exportScene: () => ScoreVideoScene;
+      loadSample: (id: string) => Promise<void>;
+    };
+  }
 }
 
 function formatBarBeat(bar: number, beat: number) {

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -55,14 +55,18 @@ export function ScoreViewer() {
   useEffect(() => {
     window.__toyMidiScoreVideo = {
       exportScene: () => runtime.exportVideoScene(),
+      loadScore: async (source) => {
+        await runtime.load({ score: source, layout: "continuous" });
+        setScore(source);
+      },
       loadSample: async (id) => {
         const sample = SCORE_VIEWER_SAMPLES.find((item) => item.id === id);
         if (!sample) {
           throw new Error(`Unknown score sample: ${id}`);
         }
-        const nextScore = { name: sample.name, xml: sample.xml };
-        await runtime.load({ score: nextScore, layout: "continuous" });
-        setScore(nextScore);
+        const source = { name: sample.name, xml: sample.xml };
+        await runtime.load({ score: source, layout: "continuous" });
+        setScore(source);
       },
     };
     return () => {
@@ -324,6 +328,7 @@ declare global {
   interface Window {
     __toyMidiScoreVideo?: {
       exportScene: () => ScoreVideoScene;
+      loadScore: (source: ScoreSource) => Promise<void>;
       loadSample: (id: string) => Promise<void>;
     };
   }

--- a/tools/render-score-video.mjs
+++ b/tools/render-score-video.mjs
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import { chromium } from "@playwright/test";
 import { Resvg } from "@resvg/resvg-js";
 
@@ -10,9 +12,19 @@ async function main() {
     viewport: { width: 1110, height: 556 },
   });
   await page.goto("http://localhost:5183/score-viewer");
-  await page.evaluate(async (id) => {
-    await window.__toyMidiScoreVideo.loadSample(id);
-  }, options.sampleId);
+  if (isMusicXmlPath(options.input)) {
+    const source = {
+      name: path.basename(options.input),
+      xml: await readFile(options.input, "utf8"),
+    };
+    await page.evaluate(async (score) => {
+      await window.__toyMidiScoreVideo.loadScore(score);
+    }, source);
+  } else {
+    await page.evaluate(async (id) => {
+      await window.__toyMidiScoreVideo.loadSample(id);
+    }, options.input);
+  }
   const scene = await page.evaluate(() =>
     window.__toyMidiScoreVideo.exportScene(),
   );
@@ -103,13 +115,19 @@ function parseOptions(args) {
     }
   }
   if (positional.length > 2) {
-    throw new Error("Expected at most a sample id and output path");
+    throw new Error(
+      "Expected at most a MusicXML path or sample id and output path",
+    );
   }
   return {
     ...options,
-    sampleId: positional[0] ?? "cursor-wrapping",
+    input: positional[0] ?? "cursor-wrapping",
     output: positional[1] ?? ".tmp/score-video.mp4",
   };
+}
+
+function isMusicXmlPath(input) {
+  return input.endsWith(".xml") || input.endsWith(".musicxml");
 }
 
 function deriveHeight(positions) {

--- a/tools/render-score-video.mjs
+++ b/tools/render-score-video.mjs
@@ -1,0 +1,188 @@
+import { spawn } from "node:child_process";
+import { chromium } from "@playwright/test";
+import { Resvg } from "@resvg/resvg-js";
+
+async function main() {
+  const { fps, height, output, sampleId } = parseOptions(process.argv.slice(2));
+
+  const browser = await chromium.launch({ channel: "chromium" });
+  const page = await browser.newPage({ viewport: { width: 1110, height } });
+  await page.goto("http://localhost:5183/score-viewer");
+  await page.evaluate(async (id) => {
+    await window.__toyMidiScoreVideo.loadSample(id);
+  }, sampleId);
+  const scene = await page.evaluate(() =>
+    window.__toyMidiScoreVideo.exportScene(),
+  );
+  await browser.close();
+  const width = scene.scoreWidth;
+  const scorePixels = new Resvg(buildScoreSvg(scene)).render().pixels;
+
+  const ffmpeg = spawn(
+    "ffmpeg",
+    [
+      "-y",
+      "-f",
+      "rawvideo",
+      "-pixel_format",
+      "rgba",
+      "-video_size",
+      `${width}x${height}`,
+      "-framerate",
+      String(fps),
+      "-i",
+      "-",
+      "-an",
+      "-c:v",
+      "libx264",
+      "-pix_fmt",
+      "yuv420p",
+      output,
+    ],
+    { stdio: ["pipe", "inherit", "inherit"] },
+  );
+
+  const frameCount = Math.ceil(scene.duration * fps);
+  let viewportTop = 0;
+  for (let frame = 0; frame < frameCount; frame++) {
+    const scoreTime = (frame / fps) * (scene.tempo / 60 / 4);
+    const cursor = resolveCursor(scene.cursorPositions, scoreTime);
+    if (
+      cursor.top < viewportTop ||
+      cursor.top + cursor.height > viewportTop + height
+    ) {
+      viewportTop = Math.max(cursor.top - 24, 0);
+    }
+    const pixels = compositeFrame({
+      cursor,
+      height,
+      scene,
+      scorePixels,
+      viewportTop,
+      width,
+    });
+    if (!ffmpeg.stdin.write(pixels)) {
+      await new Promise((resolve) => ffmpeg.stdin.once("drain", resolve));
+    }
+  }
+  ffmpeg.stdin.end();
+  const exitCode = await new Promise((resolve) =>
+    ffmpeg.once("close", resolve),
+  );
+  if (exitCode !== 0) {
+    throw new Error(`ffmpeg exited with code ${exitCode}`);
+  }
+}
+
+function parseOptions(args) {
+  const positional = [];
+  const options = { fps: 30, height: 556 };
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index];
+    switch (argument) {
+      case "--height": {
+        options.height = parsePositiveInteger(argument, args[++index]);
+        if (options.height % 2 !== 0) {
+          throw new Error("--height must be even for H.264 YUV420 output");
+        }
+        break;
+      }
+      case "--fps": {
+        options.fps = parsePositiveInteger(argument, args[++index]);
+        break;
+      }
+      default: {
+        if (argument.startsWith("--")) {
+          throw new Error(`Unknown option: ${argument}`);
+        }
+        positional.push(argument);
+      }
+    }
+  }
+  if (positional.length > 2) {
+    throw new Error("Expected at most a sample id and output path");
+  }
+  return {
+    ...options,
+    sampleId: positional[0] ?? "cursor-wrapping",
+    output: positional[1] ?? ".tmp/score-video.mp4",
+  };
+}
+
+function parsePositiveInteger(option, value) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${option} requires a positive integer`);
+  }
+  return parsed;
+}
+
+function resolveCursor(positions, scoreTime) {
+  let nextIndex = positions.findIndex((position) => position.time > scoreTime);
+  if (nextIndex < 1) {
+    nextIndex = Math.min(Math.max(nextIndex, 1), positions.length - 1);
+  }
+  const current = positions[nextIndex - 1];
+  const next = positions[nextIndex];
+  const progress =
+    current.systemId === next.systemId
+      ? (scoreTime - current.time) / (next.time - current.time)
+      : 0;
+  return {
+    height: current.height,
+    top: current.top,
+    x: current.x + (next.x - current.x) * progress,
+  };
+}
+
+function buildScoreSvg(scene) {
+  const scoreSvg = scene.scoreSvg
+    .replace(/^<svg[^>]*>/, "")
+    .replace(/<\/svg>\s*$/, "");
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${scene.scoreWidth}" height="${scene.scoreHeight}" viewBox="0 0 ${scene.scoreWidth} ${scene.scoreHeight}">
+      <rect width="100%" height="100%" fill="white"/>
+      ${scoreSvg}
+    </svg>`;
+}
+
+function compositeFrame({
+  cursor,
+  height,
+  scene,
+  scorePixels,
+  viewportTop,
+  width,
+}) {
+  const pixels = Buffer.alloc(width * height * 4, 0xff);
+  for (let index = 3; index < pixels.length; index += 4) {
+    pixels[index] = 0xff;
+  }
+
+  const destinationX = 0;
+  const sourceY = Math.max(Math.floor(viewportTop - 24), 0);
+  const destinationY = Math.max(Math.floor(24 - viewportTop), 0);
+  const rows = Math.min(scene.scoreHeight - sourceY, height - destinationY);
+  for (let row = 0; row < rows; row++) {
+    const sourceStart = (sourceY + row) * scene.scoreWidth * 4;
+    const destinationStart = ((destinationY + row) * width + destinationX) * 4;
+    pixels.set(
+      scorePixels.subarray(sourceStart, sourceStart + scene.scoreWidth * 4),
+      destinationStart,
+    );
+  }
+
+  const cursorX = Math.round(destinationX + cursor.x);
+  const cursorTop = Math.round(24 + cursor.top - viewportTop);
+  const cursorBottom = Math.min(Math.round(cursorTop + cursor.height), height);
+  for (let y = Math.max(cursorTop, 0); y < cursorBottom; y++) {
+    for (let x = cursorX; x < cursorX + 3; x++) {
+      pixels.set([0x3b, 0x82, 0xf6, 0xff], (y * width + x) * 4);
+    }
+  }
+  return pixels;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tools/render-score-video.mjs
+++ b/tools/render-score-video.mjs
@@ -3,18 +3,21 @@ import { chromium } from "@playwright/test";
 import { Resvg } from "@resvg/resvg-js";
 
 async function main() {
-  const { fps, height, output, sampleId } = parseOptions(process.argv.slice(2));
+  const options = parseOptions(process.argv.slice(2));
 
   const browser = await chromium.launch({ channel: "chromium" });
-  const page = await browser.newPage({ viewport: { width: 1110, height } });
+  const page = await browser.newPage({
+    viewport: { width: 1110, height: 556 },
+  });
   await page.goto("http://localhost:5183/score-viewer");
   await page.evaluate(async (id) => {
     await window.__toyMidiScoreVideo.loadSample(id);
-  }, sampleId);
+  }, options.sampleId);
   const scene = await page.evaluate(() =>
     window.__toyMidiScoreVideo.exportScene(),
   );
   await browser.close();
+  const height = options.height ?? deriveHeight(scene.cursorPositions);
   const width = scene.scoreWidth;
   const scorePixels = new Resvg(buildScoreSvg(scene)).render().pixels;
 
@@ -29,7 +32,7 @@ async function main() {
       "-video_size",
       `${width}x${height}`,
       "-framerate",
-      String(fps),
+      String(options.fps),
       "-i",
       "-",
       "-an",
@@ -37,15 +40,15 @@ async function main() {
       "libx264",
       "-pix_fmt",
       "yuv420p",
-      output,
+      options.output,
     ],
     { stdio: ["pipe", "inherit", "inherit"] },
   );
 
-  const frameCount = Math.ceil(scene.duration * fps);
-  let viewportTop = 0;
+  const frameCount = Math.ceil(scene.duration * options.fps);
+  let viewportTop = Math.max(scene.cursorPositions[0].top - 24, 0);
   for (let frame = 0; frame < frameCount; frame++) {
-    const scoreTime = (frame / fps) * (scene.tempo / 60 / 4);
+    const scoreTime = (frame / options.fps) * (scene.tempo / 60 / 4);
     const cursor = resolveCursor(scene.cursorPositions, scoreTime);
     if (
       cursor.top < viewportTop ||
@@ -76,7 +79,7 @@ async function main() {
 
 function parseOptions(args) {
   const positional = [];
-  const options = { fps: 30, height: 556 };
+  const options = { fps: 30 };
   for (let index = 0; index < args.length; index++) {
     const argument = args[index];
     switch (argument) {
@@ -107,6 +110,29 @@ function parseOptions(args) {
     sampleId: positional[0] ?? "cursor-wrapping",
     output: positional[1] ?? ".tmp/score-video.mp4",
   };
+}
+
+function deriveHeight(positions) {
+  const systems = [];
+  const systemIds = new Set();
+  for (const position of positions) {
+    if (!systemIds.has(position.systemId)) {
+      systemIds.add(position.systemId);
+      systems.push({
+        bottom: position.top + position.height,
+        top: position.top,
+      });
+    }
+  }
+  if (systems.length === 0) {
+    throw new Error("Score has no rendered systems");
+  }
+  const lastVisibleSystem = systems[Math.min(1, systems.length - 1)];
+  return roundUpToEven(lastVisibleSystem.bottom - systems[0].top + 48);
+}
+
+function roundUpToEven(value) {
+  return Math.ceil(value / 2) * 2;
 }
 
 function parsePositiveInteger(option, value) {

--- a/tools/render-score-video.ts
+++ b/tools/render-score-video.ts
@@ -1,8 +1,22 @@
 import { spawn } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { parseArgs } from "node:util";
 import { chromium } from "@playwright/test";
 import { Resvg } from "@resvg/resvg-js";
+import {
+  type CursorPosition,
+  type ScoreVideoScene,
+} from "../src/components/score-viewer-runtime";
+
+type Options = {
+  fps: number;
+  height?: number;
+  input: string;
+  output: string;
+};
+
+type Cursor = Pick<CursorPosition, "height" | "top" | "x">;
 
 async function main() {
   const options = parseOptions(process.argv.slice(2));
@@ -18,16 +32,25 @@ async function main() {
       xml: await readFile(options.input, "utf8"),
     };
     await page.evaluate(async (score) => {
+      if (!window.__toyMidiScoreVideo) {
+        throw new Error("Score video bridge is unavailable");
+      }
       await window.__toyMidiScoreVideo.loadScore(score);
     }, source);
   } else {
     await page.evaluate(async (id) => {
+      if (!window.__toyMidiScoreVideo) {
+        throw new Error("Score video bridge is unavailable");
+      }
       await window.__toyMidiScoreVideo.loadSample(id);
     }, options.input);
   }
-  const scene = await page.evaluate(() =>
-    window.__toyMidiScoreVideo.exportScene(),
-  );
+  const scene = await page.evaluate<ScoreVideoScene>(() => {
+    if (!window.__toyMidiScoreVideo) {
+      throw new Error("Score video bridge is unavailable");
+    }
+    return window.__toyMidiScoreVideo.exportScene();
+  });
   await browser.close();
   const height = options.height ?? deriveHeight(scene.cursorPositions);
   const width = scene.scoreWidth;
@@ -89,50 +112,41 @@ async function main() {
   }
 }
 
-function parseOptions(args) {
-  const positional = [];
-  const options = { fps: 30 };
-  for (let index = 0; index < args.length; index++) {
-    const argument = args[index];
-    switch (argument) {
-      case "--height": {
-        options.height = parsePositiveInteger(argument, args[++index]);
-        if (options.height % 2 !== 0) {
-          throw new Error("--height must be even for H.264 YUV420 output");
-        }
-        break;
-      }
-      case "--fps": {
-        options.fps = parsePositiveInteger(argument, args[++index]);
-        break;
-      }
-      default: {
-        if (argument.startsWith("--")) {
-          throw new Error(`Unknown option: ${argument}`);
-        }
-        positional.push(argument);
-      }
-    }
-  }
-  if (positional.length > 2) {
+function parseOptions(args: string[]): Options {
+  const { positionals, values } = parseArgs({
+    args,
+    allowPositionals: true,
+    options: {
+      fps: { type: "string", default: "30" },
+      height: { type: "string" },
+    },
+  });
+  if (positionals.length > 2) {
     throw new Error(
       "Expected at most a MusicXML path or sample id and output path",
     );
   }
+  const height = values.height
+    ? parsePositiveInteger("--height", values.height)
+    : undefined;
+  if (height && height % 2 !== 0) {
+    throw new Error("--height must be even for H.264 YUV420 output");
+  }
   return {
-    ...options,
-    input: positional[0] ?? "cursor-wrapping",
-    output: positional[1] ?? ".tmp/score-video.mp4",
+    fps: parsePositiveInteger("--fps", values.fps),
+    height,
+    input: positionals[0] ?? "cursor-wrapping",
+    output: positionals[1] ?? ".tmp/score-video.mp4",
   };
 }
 
-function isMusicXmlPath(input) {
+function isMusicXmlPath(input: string) {
   return input.endsWith(".xml") || input.endsWith(".musicxml");
 }
 
-function deriveHeight(positions) {
-  const systems = [];
-  const systemIds = new Set();
+function deriveHeight(positions: CursorPosition[]) {
+  const systems: { bottom: number; top: number }[] = [];
+  const systemIds = new Set<number>();
   for (const position of positions) {
     if (!systemIds.has(position.systemId)) {
       systemIds.add(position.systemId);
@@ -149,11 +163,11 @@ function deriveHeight(positions) {
   return roundUpToEven(lastVisibleSystem.bottom - systems[0].top + 48);
 }
 
-function roundUpToEven(value) {
+function roundUpToEven(value: number) {
   return Math.ceil(value / 2) * 2;
 }
 
-function parsePositiveInteger(option, value) {
+function parsePositiveInteger(option: string, value?: string) {
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed <= 0) {
     throw new Error(`${option} requires a positive integer`);
@@ -161,7 +175,7 @@ function parsePositiveInteger(option, value) {
   return parsed;
 }
 
-function resolveCursor(positions, scoreTime) {
+function resolveCursor(positions: CursorPosition[], scoreTime: number): Cursor {
   let nextIndex = positions.findIndex((position) => position.time > scoreTime);
   if (nextIndex < 1) {
     nextIndex = Math.min(Math.max(nextIndex, 1), positions.length - 1);
@@ -179,7 +193,7 @@ function resolveCursor(positions, scoreTime) {
   };
 }
 
-function buildScoreSvg(scene) {
+function buildScoreSvg(scene: ScoreVideoScene) {
   const scoreSvg = scene.scoreSvg
     .replace(/^<svg[^>]*>/, "")
     .replace(/<\/svg>\s*$/, "");
@@ -196,6 +210,13 @@ function compositeFrame({
   scorePixels,
   viewportTop,
   width,
+}: {
+  cursor: Cursor;
+  height: number;
+  scene: ScoreVideoScene;
+  scorePixels: Uint8Array;
+  viewportTop: number;
+  width: number;
 }) {
   const pixels = Buffer.alloc(width * height * 4, 0xff);
   for (let index = 3; index < pixels.length; index += 4) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src", "e2e", "*.ts"],
+  "include": ["src", "e2e", "tools", "*.ts"],
   "compilerOptions": {
     "types": ["vite/client", "node"],
     "target": "esnext",


### PR DESCRIPTION
The score viewer currently has to play in real time while its viewport is screen-recorded for the Kdenlive score layer. This adds a data-oriented offline renderer that reuses OSMD layout and the existing piecewise cursor geometry without taking browser screenshots.

The browser renders and exports the static score SVG and cursor anchors once. The CLI rasterizes that SVG once with resvg, composites deterministic viewport crops and cursor positions into raw RGBA frames, and streams them directly to FFmpeg. Output uses the fixed 1110px score layout, a configurable even viewport height, and the same cursor-containment scrolling rule as interactive playback.

Example:

```sh
pnpm dev --port 5183
pnpm render-score-video long-score .tmp/score-video.mp4 --height 556
```

Validated with the 64-measure sample at 1110x556 and 30 fps. The 2:19 video rendered in about 8 seconds locally.

Tests: `pnpm lint`, `pnpm test -- --run`

This implements the offline video-render item within #224. The remaining workflow and player follow-ups stay open.