### PR TITLE
feat: seek score by clicking measures

### DIFF
--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -42,8 +42,7 @@ test("loads and advances the cursor sample", async ({ page }) => {
   await page.goto("/score-viewer");
   await loadSample(page, "Cursor and wrapping");
 
-  // Exercise cursor motion, measure-click seeking, tempo changes, and the
-  // transition from the end of one system to the start of the next.
+  // The loaded score starts with a visible cursor at measure 1, beat 1.
   const playButton = page.getByRole("button", { name: "Play" });
   await expect(playButton).toBeEnabled();
   const cursor = page.getByTestId("score-viewer-cursor");
@@ -54,6 +53,7 @@ test("loads and advances the cursor sample", async ({ page }) => {
     (element) => element.style.transform,
   );
 
+  // Playback advances the cursor continuously rather than in discrete steps.
   await playButton.click();
   await page.waitForTimeout(100);
   const firstTransform = await cursor.evaluate(
@@ -68,6 +68,7 @@ test("loads and advances the cursor sample", async ({ page }) => {
     .poll(() => cursor.evaluate((element) => element.style.transform))
     .not.toBe(initialTransform);
 
+  // Clicking measure 2 while paused seeks the cursor to its first beat.
   await page.getByRole("button", { name: "Pause" }).click();
   await page.locator('[data-measure-index="1"]').click();
   await expect(page.getByText("02|01")).toBeVisible();
@@ -76,6 +77,7 @@ test("loads and advances the cursor sample", async ({ page }) => {
   );
   expect(seekTransform).not.toBe(initialTransform);
 
+  // Changing the tempo restarts playback, and the cursor advances from zero.
   await page.getByLabel("BPM").fill("120");
   await page.getByLabel("BPM").press("Enter");
   await page.getByRole("button", { name: "Play" }).click();
@@ -85,6 +87,8 @@ test("loads and advances the cursor sample", async ({ page }) => {
   );
   expect(fastTransform).not.toBe(seekTransform);
 
+  // Slow playback near a system end so the test observes horizontal movement
+  // before the cursor wraps from the first system to the second.
   await page.getByRole("button", { name: "Pause" }).click();
   await page.getByLabel("BPM").fill("60");
   await page.getByLabel("BPM").press("Enter");

--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -42,6 +42,8 @@ test("loads and advances the cursor sample", async ({ page }) => {
   await page.goto("/score-viewer");
   await loadSample(page, "Cursor and wrapping");
 
+  // Exercise cursor motion, measure-click seeking, tempo changes, and the
+  // transition from the end of one system to the start of the next.
   const playButton = page.getByRole("button", { name: "Play" });
   await expect(playButton).toBeEnabled();
   const cursor = page.getByTestId("score-viewer-cursor");

--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -46,7 +46,6 @@ test("loads and advances the cursor sample", async ({ page }) => {
   await expect(playButton).toBeEnabled();
   const cursor = page.getByTestId("score-viewer-cursor");
   const position = page.getByText("01|01");
-  const seekButton = page.getByRole("button", { name: "Seek" });
   await expect(cursor).toBeVisible();
   await expect(position).toBeVisible();
   const initialTransform = await cursor.evaluate(
@@ -68,9 +67,8 @@ test("loads and advances the cursor sample", async ({ page }) => {
     .not.toBe(initialTransform);
 
   await page.getByRole("button", { name: "Pause" }).click();
-  page.once("dialog", (dialog) => dialog.accept("2:3"));
-  await seekButton.click();
-  await expect(page.getByText("02|03")).toBeVisible();
+  await page.locator('[data-measure-index="1"]').click();
+  await expect(page.getByText("02|01")).toBeVisible();
   const seekTransform = await cursor.evaluate(
     (element) => element.style.transform,
   );
@@ -88,8 +86,7 @@ test("loads and advances the cursor sample", async ({ page }) => {
   await page.getByRole("button", { name: "Pause" }).click();
   await page.getByLabel("BPM").fill("60");
   await page.getByLabel("BPM").press("Enter");
-  page.once("dialog", (dialog) => dialog.accept("3|4"));
-  await seekButton.click();
+  await page.locator('[data-measure-index="3"]').click();
   await page.getByRole("button", { name: "Play" }).click();
   await page.waitForTimeout(100);
   const systemEndStart = await cursor.evaluate(

--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -173,6 +173,14 @@ test("switches score layout", async ({ page }) => {
   expect(firstSystemMeasures[0].right).toBeCloseTo(firstSystemMeasures[1].left);
   await secondPageMeasure.click({ position: { x: 20, y: 20 } });
   await expect(page.getByText("17|01")).toBeVisible();
+  const cursor = page.getByTestId("score-viewer-cursor");
+  const scroll = page.getByTestId("score-viewer-scroll");
+  await expect
+    .poll(() => scroll.evaluate((element) => element.scrollTop))
+    .toBeGreaterThan(0);
+  expect((await cursor.boundingBox())!.y).toBeGreaterThan(
+    (await firstPageMeasure.boundingBox())!.y,
+  );
 
   await page.getByLabel("Layout").selectOption("continuous");
   await expect(page.getByLabel("Layout")).toHaveValue("continuous");

--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -152,6 +152,23 @@ test("switches score layout", async ({ page }) => {
   expect((await secondPageMeasure.boundingBox())!.y).toBeGreaterThan(
     (await firstPageMeasure.boundingBox())!.y,
   );
+  const firstSystemMeasures = await page
+    .getByTestId("score-viewer-measure")
+    .evaluateAll((elements) =>
+      elements.slice(0, 4).map((element) => ({
+        index: element.getAttribute("data-measure-index"),
+        left: element.getBoundingClientRect().left,
+      })),
+    );
+  expect(firstSystemMeasures.map(({ index }) => index)).toEqual([
+    "0",
+    "1",
+    "2",
+    "3",
+  ]);
+  expect(firstSystemMeasures[1].left).toBeGreaterThan(
+    firstSystemMeasures[0].left,
+  );
 
   await page.getByLabel("Layout").selectOption("continuous");
   await expect(page.getByLabel("Layout")).toHaveValue("continuous");

--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -139,6 +139,9 @@ test("switches score layout", async ({ page }) => {
   await page.getByLabel("Layout").selectOption("paged");
   await expect(page.getByLabel("Layout")).toHaveValue("paged");
   await expect.poll(() => renderer.locator("svg").count()).toBeGreaterThan(1);
+
+  // Measure overlays use page-local OSMD geometry. Verify page 2 is placed
+  // below page 1 and the first system has contiguous, ordered hit targets.
   const firstPageMeasure = page.locator(
     '[data-testid="score-viewer-measure"][data-measure-index="0"]',
   );
@@ -168,6 +171,8 @@ test("switches score layout", async ({ page }) => {
     firstSystemMeasures[0].left,
   );
   expect(firstSystemMeasures[0].right).toBeCloseTo(firstSystemMeasures[1].left);
+
+  // Clicking page 2 must seek and scroll the page-aware playback cursor there.
   await secondPageMeasure.click({ position: { x: 20, y: 20 } });
   await expect(page.getByText("17|01")).toBeVisible();
   const cursor = page.getByTestId("score-viewer-cursor");

--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -120,6 +120,7 @@ test("seeks to the start of a clicked measure", async ({ page }) => {
   await page.goto("/score-viewer");
   await loadSample(page, "Cursor and wrapping");
 
+  // Click inside measure 3 and verify the transport snaps to its first beat.
   const renderer = page.getByTestId("score-viewer-renderer");
   const thirdMeasure = page.locator(
     '[data-testid="score-viewer-measure"][data-measure-index="2"]',

--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -142,6 +142,16 @@ test("switches score layout", async ({ page }) => {
   await page.getByLabel("Layout").selectOption("paged");
   await expect(page.getByLabel("Layout")).toHaveValue("paged");
   await expect.poll(() => renderer.locator("svg").count()).toBeGreaterThan(1);
+  const firstPageMeasure = page.locator(
+    '[data-testid="score-viewer-measure"][data-measure-index="0"]',
+  );
+  const secondPageMeasure = page.locator(
+    '[data-testid="score-viewer-measure"][data-measure-index="16"]',
+  );
+  await expect(secondPageMeasure).toBeVisible();
+  expect((await secondPageMeasure.boundingBox())!.y).toBeGreaterThan(
+    (await firstPageMeasure.boundingBox())!.y,
+  );
 
   await page.getByLabel("Layout").selectOption("continuous");
   await expect(page.getByLabel("Layout")).toHaveValue("continuous");

--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -119,6 +119,21 @@ test("switches between generated score samples", async ({ page }) => {
   await expect(page.getByLabel("BPM")).toHaveValue("200");
 });
 
+test("seeks to the start of a clicked measure", async ({ page }) => {
+  await page.goto("/score-viewer");
+  await loadSample(page, "Cursor and wrapping");
+
+  const renderer = page.getByTestId("score-viewer-renderer");
+  const thirdMeasure = page.locator(
+    '[data-testid="score-viewer-measure"][data-measure-index="2"]',
+  );
+  await expect(thirdMeasure).toBeVisible();
+  await thirdMeasure.click({ position: { x: 20, y: 20 } });
+
+  await expect(page.getByText("03|01")).toBeVisible();
+  await expect(renderer).toBeVisible();
+});
+
 test("switches score layout", async ({ page }) => {
   await page.goto("/score-viewer");
   await loadSample(page, "Long score");

--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -158,6 +158,7 @@ test("switches score layout", async ({ page }) => {
       elements.slice(0, 4).map((element) => ({
         index: element.getAttribute("data-measure-index"),
         left: element.getBoundingClientRect().left,
+        right: element.getBoundingClientRect().right,
       })),
     );
   expect(firstSystemMeasures.map(({ index }) => index)).toEqual([
@@ -169,6 +170,9 @@ test("switches score layout", async ({ page }) => {
   expect(firstSystemMeasures[1].left).toBeGreaterThan(
     firstSystemMeasures[0].left,
   );
+  expect(firstSystemMeasures[0].right).toBeCloseTo(firstSystemMeasures[1].left);
+  await secondPageMeasure.click({ position: { x: 20, y: 20 } });
+  await expect(page.getByText("17|01")).toBeVisible();
 
   await page.getByLabel("Layout").selectOption("continuous");
   await expect(page.getByLabel("Layout")).toHaveValue("continuous");

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -317,6 +317,9 @@ function buildCursorPositions(
   // OSMD exposes entry geometry, so add each system's final timestamp and
   // right border to prevent a freeze before wrapping.
   const result: CursorPosition[] = [];
+  // Each paged backend reports page-local score geometry. Match graphical
+  // pages to their rendered DOM pages to convert cursor y positions to the
+  // shared container coordinate space.
   const containerBounds = container.getBoundingClientRect();
   const pageElements = container.querySelectorAll<HTMLElement>(":scope > div");
   const pageOffsets = new Map(

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -56,6 +56,7 @@ export class ScoreViewerRuntime {
   //   <scroller>
   //     <sheet>
   //       <cursor />
+  //       <measureLayer />
   //       <container />
   //     </sheet>
   //   </scroller>

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -382,6 +382,7 @@ function buildMeasureTargets(
 
     const topStaff = system.StaffLines[0];
     const bottomStaff = system.StaffLines.at(-1)!;
+    const pageTop = system.Parent.PositionAndShape.AbsolutePosition.y * 10;
     const target = document.createElement("div");
     target.dataset.testid = "score-viewer-measure";
     target.dataset.measureIndex = String(
@@ -393,7 +394,7 @@ function buildMeasureTargets(
     target.className =
       "absolute cursor-pointer bg-transparent hover:bg-blue-500/10";
     target.style.left = `${measure.PositionAndShape.AbsolutePosition.x * 10}px`;
-    target.style.top = `${topStaff.PositionAndShape.AbsolutePosition.y * 10 - 20}px`;
+    target.style.top = `${pageTop + topStaff.PositionAndShape.AbsolutePosition.y * 10 - 20}px`;
     target.style.width = `${measure.PositionAndShape.Size.width * 10}px`;
     target.style.height = `${(bottomStaff.PositionAndShape.AbsolutePosition.y + bottomStaff.StaffHeight - topStaff.PositionAndShape.AbsolutePosition.y) * 10 + 40}px`;
     targets.push(target);

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -431,11 +431,17 @@ function buildMeasureTargets(
           nextMeasure?.PositionAndShape.AbsolutePosition.x !== undefined
             ? nextMeasure.PositionAndShape.AbsolutePosition.x * 10
             : system.GetRightBorderAbsoluteXPosition() * 10;
-        target.style.left = `${left}px`;
         // Extend 20px above and below the staves for an easier full-system hit target.
-        target.style.top = `${topStaff.PositionAndShape.AbsolutePosition.y * 10 - 20}px`;
+        const top = topStaff.PositionAndShape.AbsolutePosition.y * 10 - 20;
+        const bottom =
+          (bottomStaff.PositionAndShape.AbsolutePosition.y +
+            bottomStaff.StaffHeight) *
+            10 +
+          20;
+        target.style.left = `${left}px`;
+        target.style.top = `${top}px`;
         target.style.width = `${right - left}px`;
-        target.style.height = `${(bottomStaff.PositionAndShape.AbsolutePosition.y + bottomStaff.StaffHeight - topStaff.PositionAndShape.AbsolutePosition.y) * 10 + 40}px`;
+        target.style.height = `${bottom - top}px`;
         pageLayer.append(target);
       }
     }

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -411,6 +411,7 @@ function buildMeasureTargets(
         const topStaff = system.StaffLines[0];
         const bottomStaff = system.StaffLines.at(-1)!;
         const target = document.createElement("div");
+        // Expose the target and its source-measure identity for E2E interaction.
         target.dataset.testid = "score-viewer-measure";
         target.dataset.measureIndex = String(
           measure.parentSourceMeasure.measureListIndex,

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -415,6 +415,7 @@ function buildMeasureTargets(
         target.dataset.measureIndex = String(
           measure.parentSourceMeasure.measureListIndex,
         );
+        // Store OSMD whole-note time on the target for delegated click seeking.
         target.dataset.scoreTime = String(
           measure.parentSourceMeasure.AbsoluteTimestamp.RealValue,
         );

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -118,7 +118,8 @@ export class ScoreViewerRuntime {
       "pointer-events-none absolute top-0 left-0 z-10 w-[3px] bg-blue-500";
 
     this.#measureLayer = document.createElement("div");
-    this.#measureLayer.className = "absolute inset-0 z-[5]";
+    this.#measureLayer.className = "absolute inset-y-0 left-4 z-[5]";
+    this.#measureLayer.style.width = `${SCORE_LAYOUT_WIDTH}px`;
     this.#measureLayer.addEventListener("click", this.#handleMeasureClick);
 
     this.#container = document.createElement("div");
@@ -154,6 +155,10 @@ export class ScoreViewerRuntime {
       layout === "continuous"
         ? "relative mx-auto bg-white px-4 shadow-xl"
         : "relative mx-auto";
+    this.#measureLayer.className =
+      layout === "continuous"
+        ? "absolute inset-y-0 left-4 z-[5]"
+        : "absolute inset-y-0 left-0 z-[5]";
     this.#positions = buildCursorPositions(this.#osmd);
     buildMeasureTargets(this.#osmd, this.#measureLayer);
     this.#clock.stop();

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -432,6 +432,7 @@ function buildMeasureTargets(
             ? nextMeasure.PositionAndShape.AbsolutePosition.x * 10
             : system.GetRightBorderAbsoluteXPosition() * 10;
         target.style.left = `${left}px`;
+        // Extend 20px above and below the staves for an easier full-system hit target.
         target.style.top = `${topStaff.PositionAndShape.AbsolutePosition.y * 10 - 20}px`;
         target.style.width = `${right - left}px`;
         target.style.height = `${(bottomStaff.PositionAndShape.AbsolutePosition.y + bottomStaff.StaffHeight - topStaff.PositionAndShape.AbsolutePosition.y) * 10 + 40}px`;

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -56,7 +56,7 @@ export class ScoreViewerRuntime {
   //   <scroller>
   //     <sheet>
   //       <cursor />
-  //       <measureLayer />
+  //       <measureLayers />
   //       <container />
   //     </sheet>
   //   </scroller>
@@ -64,7 +64,7 @@ export class ScoreViewerRuntime {
   #root!: HTMLDivElement;
   #container!: HTMLDivElement;
   #cursor!: HTMLDivElement;
-  #measureLayer!: HTMLDivElement;
+  #measureLayers!: HTMLDivElement;
   #scroller!: HTMLElement;
   #sheet!: HTMLDivElement;
 
@@ -117,16 +117,15 @@ export class ScoreViewerRuntime {
     this.#cursor.className =
       "pointer-events-none absolute top-0 left-0 z-10 w-[3px] bg-blue-500";
 
-    this.#measureLayer = document.createElement("div");
-    this.#measureLayer.className = "absolute inset-y-0 left-4 z-[5]";
-    this.#measureLayer.style.width = `${SCORE_LAYOUT_WIDTH}px`;
-    this.#measureLayer.addEventListener("click", this.#handleMeasureClick);
+    this.#measureLayers = document.createElement("div");
+    this.#measureLayers.className = "absolute inset-0 z-[5]";
+    this.#measureLayers.addEventListener("click", this.#handleMeasureClick);
 
     this.#container = document.createElement("div");
     this.#container.dataset.testid = "score-viewer-renderer";
     this.#container.style.width = `${SCORE_LAYOUT_WIDTH}px`;
 
-    this.#sheet.append(this.#cursor, this.#measureLayer, this.#container);
+    this.#sheet.append(this.#cursor, this.#measureLayers, this.#container);
     this.#scroller.append(this.#sheet);
     this.#root.append(this.#scroller);
     this.#osmd = new OpenSheetMusicDisplay(this.#container, {
@@ -155,12 +154,8 @@ export class ScoreViewerRuntime {
       layout === "continuous"
         ? "relative mx-auto bg-white px-4 shadow-xl"
         : "relative mx-auto";
-    this.#measureLayer.className =
-      layout === "continuous"
-        ? "absolute inset-y-0 left-4 z-[5]"
-        : "absolute inset-y-0 left-0 z-[5]";
     this.#positions = buildCursorPositions(this.#osmd);
-    buildMeasureTargets(this.#osmd, this.#measureLayer);
+    buildMeasureTargets(this.#osmd, this.#measureLayers, this.#container);
     this.#clock.stop();
     this.#setState({
       bar: 1,
@@ -201,7 +196,7 @@ export class ScoreViewerRuntime {
 
   dispose() {
     this.#clock.stop();
-    this.#measureLayer.removeEventListener("click", this.#handleMeasureClick);
+    this.#measureLayers.removeEventListener("click", this.#handleMeasureClick);
     if (this.#root.hasChildNodes()) {
       this.#osmd.clear();
       this.#root.replaceChildren();
@@ -370,10 +365,25 @@ function buildCursorPositions(osmd: OpenSheetMusicDisplay): CursorPosition[] {
 // from its graphical measures so each target spans the full system height.
 function buildMeasureTargets(
   osmd: OpenSheetMusicDisplay,
-  layer: HTMLDivElement,
+  layers: HTMLDivElement,
+  container: HTMLDivElement,
 ) {
-  const targets: HTMLDivElement[] = [];
-  for (const page of osmd.GraphicSheet.MusicPages) {
+  const sheetBounds = layers.parentElement!.getBoundingClientRect();
+  const pageElements = container.querySelectorAll<HTMLElement>(":scope > div");
+  const pageLayers: HTMLDivElement[] = [];
+  for (const [pageIndex, page] of osmd.GraphicSheet.MusicPages.entries()) {
+    const pageElement = pageElements[pageIndex];
+    if (!pageElement) {
+      continue;
+    }
+    const pageBounds = pageElement.getBoundingClientRect();
+    const pageLayer = document.createElement("div");
+    pageLayer.className = "absolute";
+    pageLayer.style.left = `${pageBounds.left - sheetBounds.left}px`;
+    pageLayer.style.top = `${pageBounds.top - sheetBounds.top}px`;
+    pageLayer.style.width = `${pageBounds.width}px`;
+    pageLayer.style.height = `${pageBounds.height}px`;
+
     for (const system of page.MusicSystems) {
       for (const measures of system.GraphicalMeasures) {
         const measure = measures.find((candidate) => candidate?.isVisible());
@@ -383,7 +393,6 @@ function buildMeasureTargets(
 
         const topStaff = system.StaffLines[0];
         const bottomStaff = system.StaffLines.at(-1)!;
-        const pageTop = page.PositionAndShape.AbsolutePosition.y * 10;
         const target = document.createElement("div");
         target.dataset.testid = "score-viewer-measure";
         target.dataset.measureIndex = String(
@@ -394,15 +403,25 @@ function buildMeasureTargets(
         );
         target.className =
           "absolute cursor-pointer bg-transparent hover:bg-blue-500/10";
-        target.style.left = `${measure.PositionAndShape.AbsolutePosition.x * 10}px`;
-        target.style.top = `${pageTop + topStaff.PositionAndShape.AbsolutePosition.y * 10 - 20}px`;
-        target.style.width = `${measure.PositionAndShape.Size.width * 10}px`;
+        const measureIndex = system.GraphicalMeasures.indexOf(measures);
+        const nextMeasure = system.GraphicalMeasures[measureIndex + 1]?.find(
+          (candidate) => candidate?.isVisible(),
+        );
+        const left = measure.PositionAndShape.AbsolutePosition.x * 10;
+        const right =
+          nextMeasure?.PositionAndShape.AbsolutePosition.x !== undefined
+            ? nextMeasure.PositionAndShape.AbsolutePosition.x * 10
+            : system.GetRightBorderAbsoluteXPosition() * 10;
+        target.style.left = `${left}px`;
+        target.style.top = `${topStaff.PositionAndShape.AbsolutePosition.y * 10 - 20}px`;
+        target.style.width = `${right - left}px`;
         target.style.height = `${(bottomStaff.PositionAndShape.AbsolutePosition.y + bottomStaff.StaffHeight - topStaff.PositionAndShape.AbsolutePosition.y) * 10 + 40}px`;
-        targets.push(target);
+        pageLayer.append(target);
       }
     }
+    pageLayers.push(pageLayer);
   }
-  layer.replaceChildren(...targets);
+  layers.replaceChildren(...pageLayers);
 }
 
 // Temporary score-viewer transport matching the snapshot/subscription shape

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -361,6 +361,8 @@ function buildCursorPositions(osmd: OpenSheetMusicDisplay): CursorPosition[] {
   return result.sort((a, b) => a.time - b.time || a.systemId - b.systemId);
 }
 
+// OSMD does not render measure-level hit targets. Build transparent overlays
+// from its graphical measures so each target spans the full system height.
 function buildMeasureTargets(
   osmd: OpenSheetMusicDisplay,
   layer: HTMLDivElement,

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -154,7 +154,7 @@ export class ScoreViewerRuntime {
       layout === "continuous"
         ? "relative mx-auto bg-white px-4 shadow-xl"
         : "relative mx-auto";
-    this.#positions = buildCursorPositions(this.#osmd);
+    this.#positions = buildCursorPositions(this.#osmd, this.#container);
     buildMeasureTargets(this.#osmd, this.#measureLayers, this.#container);
     this.#clock.stop();
     this.#setState({
@@ -293,7 +293,10 @@ function parseTempo(xml: string) {
   return Number.isFinite(value) && value > 0 ? value : 120;
 }
 
-function buildCursorPositions(osmd: OpenSheetMusicDisplay): CursorPosition[] {
+function buildCursorPositions(
+  osmd: OpenSheetMusicDisplay,
+  container: HTMLDivElement,
+): CursorPosition[] {
   // TODO: Define how simultaneous entries at one timestamp map to a single
   // cursor anchor before MusicXML chord or multi-voice support is added.
   // OSMD has no high-level playback geometry API, so derive anchors from its
@@ -314,6 +317,15 @@ function buildCursorPositions(osmd: OpenSheetMusicDisplay): CursorPosition[] {
   // OSMD exposes entry geometry, so add each system's final timestamp and
   // right border to prevent a freeze before wrapping.
   const result: CursorPosition[] = [];
+  const containerBounds = container.getBoundingClientRect();
+  const pageElements = container.querySelectorAll<HTMLElement>(":scope > div");
+  const pageOffsets = new Map(
+    osmd.GraphicSheet.MusicPages.map((page, index) => [
+      page,
+      (pageElements[index]?.getBoundingClientRect().top ??
+        containerBounds.top) - containerBounds.top,
+    ]),
+  );
 
   // Add real anchors at rendered staff entries and their score timestamps.
   for (const container of osmd.GraphicSheet
@@ -325,8 +337,10 @@ function buildCursorPositions(osmd: OpenSheetMusicDisplay): CursorPosition[] {
     }
     const topStaff = system.StaffLines[0];
     const bottomStaff = system.StaffLines.at(-1)!;
+    const pageTop = pageOffsets.get(system.Parent) ?? 0;
     // 20px padding above and below the system
-    const top = topStaff.PositionAndShape.AbsolutePosition.y * 10 - 20;
+    const top =
+      pageTop + topStaff.PositionAndShape.AbsolutePosition.y * 10 - 20;
     const bottom =
       (bottomStaff.PositionAndShape.AbsolutePosition.y +
         bottomStaff.StaffHeight) *

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -63,6 +63,7 @@ export class ScoreViewerRuntime {
   #root!: HTMLDivElement;
   #container!: HTMLDivElement;
   #cursor!: HTMLDivElement;
+  #measureLayer!: HTMLDivElement;
   #scroller!: HTMLElement;
   #sheet!: HTMLDivElement;
 
@@ -115,11 +116,15 @@ export class ScoreViewerRuntime {
     this.#cursor.className =
       "pointer-events-none absolute top-0 left-0 z-10 w-[3px] bg-blue-500";
 
+    this.#measureLayer = document.createElement("div");
+    this.#measureLayer.className = "absolute inset-0 z-[5]";
+    this.#measureLayer.addEventListener("click", this.#handleMeasureClick);
+
     this.#container = document.createElement("div");
     this.#container.dataset.testid = "score-viewer-renderer";
     this.#container.style.width = `${SCORE_LAYOUT_WIDTH}px`;
 
-    this.#sheet.append(this.#cursor, this.#container);
+    this.#sheet.append(this.#cursor, this.#measureLayer, this.#container);
     this.#scroller.append(this.#sheet);
     this.#root.append(this.#scroller);
     this.#osmd = new OpenSheetMusicDisplay(this.#container, {
@@ -149,6 +154,7 @@ export class ScoreViewerRuntime {
         ? "relative mx-auto bg-white px-4 shadow-xl"
         : "relative mx-auto";
     this.#positions = buildCursorPositions(this.#osmd);
+    buildMeasureTargets(this.#osmd, this.#measureLayer);
     this.#clock.stop();
     this.#setState({
       bar: 1,
@@ -189,11 +195,22 @@ export class ScoreViewerRuntime {
 
   dispose() {
     this.#clock.stop();
+    this.#measureLayer.removeEventListener("click", this.#handleMeasureClick);
     if (this.#root.hasChildNodes()) {
       this.#osmd.clear();
       this.#root.replaceChildren();
     }
   }
+
+  #handleMeasureClick = (event: MouseEvent) => {
+    const target = (event.target as Element).closest<HTMLElement>(
+      "[data-score-time]",
+    );
+    if (!target) {
+      return;
+    }
+    this.seek(Number(target.dataset.scoreTime));
+  };
 
   #updateCursor(scoreTime: number) {
     if (this.#positions.length < 2) {
@@ -341,6 +358,39 @@ function buildCursorPositions(osmd: OpenSheetMusicDisplay): CursorPosition[] {
     }
   }
   return result.sort((a, b) => a.time - b.time || a.systemId - b.systemId);
+}
+
+function buildMeasureTargets(
+  osmd: OpenSheetMusicDisplay,
+  layer: HTMLDivElement,
+) {
+  const targets: HTMLDivElement[] = [];
+  for (const measures of osmd.GraphicSheet.MeasureList) {
+    const measure = measures.find((candidate) => candidate?.isVisible());
+    const system = measure?.ParentMusicSystem;
+    if (!measure || !system) {
+      continue;
+    }
+
+    const topStaff = system.StaffLines[0];
+    const bottomStaff = system.StaffLines.at(-1)!;
+    const target = document.createElement("div");
+    target.dataset.testid = "score-viewer-measure";
+    target.dataset.measureIndex = String(
+      measure.parentSourceMeasure.measureListIndex,
+    );
+    target.dataset.scoreTime = String(
+      measure.parentSourceMeasure.AbsoluteTimestamp.RealValue,
+    );
+    target.className =
+      "absolute cursor-pointer bg-transparent hover:bg-blue-500/10";
+    target.style.left = `${measure.PositionAndShape.AbsolutePosition.x * 10}px`;
+    target.style.top = `${topStaff.PositionAndShape.AbsolutePosition.y * 10 - 20}px`;
+    target.style.width = `${measure.PositionAndShape.Size.width * 10}px`;
+    target.style.height = `${(bottomStaff.PositionAndShape.AbsolutePosition.y + bottomStaff.StaffHeight - topStaff.PositionAndShape.AbsolutePosition.y) * 10 + 40}px`;
+    targets.push(target);
+  }
+  layer.replaceChildren(...targets);
 }
 
 // Temporary score-viewer transport matching the snapshot/subscription shape

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -373,31 +373,34 @@ function buildMeasureTargets(
   layer: HTMLDivElement,
 ) {
   const targets: HTMLDivElement[] = [];
-  for (const measures of osmd.GraphicSheet.MeasureList) {
-    const measure = measures.find((candidate) => candidate?.isVisible());
-    const system = measure?.ParentMusicSystem;
-    if (!measure || !system) {
-      continue;
-    }
+  for (const page of osmd.GraphicSheet.MusicPages) {
+    for (const system of page.MusicSystems) {
+      for (const measures of system.GraphicalMeasures) {
+        const measure = measures.find((candidate) => candidate?.isVisible());
+        if (!measure) {
+          continue;
+        }
 
-    const topStaff = system.StaffLines[0];
-    const bottomStaff = system.StaffLines.at(-1)!;
-    const pageTop = system.Parent.PositionAndShape.AbsolutePosition.y * 10;
-    const target = document.createElement("div");
-    target.dataset.testid = "score-viewer-measure";
-    target.dataset.measureIndex = String(
-      measure.parentSourceMeasure.measureListIndex,
-    );
-    target.dataset.scoreTime = String(
-      measure.parentSourceMeasure.AbsoluteTimestamp.RealValue,
-    );
-    target.className =
-      "absolute cursor-pointer bg-transparent hover:bg-blue-500/10";
-    target.style.left = `${measure.PositionAndShape.AbsolutePosition.x * 10}px`;
-    target.style.top = `${pageTop + topStaff.PositionAndShape.AbsolutePosition.y * 10 - 20}px`;
-    target.style.width = `${measure.PositionAndShape.Size.width * 10}px`;
-    target.style.height = `${(bottomStaff.PositionAndShape.AbsolutePosition.y + bottomStaff.StaffHeight - topStaff.PositionAndShape.AbsolutePosition.y) * 10 + 40}px`;
-    targets.push(target);
+        const topStaff = system.StaffLines[0];
+        const bottomStaff = system.StaffLines.at(-1)!;
+        const pageTop = page.PositionAndShape.AbsolutePosition.y * 10;
+        const target = document.createElement("div");
+        target.dataset.testid = "score-viewer-measure";
+        target.dataset.measureIndex = String(
+          measure.parentSourceMeasure.measureListIndex,
+        );
+        target.dataset.scoreTime = String(
+          measure.parentSourceMeasure.AbsoluteTimestamp.RealValue,
+        );
+        target.className =
+          "absolute cursor-pointer bg-transparent hover:bg-blue-500/10";
+        target.style.left = `${measure.PositionAndShape.AbsolutePosition.x * 10}px`;
+        target.style.top = `${pageTop + topStaff.PositionAndShape.AbsolutePosition.y * 10 - 20}px`;
+        target.style.width = `${measure.PositionAndShape.Size.width * 10}px`;
+        target.style.height = `${(bottomStaff.PositionAndShape.AbsolutePosition.y + bottomStaff.StaffHeight - topStaff.PositionAndShape.AbsolutePosition.y) * 10 + 40}px`;
+        targets.push(target);
+      }
+    }
   }
   layer.replaceChildren(...targets);
 }

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -3,7 +3,6 @@ import {
   ChevronsUpDownIcon,
   FolderIcon,
   FolderOpenIcon,
-  LocateFixedIcon,
   MoreVerticalIcon,
   PauseIcon,
   PlayIcon,
@@ -97,21 +96,6 @@ export function ScoreViewer() {
     }
   }
 
-  // TODO: Parse time signatures and score bounds for meter-aware seeking.
-  function promptForPosition() {
-    const value = window.prompt(
-      "Go to bar and beat",
-      formatBarBeat(runtimeState.bar, runtimeState.beat),
-    );
-    const match = value?.match(/^(\d+)[|:](\d+)$/);
-    if (!match) {
-      return;
-    }
-    const bar = Math.max(Number(match[1]), 1);
-    const beat = Math.min(Math.max(Number(match[2]), 1), 4);
-    runtime.seek(((bar - 1) * 4 + (beat - 1)) / 4);
-  }
-
   return (
     <main
       className={cn(
@@ -150,20 +134,9 @@ export function ScoreViewer() {
 
         <div className="h-5 w-px bg-border" />
 
-        <div className="flex items-center gap-1">
-          <span className="whitespace-nowrap font-mono text-sm text-neutral-300">
-            {formatBarBeat(runtimeState.bar, runtimeState.beat)}
-          </span>
-          <Button
-            aria-label="Seek"
-            title="Seek"
-            disabled={!runtimeState.isReady}
-            onClick={promptForPosition}
-            className="size-7 px-0 text-neutral-400 hover:bg-accent hover:text-white"
-          >
-            <LocateFixedIcon className="size-3.5" />
-          </Button>
-        </div>
+        <span className="whitespace-nowrap font-mono text-sm text-neutral-300">
+          {formatBarBeat(runtimeState.bar, runtimeState.beat)}
+        </span>
 
         <div className="h-5 w-px bg-border" />
 


### PR DESCRIPTION
- part of https://github.com/hi-ogawa/toy-midi/issues/224

The score viewer only supported seeking through the bar/beat prompt, which is cumbersome when navigating a rendered score.

This PR makes each rendered measure clickable and seeks to its start while preserving the current playback state. It derives full-system hit regions from OSMD's graphical measures, adds a subtle hover affordance, and aligns separate overlay and cursor geometry with each rendered page so seeking works across both continuous and paged layouts.