### PR TITLE
feat: add persisted project score route

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,7 @@ The editor supports one MIDI track and multiple audio tracks on a shared beat-ba
 - `src/hooks/use-audio.ts` exposes reactive audio state to the UI.
 - `src/lib/project-session.ts` owns the active-project lifecycle.
 - `src/lib/project-storage.ts` owns browser persistence access.
+- `src/components/score-viewer.tsx` owns standalone and project-backed score playback.
 
 ## State And Audio Flow
 
@@ -43,5 +44,7 @@ Project documents and their metadata index live in localStorage. Binary audio as
 Compatible document changes migrate when a project is loaded. Breaking or lossy storage changes require a new storage layout and a copy-before-delete migration so the previous data remains recoverable until commit.
 
 An active project session coordinates hydration, audio synchronization, autosave, asset restoration, shortcuts, and cleanup. The editor renders from hydrated project data immediately, while audio initialization and restoration continue in the background.
+
+Project score routes read persisted documents directly and generate MusicXML in memory. They do not establish an active project session or mutate editor state; the editor flushes pending autosave before opening a score snapshot.
 
 Portable project files are zip archives containing project data, a manifest, and audio assets. MIDI import and export remain separate from the project-file format.

--- a/e2e/project-route.spec.ts
+++ b/e2e/project-route.spec.ts
@@ -99,4 +99,14 @@ test.describe("Project Route", () => {
       page.getByText("Project does-not-exist metadata not found"),
     ).toBeVisible();
   });
+
+  test("unknown project score id shows error", async ({ page }) => {
+    await page.goto("/project/does-not-exist/score");
+    await expect(
+      page.getByText("Project does-not-exist metadata not found"),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Back to project" }),
+    ).toHaveAttribute("href", "/project/does-not-exist");
+  });
 });

