### PR TITLE
refactor: remove startup continue shortcuts

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -10,14 +10,6 @@ export async function clickNewProject(page: Page): Promise<void> {
 }
 
 /**
- * Click "Continue" on startup screen to restore saved project.
- */
-export async function clickContinue(page: Page): Promise<void> {
-  await page.getByTestId("continue-button").click();
-  await page.getByTestId("transport").waitFor({ state: "visible" });
-}
-
-/**
  * Wait for the editor UI after navigating or reloading into /project/:id.
  * The editor mounts before audio is ready; use waitForAudioReady before
  * driving playback via keyboard.

--- a/e2e/multiple-projects.spec.ts
+++ b/e2e/multiple-projects.spec.ts
@@ -158,37 +158,6 @@ test.describe("Multiple Projects", () => {
     ).toBe(24);
   });
 
-  test("continue last project", async ({ page }) => {
-    // Create a project
-    await clickNewProject(page);
-    await evaluateStore(page, (store) => {
-      store.getState().addNote({
-        id: "note-last",
-        pitch: 55,
-        start: 0,
-        duration: 1,
-        velocity: 100,
-      });
-      store.getState().setTempo(130);
-    });
-    await evaluateFlushAutoSave(page);
-
-    // Reload and use "Continue Last" button
-    await page.goto("/");
-    await expect(page.getByTestId("continue-button")).toBeVisible();
-    await page.getByTestId("continue-button").click();
-
-    await expect(page.getByTestId("transport")).toBeVisible();
-
-    // Should have restored the project
-    const notes = await evaluateStore(page, (store) => store.getState().notes);
-    expect(notes).toHaveLength(1);
-    expect(notes[0].pitch).toBe(55);
-
-    const tempo = await evaluateStore(page, (store) => store.getState().tempo);
-    expect(tempo).toBe(130);
-  });
-
   test("project list shows most recently updated first", async ({ page }) => {
     // Create first project
     await clickNewProject(page);
@@ -228,24 +197,6 @@ test.describe("Multiple Projects", () => {
       "data-testid",
       `project-card-${project1Id}`,
     );
-  });
-
-  test("Space key continues last project", async ({ page }) => {
-    // Create a project
-    await clickNewProject(page);
-    await evaluateStore(page, (store) => {
-      store.getState().setTempo(115);
-    });
-    await evaluateFlushAutoSave(page);
-
-    // Reload and press Space
-    await page.goto("/");
-    await expect(page.getByTestId("continue-button")).toBeVisible();
-    await page.keyboard.press("Space");
-
-    await expect(page.getByTestId("transport")).toBeVisible();
-    const tempo = await evaluateStore(page, (store) => store.getState().tempo);
-    expect(tempo).toBe(115);
   });
 
   test("can rename project from startup screen", async ({ page }) => {

--- a/e2e/project-migration.spec.ts
+++ b/e2e/project-migration.spec.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { expect, test } from "@playwright/test";
 import { exportProjectFileV1 } from "../src/lib/project-file";
 import type { SavedProjectV1 } from "../src/lib/project-store";
-import { clickContinue, evaluateStore, waitForEditor } from "./helpers";
+import { evaluateStore, waitForEditor } from "./helpers";
 
 const TEST_AUDIO_PATH = path.join(
   import.meta.dirname,
@@ -50,7 +50,8 @@ test.describe("Project Migration", () => {
     );
 
     await page.goto("/");
-    await clickContinue(page);
+    await page.locator('[data-testid^="project-card-"]').click();
+    await waitForEditor(page);
 
     const audioTracks = await evaluateStore(page, (store) => {
       return store.getState().audioTracks.map((track) => ({
@@ -152,10 +153,15 @@ test.describe("Project Migration", () => {
       137,
     );
 
-    // Continue (last-project pointer) survives the migration, and a second
-    // load is a no-op migration
+    // The last-project pointer survives the migration, and a second load is a
+    // no-op migration
     await page.goto("/");
-    await clickContinue(page);
+    await expect(page.getByTestId(`project-card-${bareId}`)).toHaveAttribute(
+      "aria-current",
+      "true",
+    );
+    await page.getByTestId(`project-card-${bareId}`).click();
+    await waitForEditor(page);
     expect(await evaluateStore(page, (store) => store.getState().tempo)).toBe(
       137,
     );

--- a/e2e/startup-screen.spec.ts
+++ b/e2e/startup-screen.spec.ts
@@ -22,9 +22,6 @@ test.describe("Startup Screen", () => {
     const newProjectButton = page.getByTestId("new-project-button");
     await expect(newProjectButton).toBeVisible();
 
-    // Continue button should NOT be visible (no saved project)
-    await expect(page.getByTestId("continue-button")).not.toBeVisible();
-
     // Click new project
     await newProjectButton.click();
 
@@ -40,7 +37,7 @@ test.describe("Startup Screen", () => {
     expect(tempo).toBe(120);
   });
 
-  test("continue project flow", async ({ page }) => {
+  test("open existing project flow", async ({ page }) => {
     // First, create a project with some data via store
     const newProjectButton = page.getByTestId("new-project-button");
     await newProjectButton.click();
@@ -59,12 +56,9 @@ test.describe("Startup Screen", () => {
 
     await evaluateFlushAutoSave(page);
 
-    // Back on the project list, continue button should now be visible
+    // Open the saved project from the project list
     await page.goto("/");
-
-    const continueButton = page.getByTestId("continue-button");
-    await expect(continueButton).toBeVisible();
-    await continueButton.click();
+    await page.locator('[data-testid^="project-card-"]').click();
 
     // Main UI should be visible with restored state
     await expect(page.getByTestId("transport")).toBeVisible();
@@ -74,34 +68,5 @@ test.describe("Startup Screen", () => {
 
     const tempo = await evaluateStore(page, (store) => store.getState().tempo);
     expect(tempo).toBe(140);
-  });
-
-  test("Space key shortcut", async ({ page }) => {
-    // Without saved project, Space should start new project
-    await expect(page.getByTestId("startup-screen")).toBeVisible();
-    await page.keyboard.press("Space");
-    await expect(page.getByTestId("transport")).toBeVisible();
-
-    // Add a note and reload
-    await evaluateStore(page, (store) => {
-      store.getState().addNote({
-        id: "test-note-enter",
-        pitch: 65,
-        start: 0.5,
-        duration: 1.5,
-        velocity: 90,
-      });
-    });
-    await evaluateFlushAutoSave(page);
-
-    // With saved project, Space should continue
-    await page.goto("/");
-    await expect(page.getByTestId("continue-button")).toBeVisible();
-    await page.keyboard.press("Space");
-    await expect(page.getByTestId("transport")).toBeVisible();
-
-    const notes = await evaluateStore(page, (store) => store.getState().notes);
-    expect(notes).toHaveLength(1);
-    expect(notes[0].pitch).toBe(65);
   });
 });

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,8 +1,6 @@
 import { Editor } from "./components/editor";
 import { ProjectListView } from "./components/project-list-view";
 import { ScoreViewer } from "./components/score-viewer";
-import { useWindowEvent } from "./hooks/use-window-event";
-import { matchKeyboardEvent } from "./lib/keyboard";
 import { getProjectSession } from "./lib/project-session";
 import { projectStorage } from "./lib/project-storage";
 
@@ -57,29 +55,6 @@ function ProjectRoute({ projectId }: { projectId: string }) {
 }
 
 function StartupApp() {
-  // Space to continue/start project
-  useWindowEvent(
-    "keydown",
-    (e) => {
-      const target = e.target as HTMLElement | null;
-      if (
-        target?.tagName === "INPUT" ||
-        target?.tagName === "TEXTAREA" ||
-        target?.isContentEditable
-      ) {
-        return;
-      }
-      if (matchKeyboardEvent(e, "Space")) {
-        e.preventDefault();
-        e.stopPropagation();
-        openProject(
-          projectStorage.getLastProjectId() ?? projectStorage.createNew(),
-        );
-      }
-    },
-    true,
-  );
-
   return (
     <ProjectListView
       onSelectProject={openProject}

--- a/src/components/project-list-view.tsx
+++ b/src/components/project-list-view.tsx
@@ -150,16 +150,6 @@ export function ProjectListView({
 
         <div className="flex flex-col items-center gap-4">
           <div className="flex gap-4">
-            {hasProjects && (
-              <Button
-                data-testid="continue-button"
-                disabled={isLoading}
-                onClick={() => lastProjectId && onSelectProject(lastProjectId)}
-                className="px-6 py-2.5 bg-emerald-600 hover:bg-emerald-500 text-white shadow-lg shadow-emerald-900/30"
-              >
-                Continue
-              </Button>
-            )}
             <Button
               data-testid="new-project-button"
               disabled={isLoading}
@@ -181,13 +171,6 @@ export function ProjectListView({
               {isLoading ? "Importing..." : "Import Project"}
             </Button>
           </div>
-          <p className="text-neutral-600 text-sm">
-            Press{" "}
-            <kbd className="px-2 py-1 bg-neutral-800 text-neutral-400 rounded font-mono text-xs border border-neutral-700">
-              Space
-            </kbd>{" "}
-            to {hasProjects ? "continue" : "start"}
-          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Before project-specific URLs, every reload returned to the startup screen, so Continue and its Space shortcut provided a quick path back into the active project. Reloads now stay on the canonical `/project/:id` route, while the project list already links directly to every project, so those extra entry paths are redundant.

This PR removes the Continue button, global startup Space handler, and shortcut hint. Existing projects continue to open through their project links, and the last-opened project highlight remains.