--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -21,8 +21,6 @@ test("opens the latest project state as a score in a new tab", async ({
   const projectId = await page.evaluate(() =>
     window.__e2e.projectStorage.getLastProjectId(),
   );
-  await page.getByTestId("app-menu-button").click();
-
   await page.evaluate(() => {
     const state = window.__e2e.useProjectStore.getState();
     state.addNote({
@@ -34,10 +32,12 @@ test("opens the latest project state as a score in a new tab", async ({
     });
     state.setTempo(137);
   });
+  await page.getByTestId("settings-button").click();
   const popupPromise = page.waitForEvent("popup");
-  await page.getByTestId("view-score-menu-item").click();
+  await page.getByTestId("view-score-button").click();
   const scorePage = await popupPromise;
 
+  await expect(page.getByTestId("settings-dialog")).not.toBeVisible();
   await expect(scorePage).toHaveURL(`/project/${projectId}/score`);
   await expect(scorePage.getByTestId("score-name")).toHaveText(
     "Untitled.musicxml",

--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { expect, Page, test } from "@playwright/test";
+import { clickNewProject } from "./helpers";
 
 test("navigates between projects and the score viewer", async ({ page }) => {
   await page.goto("/");
@@ -10,6 +11,47 @@ test("navigates between projects and the score viewer", async ({ page }) => {
   await page.getByTestId("all-projects-menu-item").click();
   await expect(page).toHaveURL(/\/$/);
   await expect(page.getByTestId("startup-screen")).toBeVisible();
+});
+
+test("opens the latest project state as a score in a new tab", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await clickNewProject(page);
+  const projectId = await page.evaluate(() =>
+    window.__e2e.projectStorage.getLastProjectId(),
+  );
+  await page.getByTestId("app-menu-button").click();
+
+  const popupPromise = page.waitForEvent("popup");
+  await page.evaluate(() => {
+    const state = window.__e2e.useProjectStore.getState();
+    state.addNote({
+      id: "note-project-score",
+      pitch: 48,
+      start: 0,
+      duration: 1,
+      velocity: 100,
+    });
+    state.setTempo(137);
+    document
+      .querySelector<HTMLElement>("[data-testid=view-score-menu-item]")!
+      .click();
+  });
+  const scorePage = await popupPromise;
+
+  await expect(scorePage).toHaveURL(`/project/${projectId}/score`);
+  await expect(scorePage.getByTestId("score-name")).toHaveText(
+    "Untitled.musicxml",
+  );
+  await expect(
+    scorePage.getByTestId("score-viewer-renderer").locator("svg"),
+  ).toBeVisible();
+  await expect(scorePage.getByLabel("BPM")).toHaveValue("137");
+  await expect(scorePage.getByRole("button", { name: "Samples" })).toHaveCount(
+    0,
+  );
+  await expect(scorePage.getByLabel("Open MusicXML")).toHaveCount(0);
 });
 
 test("renders and plays a Toy MIDI MusicXML export", async ({ page }) => {

--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -23,7 +23,6 @@ test("opens the latest project state as a score in a new tab", async ({
   );
   await page.getByTestId("app-menu-button").click();
 
-  const popupPromise = page.waitForEvent("popup");
   await page.evaluate(() => {
     const state = window.__e2e.useProjectStore.getState();
     state.addNote({
@@ -34,10 +33,9 @@ test("opens the latest project state as a score in a new tab", async ({
       velocity: 100,
     });
     state.setTempo(137);
-    document
-      .querySelector<HTMLElement>("[data-testid=view-score-menu-item]")!
-      .click();
   });
+  const popupPromise = page.waitForEvent("popup");
+  await page.getByTestId("view-score-menu-item").click();
   const scorePage = await popupPromise;
 
   await expect(scorePage).toHaveURL(`/project/${projectId}/score`);

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3,18 +3,58 @@ import { ProjectListView } from "./components/project-list-view";
 import { ScoreViewer } from "./components/score-viewer";
 import { useWindowEvent } from "./hooks/use-window-event";
 import { matchKeyboardEvent } from "./lib/keyboard";
+import { exportMusicXml } from "./lib/musicxml-export";
 import { getProjectSession } from "./lib/project-session";
 import { projectStorage } from "./lib/project-storage";
+import { fromSavedProject } from "./lib/project-store";
 
 export function App() {
   if (window.location.pathname === "/score-viewer") {
     return <ScoreViewer />;
+  }
+  const scoreMatch = window.location.pathname.match(
+    /^\/project\/([^/]+)\/score$/,
+  );
+  if (scoreMatch) {
+    return <ProjectScoreRoute projectId={scoreMatch[1]} />;
   }
   const match = window.location.pathname.match(/^\/project\/([^/]+)$/);
   if (match) {
     return <ProjectRoute projectId={match[1]} />;
   }
   return <StartupApp />;
+}
+
+function ProjectScoreRoute({ projectId }: { projectId: string }) {
+  try {
+    const metadata = projectStorage.getMetadata(projectId);
+    if (!metadata) {
+      throw new Error(`Project ${projectId} metadata not found`);
+    }
+    const project = fromSavedProject(projectStorage.load(projectId));
+    const xml = exportMusicXml({
+      notes: project.notes,
+      tempo: project.tempo,
+      timeSignature: project.timeSignature,
+      keySignature: project.keySignature,
+      openStringPitches: project.tabOpenStringPitches,
+    });
+    return (
+      <ScoreViewer initialSource={{ name: `${metadata.name}.musicxml`, xml }} />
+    );
+  } catch (error) {
+    return (
+      <div className="fixed inset-0 bg-neutral-900 flex flex-col items-center justify-center gap-4 text-neutral-400">
+        {String(error)}
+        <a
+          href={`/project/${projectId}`}
+          className="text-emerald-400 hover:text-emerald-300"
+        >
+          Back to project
+        </a>
+      </div>
+    );
+  }
 }
 
 // All project opens are full-page navigation; ProjectRoute is the only way

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,10 +1,9 @@
 import { Editor } from "./components/editor";
 import { ProjectListView } from "./components/project-list-view";
 import { ScoreViewer } from "./components/score-viewer";
-import { exportMusicXml } from "./lib/musicxml-export";
+import { getProjectScoreSource } from "./lib/project-score";
 import { getProjectSession } from "./lib/project-session";
 import { projectStorage } from "./lib/project-storage";
-import { fromSavedProject } from "./lib/project-store";
 
 export function App() {
   if (window.location.pathname === "/score-viewer") {
@@ -24,35 +23,19 @@ export function App() {
 }
 
 function ProjectScoreRoute({ projectId }: { projectId: string }) {
-  try {
-    const metadata = projectStorage.getMetadata(projectId);
-    if (!metadata) {
-      throw new Error(`Project ${projectId} metadata not found`);
-    }
-    const project = fromSavedProject(projectStorage.load(projectId));
-    const xml = exportMusicXml({
-      notes: project.notes,
-      tempo: project.tempo,
-      timeSignature: project.timeSignature,
-      keySignature: project.keySignature,
-      openStringPitches: project.tabOpenStringPitches,
-    });
+  const score = getProjectScoreSource(projectId);
+
+  if (!score.ok) {
     return (
-      <ScoreViewer initialSource={{ name: `${metadata.name}.musicxml`, xml }} />
-    );
-  } catch (error) {
-    return (
-      <div className="fixed inset-0 bg-neutral-900 flex flex-col items-center justify-center gap-4 text-neutral-400">
-        {String(error)}
-        <a
-          href={`/project/${projectId}`}
-          className="text-emerald-400 hover:text-emerald-300"
-        >
-          Back to project
-        </a>
-      </div>
+      <RouteError
+        error={score.error}
+        backHref={`/project/${projectId}`}
+        backLabel="Back to project"
+      />
     );
   }
+
+  return <ScoreViewer initialSource={score.value} />;
 }
 
 // All project opens are full-page navigation; ProjectRoute is the only way
@@ -77,12 +60,11 @@ function ProjectRoute({ projectId }: { projectId: string }) {
 
   if (!session.ok) {
     return (
-      <div className="fixed inset-0 bg-neutral-900 flex flex-col items-center justify-center gap-4 text-neutral-400">
-        {String(session.error)}
-        <a href="/" className="text-emerald-400 hover:text-emerald-300">
-          Back to projects
-        </a>
-      </div>
+      <RouteError
+        error={session.error}
+        backHref="/"
+        backLabel="Back to projects"
+      />
     );
   }
 
@@ -91,6 +73,25 @@ function ProjectRoute({ projectId }: { projectId: string }) {
       projectId={session.value.projectId}
       initialProjectName={session.value.projectName}
     />
+  );
+}
+
+function RouteError({
+  error,
+  backHref,
+  backLabel,
+}: {
+  error: unknown;
+  backHref: string;
+  backLabel: string;
+}) {
+  return (
+    <div className="fixed inset-0 flex flex-col items-center justify-center gap-4 bg-neutral-900 text-neutral-400">
+      {String(error)}
+      <a href={backHref} className="text-emerald-400 hover:text-emerald-300">
+        {backLabel}
+      </a>
+    </div>
   );
 }
 

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -1,5 +1,6 @@
 import {
   CircleHelpIcon,
+  FileMusicIcon,
   FolderIcon,
   MoreVerticalIcon,
   SettingsIcon,
@@ -9,6 +10,7 @@ import {
 import { useEffect, useState } from "react";
 import { useWindowEvent } from "../hooks/use-window-event";
 import { isShortcutTextInputTarget, matchKeyboardEvent } from "../lib/keyboard";
+import { flushAutoSave } from "../lib/project-session";
 import { projectStorage } from "../lib/project-storage";
 import { useProjectStore } from "../lib/project-store";
 import { AudioToMidi } from "./audio-to-midi";
@@ -110,6 +112,19 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
+                <DropdownMenuItem asChild>
+                  <a
+                    href={`/project/${projectId}/score`}
+                    target="_blank"
+                    rel="noreferrer"
+                    data-testid="view-score-menu-item"
+                    onPointerDown={flushAutoSave}
+                    onClick={flushAutoSave}
+                  >
+                    <FileMusicIcon />
+                    View Score
+                  </a>
+                </DropdownMenuItem>
                 <DropdownMenuItem asChild>
                   <a href="/" data-testid="all-projects-menu-item">
                     <FolderIcon />

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -1,6 +1,5 @@
 import {
   CircleHelpIcon,
-  FileMusicIcon,
   FolderIcon,
   MoreVerticalIcon,
   SettingsIcon,
@@ -113,18 +112,6 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 <DropdownMenuItem asChild>
-                  <a
-                    href={`/project/${projectId}/score`}
-                    target="_blank"
-                    rel="noreferrer"
-                    data-testid="view-score-menu-item"
-                    onClick={flushAutoSave}
-                  >
-                    <FileMusicIcon />
-                    View Score
-                  </a>
-                </DropdownMenuItem>
-                <DropdownMenuItem asChild>
                   <a href="/" data-testid="all-projects-menu-item">
                     <FolderIcon />
                     All Projects
@@ -179,11 +166,16 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
       >
         <Settings
           projectName={projectName}
+          projectScoreHref={`/project/${projectId}/score`}
           onProjectNameChange={(name) => {
             if (name && name !== projectName) {
               projectStorage.updateMetadata(projectId, { name });
               setProjectName(name);
             }
+          }}
+          onProjectScoreOpen={() => {
+            flushAutoSave();
+            setIsSettingsOpen(false);
           }}
           onAudioToMidiClick={(trackId) => {
             setIsSettingsOpen(false);

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -118,7 +118,6 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
                     target="_blank"
                     rel="noreferrer"
                     data-testid="view-score-menu-item"
-                    onPointerDown={flushAutoSave}
                     onClick={flushAutoSave}
                   >
                     <FileMusicIcon />

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -69,7 +69,6 @@ export class ScoreViewerRuntime {
   #sheet!: HTMLDivElement;
 
   #osmd!: OpenSheetMusicDisplay;
-  #loadGeneration = 0;
 
   #positions: CursorPosition[] = [];
   #state = INITIAL_RUNTIME_STATE;
@@ -101,7 +100,6 @@ export class ScoreViewerRuntime {
   };
 
   attach(root: HTMLDivElement) {
-    this.#loadGeneration++;
     this.#root = root;
     this.#root.replaceChildren();
 
@@ -143,26 +141,21 @@ export class ScoreViewerRuntime {
   }
 
   async load({ score, layout }: { score: ScoreSource; layout: ScoreLayout }) {
-    const loadGeneration = ++this.#loadGeneration;
-    const osmd = this.#osmd;
     this.#clock.stop();
     this.#setState({ isReady: false });
 
-    osmd.clear();
-    osmd.setPageFormat(layout === "paged" ? "A4_P" : "Endless");
-    await osmd.load(score.xml);
-    if (loadGeneration !== this.#loadGeneration) {
-      return false;
-    }
+    this.#osmd.clear();
+    this.#osmd.setPageFormat(layout === "paged" ? "A4_P" : "Endless");
+    await this.#osmd.load(score.xml);
     this.#sheet.hidden = false;
-    osmd.render();
+    this.#osmd.render();
 
     this.#sheet.className =
       layout === "continuous"
         ? "relative mx-auto bg-white px-4 shadow-xl"
         : "relative mx-auto";
-    this.#positions = buildCursorPositions(osmd, this.#container);
-    buildMeasureTargets(osmd, this.#measureLayers, this.#container);
+    this.#positions = buildCursorPositions(this.#osmd, this.#container);
+    buildMeasureTargets(this.#osmd, this.#measureLayers, this.#container);
     this.#clock.stop();
     this.#setState({
       bar: 1,
@@ -171,7 +164,6 @@ export class ScoreViewerRuntime {
       tempo: parseTempo(score.xml),
     });
     this.#updateCursor(0);
-    return true;
   }
 
   togglePlayback() {
@@ -203,7 +195,6 @@ export class ScoreViewerRuntime {
   }
 
   dispose() {
-    this.#loadGeneration++;
     this.#clock.stop();
     this.#measureLayers.removeEventListener("click", this.#handleMeasureClick);
     if (this.#root.hasChildNodes()) {

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -69,6 +69,7 @@ export class ScoreViewerRuntime {
   #sheet!: HTMLDivElement;
 
   #osmd!: OpenSheetMusicDisplay;
+  #loadGeneration = 0;
 
   #positions: CursorPosition[] = [];
   #state = INITIAL_RUNTIME_STATE;
@@ -100,6 +101,7 @@ export class ScoreViewerRuntime {
   };
 
   attach(root: HTMLDivElement) {
+    this.#loadGeneration++;
     this.#root = root;
     this.#root.replaceChildren();
 
@@ -141,21 +143,26 @@ export class ScoreViewerRuntime {
   }
 
   async load({ score, layout }: { score: ScoreSource; layout: ScoreLayout }) {
+    const loadGeneration = ++this.#loadGeneration;
+    const osmd = this.#osmd;
     this.#clock.stop();
     this.#setState({ isReady: false });
 
-    this.#osmd.clear();
-    this.#osmd.setPageFormat(layout === "paged" ? "A4_P" : "Endless");
-    await this.#osmd.load(score.xml);
+    osmd.clear();
+    osmd.setPageFormat(layout === "paged" ? "A4_P" : "Endless");
+    await osmd.load(score.xml);
+    if (loadGeneration !== this.#loadGeneration) {
+      return false;
+    }
     this.#sheet.hidden = false;
-    this.#osmd.render();
+    osmd.render();
 
     this.#sheet.className =
       layout === "continuous"
         ? "relative mx-auto bg-white px-4 shadow-xl"
         : "relative mx-auto";
-    this.#positions = buildCursorPositions(this.#osmd, this.#container);
-    buildMeasureTargets(this.#osmd, this.#measureLayers, this.#container);
+    this.#positions = buildCursorPositions(osmd, this.#container);
+    buildMeasureTargets(osmd, this.#measureLayers, this.#container);
     this.#clock.stop();
     this.#setState({
       bar: 1,
@@ -164,6 +171,7 @@ export class ScoreViewerRuntime {
       tempo: parseTempo(score.xml),
     });
     this.#updateCursor(0);
+    return true;
   }
 
   togglePlayback() {
@@ -195,6 +203,7 @@ export class ScoreViewerRuntime {
   }
 
   dispose() {
+    this.#loadGeneration++;
     this.#clock.stop();
     this.#measureLayers.removeEventListener("click", this.#handleMeasureClick);
     if (this.#root.hasChildNodes()) {

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -9,7 +9,13 @@ import {
   RotateCcwIcon,
   UploadIcon,
 } from "lucide-react";
-import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import {
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { useDraftInput } from "../hooks/use-draft-input";
 import { useWindowEvent } from "../hooks/use-window-event";
 import { isShortcutTextInputTarget, matchKeyboardEvent } from "../lib/keyboard";
@@ -29,10 +35,14 @@ import {
 } from "./ui/dropdown-menu";
 import { cn } from "./ui/utils";
 
-export function ScoreViewer() {
+export function ScoreViewer({
+  initialSource,
+}: {
+  initialSource?: ScoreSource;
+}) {
   const runtimeRootRef = useRef<HTMLDivElement>(null);
 
-  const [score, setScore] = useState<ScoreSource>();
+  const [score, setScore] = useState<ScoreSource | undefined>(initialSource);
   const [layout, setLayout] = useState<ScoreLayout>("continuous");
 
   // initialize runtime
@@ -41,15 +51,6 @@ export function ScoreViewer() {
     runtime.subscribe,
     runtime.getSnapshot,
   );
-  useEffect(() => {
-    const root = runtimeRootRef.current;
-    if (!root) {
-      return;
-    }
-    runtime.attach(root);
-    return () => runtime.dispose();
-  }, [runtime]);
-
   const tempoInput = useDraftInput({
     value: runtimeState.tempo,
     onCommit: (tempo) => runtime.setTempo(tempo),
@@ -78,10 +79,26 @@ export function ScoreViewer() {
         source instanceof File
           ? { name: source.name, xml: await source.text() }
           : source;
-      await runtime.load({ score: nextScore, layout });
-      setScore(nextScore);
+      if (await runtime.load({ score: nextScore, layout })) {
+        setScore(nextScore);
+      }
     },
   });
+
+  const loadInitialSource = useEffectEvent((source: ScoreSource) => {
+    loadMutation.mutate({ layout: "continuous", source });
+  });
+  useEffect(() => {
+    const root = runtimeRootRef.current;
+    if (!root) {
+      return;
+    }
+    runtime.attach(root);
+    if (initialSource) {
+      loadInitialSource(initialSource);
+    }
+    return () => runtime.dispose();
+  }, [initialSource, runtime]);
 
   function changeLayout(nextLayout: ScoreLayout) {
     if (nextLayout === layout) {
@@ -178,47 +195,51 @@ export function ScoreViewer() {
           {score?.name ?? "No score loaded"}
         </span>
 
-        <div className="h-5 w-px bg-border" />
+        {!initialSource && (
+          <>
+            <div className="h-5 w-px bg-border" />
 
-        <FileDropInput
-          accept=".musicxml,.xml,application/vnd.recordare.musicxml+xml"
-          disabled={loadMutation.isPending}
-          inputProps={{ "aria-label": "Open MusicXML" }}
-          onFile={(file) => loadMutation.mutate({ layout, source: file })}
-          className="h-8 gap-1.5 px-3 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
-        >
-          <FolderOpenIcon className="size-4" />
-          Open
-        </FileDropInput>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button className="h-8 gap-1.5 px-3 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50">
-              Samples
-              <ChevronsUpDownIcon className="size-4 opacity-50" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-72">
-            {SCORE_VIEWER_SAMPLES.map((sample) => (
-              <DropdownMenuItem
-                key={sample.id}
-                onSelect={() =>
-                  loadMutation.mutate({
-                    layout,
-                    source: { name: sample.name, xml: sample.xml },
-                  })
-                }
-                className="items-start"
-              >
-                <div>
-                  <div>{sample.name}</div>
-                  <div className="text-xs text-muted-foreground">
-                    {sample.description}
-                  </div>
-                </div>
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
+            <FileDropInput
+              accept=".musicxml,.xml,application/vnd.recordare.musicxml+xml"
+              disabled={loadMutation.isPending}
+              inputProps={{ "aria-label": "Open MusicXML" }}
+              onFile={(file) => loadMutation.mutate({ layout, source: file })}
+              className="h-8 gap-1.5 px-3 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+            >
+              <FolderOpenIcon className="size-4" />
+              Open
+            </FileDropInput>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button className="h-8 gap-1.5 px-3 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50">
+                  Samples
+                  <ChevronsUpDownIcon className="size-4 opacity-50" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-72">
+                {SCORE_VIEWER_SAMPLES.map((sample) => (
+                  <DropdownMenuItem
+                    key={sample.id}
+                    onSelect={() =>
+                      loadMutation.mutate({
+                        layout,
+                        source: { name: sample.name, xml: sample.xml },
+                      })
+                    }
+                    className="items-start"
+                  >
+                    <div>
+                      <div>{sample.name}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {sample.description}
+                      </div>
+                    </div>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </>
+        )}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   ChevronsUpDownIcon,
   FolderIcon,
@@ -9,13 +9,7 @@ import {
   RotateCcwIcon,
   UploadIcon,
 } from "lucide-react";
-import {
-  useEffect,
-  useEffectEvent,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { useDraftInput } from "../hooks/use-draft-input";
 import { useWindowEvent } from "../hooks/use-window-event";
 import { isShortcutTextInputTarget, matchKeyboardEvent } from "../lib/keyboard";
@@ -44,6 +38,7 @@ export function ScoreViewer({
 
   const [score, setScore] = useState<ScoreSource | undefined>(initialSource);
   const [layout, setLayout] = useState<ScoreLayout>("continuous");
+  const [isRuntimeAttached, setIsRuntimeAttached] = useState(false);
 
   // initialize runtime
   const [runtime] = useState(() => new ScoreViewerRuntime());
@@ -67,38 +62,48 @@ export function ScoreViewer({
     }
   });
 
-  const loadMutation = useMutation({
-    mutationFn: async ({
-      layout,
-      source,
-    }: {
-      layout: ScoreLayout;
-      source: File | ScoreSource;
-    }) => {
-      const nextScore =
-        source instanceof File
-          ? { name: source.name, xml: await source.text() }
-          : source;
-      if (await runtime.load({ score: nextScore, layout })) {
-        setScore(nextScore);
+  async function loadScore({
+    layout,
+    source,
+  }: {
+    layout: ScoreLayout;
+    source: File | ScoreSource;
+  }) {
+    const nextScore =
+      source instanceof File
+        ? { name: source.name, xml: await source.text() }
+        : source;
+    await runtime.load({ score: nextScore, layout });
+    setScore(nextScore);
+    return nextScore;
+  }
+
+  const loadMutation = useMutation({ mutationFn: loadScore });
+  const initialLoadQuery = useQuery({
+    queryKey: ["score-viewer-initial-source", initialSource],
+    enabled: isRuntimeAttached && initialSource !== undefined,
+    staleTime: Infinity,
+    queryFn: async () => {
+      if (!initialSource) {
+        throw new Error("Initial score source is missing");
       }
+      return await loadScore({
+        layout: "continuous",
+        source: initialSource,
+      });
     },
   });
+  const loadError = loadMutation.error ?? initialLoadQuery.error;
 
-  const loadInitialSource = useEffectEvent((source: ScoreSource) => {
-    loadMutation.mutate({ layout: "continuous", source });
-  });
   useEffect(() => {
     const root = runtimeRootRef.current;
     if (!root) {
       return;
     }
     runtime.attach(root);
-    if (initialSource) {
-      loadInitialSource(initialSource);
-    }
+    setIsRuntimeAttached(true);
     return () => runtime.dispose();
-  }, [initialSource, runtime]);
+  }, [runtime]);
 
   function changeLayout(nextLayout: ScoreLayout) {
     if (nextLayout === layout) {
@@ -260,7 +265,7 @@ export function ScoreViewer({
           </DropdownMenuContent>
         </DropdownMenu>
       </header>
-      {!score && !loadMutation.error && (
+      {!score && !loadError && (
         <section className="min-h-0 flex-1 p-6">
           <div className="flex justify-center">
             <FileDropInput
@@ -281,9 +286,9 @@ export function ScoreViewer({
           </div>
         </section>
       )}
-      {loadMutation.error && (
+      {loadError && (
         <p className="mx-auto mt-4 max-w-6xl text-red-800">
-          {loadMutation.error.message}
+          {loadError.message}
         </p>
       )}
       <div

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -46,6 +46,16 @@ export function ScoreViewer({
     runtime.subscribe,
     runtime.getSnapshot,
   );
+  useEffect(() => {
+    const root = runtimeRootRef.current;
+    if (!root) {
+      return;
+    }
+    runtime.attach(root);
+    setIsRuntimeAttached(true);
+    return () => runtime.dispose();
+  }, [runtime]);
+
   const tempoInput = useDraftInput({
     value: runtimeState.tempo,
     onCommit: (tempo) => runtime.setTempo(tempo),
@@ -62,48 +72,36 @@ export function ScoreViewer({
     }
   });
 
-  async function loadScore({
-    layout,
-    source,
-  }: {
-    layout: ScoreLayout;
-    source: File | ScoreSource;
-  }) {
-    const nextScore =
-      source instanceof File
-        ? { name: source.name, xml: await source.text() }
-        : source;
-    await runtime.load({ score: nextScore, layout });
-    setScore(nextScore);
-    return nextScore;
-  }
+  const loadMutation = useMutation({
+    mutationFn: async ({
+      layout,
+      source,
+    }: {
+      layout: ScoreLayout;
+      source: File | ScoreSource;
+    }) => {
+      const nextScore =
+        source instanceof File
+          ? { name: source.name, xml: await source.text() }
+          : source;
+      await runtime.load({ score: nextScore, layout });
+      setScore(nextScore);
+    },
+  });
 
-  const loadMutation = useMutation({ mutationFn: loadScore });
-  const initialLoadQuery = useQuery({
+  // Use the query cache to deduplicate initial loading under Strict Mode.
+  useQuery({
     queryKey: ["score-viewer-initial-source", initialSource],
     enabled: isRuntimeAttached && initialSource !== undefined,
     staleTime: Infinity,
     queryFn: async () => {
-      if (!initialSource) {
-        throw new Error("Initial score source is missing");
-      }
-      return await loadScore({
-        layout: "continuous",
-        source: initialSource,
+      loadMutation.mutate({
+        layout,
+        source: initialSource!,
       });
+      return true;
     },
   });
-  const loadError = loadMutation.error ?? initialLoadQuery.error;
-
-  useEffect(() => {
-    const root = runtimeRootRef.current;
-    if (!root) {
-      return;
-    }
-    runtime.attach(root);
-    setIsRuntimeAttached(true);
-    return () => runtime.dispose();
-  }, [runtime]);
 
   function changeLayout(nextLayout: ScoreLayout) {
     if (nextLayout === layout) {
@@ -265,7 +263,7 @@ export function ScoreViewer({
           </DropdownMenuContent>
         </DropdownMenu>
       </header>
-      {!score && !loadError && (
+      {!score && !loadMutation.error && (
         <section className="min-h-0 flex-1 p-6">
           <div className="flex justify-center">
             <FileDropInput
@@ -286,9 +284,9 @@ export function ScoreViewer({
           </div>
         </section>
       )}
-      {loadError && (
+      {loadMutation.error && (
         <p className="mx-auto mt-4 max-w-6xl text-red-800">
-          {loadError.message}
+          {loadMutation.error.message}
         </p>
       )}
       <div

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -1,6 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import {
   DownloadIcon,
+  FileMusicIcon,
   SparklesIcon,
   Trash2Icon,
   UploadIcon,
@@ -33,14 +34,18 @@ import { Button } from "./ui/button";
 type SettingsProps = {
   // Project section
   projectName: string;
+  projectScoreHref: string;
   onProjectNameChange: (name: string) => void;
+  onProjectScoreOpen: () => void;
   // Closes settings and opens the transcription panel for the track
   onAudioToMidiClick: (trackId: string) => void;
 };
 
 export function Settings({
   projectName,
+  projectScoreHref,
   onProjectNameChange,
+  onProjectScoreOpen,
   onAudioToMidiClick,
 }: SettingsProps) {
   const projectNameInput = useDraftTextInput({
@@ -394,6 +399,17 @@ export function Settings({
             <DownloadIcon className="size-4" />
             Export MIDI
           </Button>
+          <a
+            href={projectScoreHref}
+            target="_blank"
+            rel="noreferrer"
+            data-testid="view-score-button"
+            onClick={onProjectScoreOpen}
+            className="inline-flex h-8 w-full items-center justify-start gap-1.5 rounded-md border border-border bg-background px-3 text-sm shadow-xs transition-colors outline-none hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 dark:border-input dark:bg-input/30 dark:hover:bg-input/50"
+          >
+            <FileMusicIcon className="size-4" />
+            View Score
+          </a>
           <Button
             data-testid="export-musicxml-button"
             onClick={() => exportMusicXmlMutation.mutate()}

--- a/src/lib/project-score.ts
+++ b/src/lib/project-score.ts
@@ -1,3 +1,4 @@
+import { memo } from "../utils/memo";
 import { exportMusicXml } from "./musicxml-export";
 import { projectStorage } from "./project-storage";
 import { fromSavedProject } from "./project-store";
@@ -6,36 +7,34 @@ type ProjectScoreResult =
   | { ok: true; value: { name: string; xml: string } }
   | { ok: false; error: unknown };
 
-// Score routes are full-page snapshots. Cache their source so rendering stays
-// idempotent under Strict Mode, matching active project session loading.
-const projectScoreResults = new Map<string, ProjectScoreResult>();
+// Score routes are full-page snapshots. Memoize their source so rendering
+// stays idempotent under Strict Mode, matching active project session loading.
+export const getProjectScoreSource = memo(getProjectScoreSourceImpl);
 
-export function getProjectScoreSource(projectId: string): ProjectScoreResult {
-  let result = projectScoreResults.get(projectId);
-  if (!result) {
-    try {
-      const metadata = projectStorage.getMetadata(projectId);
-      if (!metadata) {
-        throw new Error(`Project ${projectId} metadata not found`);
-      }
-      const project = fromSavedProject(projectStorage.load(projectId));
-      result = {
-        ok: true,
-        value: {
-          name: `${metadata.name}.musicxml`,
-          xml: exportMusicXml({
-            notes: project.notes,
-            tempo: project.tempo,
-            timeSignature: project.timeSignature,
-            keySignature: project.keySignature,
-            openStringPitches: project.tabOpenStringPitches,
-          }),
-        },
+function getProjectScoreSourceImpl(projectId: string): ProjectScoreResult {
+  try {
+    const metadata = projectStorage.getMetadata(projectId);
+    if (!metadata) {
+      return {
+        ok: false,
+        error: new Error(`Project ${projectId} metadata not found`),
       };
-    } catch (error) {
-      result = { ok: false, error };
     }
-    projectScoreResults.set(projectId, result);
+    const project = fromSavedProject(projectStorage.load(projectId));
+    return {
+      ok: true,
+      value: {
+        name: `${metadata.name}.musicxml`,
+        xml: exportMusicXml({
+          notes: project.notes,
+          tempo: project.tempo,
+          timeSignature: project.timeSignature,
+          keySignature: project.keySignature,
+          openStringPitches: project.tabOpenStringPitches,
+        }),
+      },
+    };
+  } catch (error) {
+    return { ok: false, error };
   }
-  return result;
 }

--- a/src/lib/project-score.ts
+++ b/src/lib/project-score.ts
@@ -1,0 +1,41 @@
+import { exportMusicXml } from "./musicxml-export";
+import { projectStorage } from "./project-storage";
+import { fromSavedProject } from "./project-store";
+
+type ProjectScoreResult =
+  | { ok: true; value: { name: string; xml: string } }
+  | { ok: false; error: unknown };
+
+// Score routes are full-page snapshots. Cache their source so rendering stays
+// idempotent under Strict Mode, matching active project session loading.
+const projectScoreResults = new Map<string, ProjectScoreResult>();
+
+export function getProjectScoreSource(projectId: string): ProjectScoreResult {
+  let result = projectScoreResults.get(projectId);
+  if (!result) {
+    try {
+      const metadata = projectStorage.getMetadata(projectId);
+      if (!metadata) {
+        throw new Error(`Project ${projectId} metadata not found`);
+      }
+      const project = fromSavedProject(projectStorage.load(projectId));
+      result = {
+        ok: true,
+        value: {
+          name: `${metadata.name}.musicxml`,
+          xml: exportMusicXml({
+            notes: project.notes,
+            tempo: project.tempo,
+            timeSignature: project.timeSignature,
+            keySignature: project.keySignature,
+            openStringPitches: project.tabOpenStringPitches,
+          }),
+        },
+      };
+    } catch (error) {
+      result = { ok: false, error };
+    }
+    projectScoreResults.set(projectId, result);
+  }
+  return result;
+}

--- a/src/lib/project-session.ts
+++ b/src/lib/project-session.ts
@@ -1,4 +1,5 @@
 import { toast } from "sonner";
+import { memo } from "../utils/memo";
 import { debounce } from "../utils/timing";
 import { audioManager, loadAudioFile } from "./audio";
 import { historyStore } from "./history-store";
@@ -12,13 +13,13 @@ import {
   useProjectStore,
 } from "./project-store";
 
-export interface ProjectSession {
+interface ProjectSession {
   projectId: string;
   projectName: string;
   dispose: () => void;
 }
 
-export type ProjectSessionResult =
+type ProjectSessionResult =
   | { ok: true; value: ProjectSession }
   | { ok: false; error: unknown };
 
@@ -27,19 +28,14 @@ export type ProjectSessionResult =
 // double render. Failures are cached like successes, so an open is attempted
 // exactly once per id. Entries live until full-page navigation, matching the
 // previous react-query gcTime: Infinity behavior.
-const sessionResults = new Map<string, ProjectSessionResult>();
+export const getProjectSession = memo(getProjectSessionImpl);
 
-export function getProjectSession(projectId: string): ProjectSessionResult {
-  let result = sessionResults.get(projectId);
-  if (!result) {
-    try {
-      result = { ok: true, value: openProjectSession(projectId) };
-    } catch (error) {
-      result = { ok: false, error };
-    }
-    sessionResults.set(projectId, result);
+function getProjectSessionImpl(projectId: string): ProjectSessionResult {
+  try {
+    return { ok: true, value: openProjectSession(projectId) };
+  } catch (error) {
+    return { ok: false, error };
   }
-  return result;
 }
 
 // Open a project as the active document: hydrate the store synchronously,

--- a/src/lib/project-store.ts
+++ b/src/lib/project-store.ts
@@ -717,7 +717,7 @@ export type SavedProjectV1 = Omit<SavedProject, "version" | "audioTracks"> & {
 export type AnySavedProject = SavedProjectV1 | SavedProject;
 
 // Default values for new/missing fields
-const DEFAULTS: Omit<SavedProject, "version"> = {
+const DEFAULTS = {
   notes: [],
   tempo: 120,
   timeSignature: { numerator: 4, denominator: 4 }, // Default 4/4 time
@@ -740,7 +740,7 @@ const DEFAULTS: Omit<SavedProject, "version"> = {
   scrollY: 51, // MAX_PITCH (127) - DEFAULT_VIEW_MAX_PITCH (76)
   pixelsPerBeat: 80,
   pixelsPerKey: 20,
-};
+} satisfies Omit<SavedProject, "version">;
 
 export function createDefaultSavedProject(): SavedProject {
   return { version: STORAGE_VERSION, ...DEFAULTS };
@@ -802,8 +802,18 @@ export function migrateSavedProject(data: AnySavedProject): SavedProject {
   return data;
 }
 
-// Pure deserialization: SavedProject -> Partial<ProjectState>
-export function fromSavedProject(data: AnySavedProject): Partial<ProjectState> {
+// Pure deserialization: SavedProject -> persisted ProjectState fields
+export function fromSavedProject(
+  data: AnySavedProject,
+): Partial<ProjectState> &
+  Pick<
+    ProjectState,
+    | "notes"
+    | "tempo"
+    | "timeSignature"
+    | "keySignature"
+    | "tabOpenStringPitches"
+  > {
   // Version check: only reject if major breaking change
   if (data.version > STORAGE_VERSION) {
     console.warn("Project from newer version, some data may be lost");

--- a/src/lib/project-store.ts
+++ b/src/lib/project-store.ts
@@ -803,17 +803,7 @@ export function migrateSavedProject(data: AnySavedProject): SavedProject {
 }
 
 // Pure deserialization: SavedProject -> persisted ProjectState fields
-export function fromSavedProject(
-  data: AnySavedProject,
-): Partial<ProjectState> &
-  Pick<
-    ProjectState,
-    | "notes"
-    | "tempo"
-    | "timeSignature"
-    | "keySignature"
-    | "tabOpenStringPitches"
-  > {
+export function fromSavedProject(data: AnySavedProject) {
   // Version check: only reject if major breaking change
   if (data.version > STORAGE_VERSION) {
     console.warn("Project from newer version, some data may be lost");
@@ -860,5 +850,5 @@ export function fromSavedProject(
     selectedNoteIds: new Set(),
     selectedLocatorId: undefined,
     selectedAudioTrackId: undefined,
-  };
+  } satisfies Partial<ProjectState>;
 }

--- a/src/utils/memo.test.ts
+++ b/src/utils/memo.test.ts
@@ -1,0 +1,15 @@
+import { expect, it, vi } from "vitest";
+import { memo } from "./memo";
+
+it("memoizes results by input", () => {
+  const compute = vi.fn((input: string) =>
+    input === "missing" ? undefined : input.length,
+  );
+  const memoized = memo(compute);
+
+  expect(memoized("value")).toBe(5);
+  expect(memoized("value")).toBe(5);
+  expect(memoized("missing")).toBeUndefined();
+  expect(memoized("missing")).toBeUndefined();
+  expect(compute).toHaveBeenCalledTimes(2);
+});

--- a/src/utils/memo.ts
+++ b/src/utils/memo.ts
@@ -1,0 +1,13 @@
+export function memo<Input, Output>(fn: (input: Input) => Output) {
+  const cache = new Map<Input, { value: Output }>();
+
+  return (input: Input): Output => {
+    const cached = cache.get(input);
+    if (cached) {
+      return cached.value;
+    }
+    const value = fn(input);
+    cache.set(input, { value });
+    return value;
+  };
+}


### PR DESCRIPTION
- follow-up to https://github.com/hi-ogawa/toy-midi/pull/221
- related to https://github.com/hi-ogawa/toy-midi/issues/224

The standalone score viewer still requires exporting and reopening MusicXML when the score already exists as a Toy MIDI project. It can also miss the latest editor changes when autosave is still pending.

This PR adds `/project/<id>/score` to generate MusicXML directly from the persisted project and open it with the shared score player. The editor flushes pending autosave before opening the route in a new tab, and the score route stays outside the active project session so it does not hydrate editor state, initialize audio, or change the last-project pointer. `/score-viewer` remains the standalone file and sample workflow.