### PR TITLE
fix: prevent autosave starvation

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -62,7 +62,7 @@ export async function loadAudioFile(
 
 /**
  * Force a pending auto-save to run immediately instead of waiting out the
- * debounce.
+ * throttle.
  */
 export async function evaluateFlushAutoSave(page: Page): Promise<void> {
   await page.waitForFunction(() => window.__e2e !== undefined);

--- a/e2e/persistence.spec.ts
+++ b/e2e/persistence.spec.ts
@@ -39,8 +39,8 @@ test.describe("Project Persistence", () => {
     const note = page.locator("[data-testid^='note-']");
     await expect(note).toHaveCount(1);
 
-    // Wait out the real debounce (50ms via VITE_AUTO_SAVE_DEBOUNCE_MS). This
-    // test intentionally covers the debounced auto-save path end-to-end;
+    // Wait out the real throttle (50ms via VITE_AUTO_SAVE_THROTTLE_MS). This
+    // test intentionally covers the throttled auto-save path end-to-end;
     // other tests use evaluateFlushAutoSave() instead.
     await page.waitForTimeout(100);
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     url: "http://localhost:5183",
     reuseExistingServer: false,
     env: {
-      VITE_AUTO_SAVE_DEBOUNCE_MS: "50",
+      VITE_AUTO_SAVE_THROTTLE_MS: "50",
       ...(process.env.CI ? { VITE_FAKE_BASIC_PITCH: "true" } : {}),
     },
   },

--- a/src/lib/project-session.ts
+++ b/src/lib/project-session.ts
@@ -66,17 +66,24 @@ function openProjectSession(projectId: string): ProjectSession {
   const autoSaveDebounceMs = Number(
     import.meta.env.VITE_AUTO_SAVE_DEBOUNCE_MS ?? 1000,
   );
-  const saveDebouncer = debounce(() => {
-    try {
-      projectStorage.save(
-        projectId,
-        toSavedProject(useProjectStore.getState()),
-      );
-    } catch (e) {
-      console.error("Failed to save project:", e);
-      toast.error("Failed to save project. Changes may be lost.");
-    }
-  }, autoSaveDebounceMs);
+  const autoSaveMaxWaitMs = 10_000;
+  const saveDebouncer = debounce(
+    () => {
+      try {
+        projectStorage.save(
+          projectId,
+          toSavedProject(useProjectStore.getState()),
+        );
+      } catch (e) {
+        console.error("Failed to save project:", e);
+        toast.error("Failed to save project. Changes may be lost.");
+      }
+    },
+    {
+      wait: autoSaveDebounceMs,
+      maxWait: autoSaveMaxWaitMs,
+    },
+  );
   const unsubscribeAutoSave = useProjectStore.subscribe(saveDebouncer.schedule);
   activeSaveDebouncer = saveDebouncer;
 

--- a/src/lib/project-session.ts
+++ b/src/lib/project-session.ts
@@ -1,5 +1,5 @@
 import { toast } from "sonner";
-import { debounce } from "../utils/timing";
+import { throttle } from "../utils/timing";
 import { audioManager, loadAudioFile } from "./audio";
 import { historyStore } from "./history-store";
 import { isShortcutTextInputTarget, matchKeyboardEvent } from "./keyboard";
@@ -62,30 +62,23 @@ function openProjectSession(projectId: string): ProjectSession {
     audioManager.applyState(state, prevState);
   });
 
-  // Auto-save on state changes (debounced)
-  const autoSaveDebounceMs = Number(
-    import.meta.env.VITE_AUTO_SAVE_DEBOUNCE_MS ?? 1000,
+  // Auto-save on state changes (throttled)
+  const autoSaveThrottleMs = Number(
+    import.meta.env.VITE_AUTO_SAVE_THROTTLE_MS ?? 1000,
   );
-  const autoSaveMaxWaitMs = 10_000;
-  const saveDebouncer = debounce(
-    () => {
-      try {
-        projectStorage.save(
-          projectId,
-          toSavedProject(useProjectStore.getState()),
-        );
-      } catch (e) {
-        console.error("Failed to save project:", e);
-        toast.error("Failed to save project. Changes may be lost.");
-      }
-    },
-    {
-      wait: autoSaveDebounceMs,
-      maxWait: autoSaveMaxWaitMs,
-    },
-  );
-  const unsubscribeAutoSave = useProjectStore.subscribe(saveDebouncer.schedule);
-  activeSaveDebouncer = saveDebouncer;
+  const saveThrottle = throttle(() => {
+    try {
+      projectStorage.save(
+        projectId,
+        toSavedProject(useProjectStore.getState()),
+      );
+    } catch (e) {
+      console.error("Failed to save project:", e);
+      toast.error("Failed to save project. Changes may be lost.");
+    }
+  }, autoSaveThrottleMs);
+  const unsubscribeAutoSave = useProjectStore.subscribe(saveThrottle.schedule);
+  activeSaveThrottle = saveThrottle;
 
   // Session lifetime as an AbortController: dispose aborts, which detaches
   // the shortcut listener and stops the background audio attach.
@@ -134,8 +127,8 @@ function openProjectSession(projectId: string): ProjectSession {
       abortController.abort();
       unsubscribeAudioSync();
       unsubscribeAutoSave();
-      saveDebouncer.flush();
-      activeSaveDebouncer = undefined;
+      saveThrottle.flush();
+      activeSaveThrottle = undefined;
       historyStore.clearHistory();
     },
   };
@@ -198,10 +191,10 @@ async function loadStoredTrackAudio(track: AudioTrack) {
   return await loadAudioFile(new File([asset.blob], asset.name));
 }
 
-// Auto-save debouncer of the active session, so e2e tests can force a save
-// instead of waiting out the debounce.
-let activeSaveDebouncer: ReturnType<typeof debounce> | undefined;
+// Auto-save throttle of the active session, so e2e tests can force a save
+// instead of waiting out the throttle.
+let activeSaveThrottle: ReturnType<typeof throttle> | undefined;
 
 export function flushAutoSave() {
-  activeSaveDebouncer?.flush();
+  activeSaveThrottle?.flush();
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,7 +19,7 @@ function main() {
 
   unlockAudioOnFirstGesture();
 
-  // Auto-save is debounced; flush pending changes when leaving the page
+  // Auto-save is throttled; flush pending changes when leaving the page
   // (navigation away or tab close).
   window.addEventListener("pagehide", () => flushAutoSave());
 

--- a/src/utils/timing.test.ts
+++ b/src/utils/timing.test.ts
@@ -1,59 +1,68 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { debounce } from "./timing";
+import { throttle } from "./timing";
 
 afterEach(() => {
   vi.useRealTimers();
 });
 
-describe("debounce", () => {
-  it("runs after the trailing wait from the latest schedule", () => {
+describe("throttle", () => {
+  it("runs on the leading edge and once more for pending work", () => {
     vi.useFakeTimers();
     const fn = vi.fn();
-    const debouncer = debounce(fn, { wait: 100, maxWait: 1_000 });
+    const throttler = throttle(fn, 100);
 
-    debouncer.schedule();
-    vi.advanceTimersByTime(50);
-    debouncer.schedule();
-    vi.advanceTimersByTime(99);
-
-    expect(fn).not.toHaveBeenCalled();
-
-    vi.advanceTimersByTime(1);
-
+    throttler.schedule();
     expect(fn).toHaveBeenCalledOnce();
+
+    vi.advanceTimersByTime(50);
+    throttler.schedule();
+    throttler.schedule();
+    expect(fn).toHaveBeenCalledOnce();
+
+    vi.advanceTimersByTime(50);
+
+    expect(fn).toHaveBeenCalledTimes(2);
   });
 
-  it("runs at the maximum wait while schedules continue", () => {
+  it("runs once per interval while schedules continue", () => {
     vi.useFakeTimers();
     const fn = vi.fn();
-    const debouncer = debounce(fn, { wait: 100, maxWait: 250 });
+    const throttler = throttle(fn, 100);
 
-    debouncer.schedule();
-    vi.advanceTimersByTime(90);
-    debouncer.schedule();
-    vi.advanceTimersByTime(90);
-    debouncer.schedule();
-    vi.advanceTimersByTime(69);
+    throttler.schedule();
+    for (let elapsed = 10; elapsed < 300; elapsed += 10) {
+      vi.advanceTimersByTime(10);
+      throttler.schedule();
+    }
 
-    expect(fn).not.toHaveBeenCalled();
+    expect(fn).toHaveBeenCalledTimes(3);
 
-    vi.advanceTimersByTime(1);
+    vi.advanceTimersByTime(10);
+    expect(fn).toHaveBeenCalledTimes(4);
+  });
 
-    expect(fn).toHaveBeenCalledOnce();
-    vi.advanceTimersByTime(100);
+  it("does not duplicate a leading call when no work is pending", () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const throttler = throttle(fn, 100);
+
+    throttler.schedule();
+    vi.runAllTimers();
+
     expect(fn).toHaveBeenCalledOnce();
   });
 
   it("flushes pending work immediately", () => {
     vi.useFakeTimers();
     const fn = vi.fn();
-    const debouncer = debounce(fn, { wait: 100, maxWait: 250 });
+    const throttler = throttle(fn, 100);
 
-    debouncer.schedule();
-    debouncer.flush();
+    throttler.schedule();
+    throttler.schedule();
+    throttler.flush();
 
-    expect(fn).toHaveBeenCalledOnce();
+    expect(fn).toHaveBeenCalledTimes(2);
     vi.runAllTimers();
-    expect(fn).toHaveBeenCalledOnce();
+    expect(fn).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/utils/timing.test.ts
+++ b/src/utils/timing.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { debounce } from "./timing";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("debounce", () => {
+  it("runs after the trailing wait from the latest schedule", () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const debouncer = debounce(fn, { wait: 100, maxWait: 1_000 });
+
+    debouncer.schedule();
+    vi.advanceTimersByTime(50);
+    debouncer.schedule();
+    vi.advanceTimersByTime(99);
+
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it("runs at the maximum wait while schedules continue", () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const debouncer = debounce(fn, { wait: 100, maxWait: 250 });
+
+    debouncer.schedule();
+    vi.advanceTimersByTime(90);
+    debouncer.schedule();
+    vi.advanceTimersByTime(90);
+    debouncer.schedule();
+    vi.advanceTimersByTime(69);
+
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+
+    expect(fn).toHaveBeenCalledOnce();
+    vi.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it("flushes pending work immediately", () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const debouncer = debounce(fn, { wait: 100, maxWait: 250 });
+
+    debouncer.schedule();
+    debouncer.flush();
+
+    expect(fn).toHaveBeenCalledOnce();
+    vi.runAllTimers();
+    expect(fn).toHaveBeenCalledOnce();
+  });
+});

--- a/src/utils/timing.ts
+++ b/src/utils/timing.ts
@@ -1,19 +1,35 @@
 // Copied from ../acpella/src/utils/timing.ts.
-export function debounce(fn: () => void, ms: number) {
+export function debounce(
+  fn: () => void,
+  { wait, maxWait }: { wait: number; maxWait?: number },
+) {
   let timeout: ReturnType<typeof setTimeout> | undefined;
+  let maxTimeout: ReturnType<typeof setTimeout> | undefined;
 
   function schedule() {
-    cancel();
+    if (typeof timeout !== "undefined") {
+      clearTimeout(timeout);
+    }
     timeout = setTimeout(() => {
-      timeout = undefined;
+      cancel();
       fn();
-    }, ms);
+    }, wait);
+    if (typeof maxWait !== "undefined") {
+      maxTimeout ??= setTimeout(() => {
+        cancel();
+        fn();
+      }, maxWait);
+    }
   }
 
   function cancel() {
     if (typeof timeout !== "undefined") {
       clearTimeout(timeout);
       timeout = undefined;
+    }
+    if (typeof maxTimeout !== "undefined") {
+      clearTimeout(maxTimeout);
+      maxTimeout = undefined;
     }
   }
 

--- a/src/utils/timing.ts
+++ b/src/utils/timing.ts
@@ -1,24 +1,23 @@
 // Copied from ../acpella/src/utils/timing.ts.
-export function debounce(
-  fn: () => void,
-  { wait, maxWait }: { wait: number; maxWait?: number },
-) {
+export function throttle(fn: () => void, ms: number) {
   let timeout: ReturnType<typeof setTimeout> | undefined;
-  let maxTimeout: ReturnType<typeof setTimeout> | undefined;
+  let pending = false;
 
   function schedule() {
-    if (typeof timeout !== "undefined") {
-      clearTimeout(timeout);
-    }
-    timeout = setTimeout(() => {
-      cancel();
+    if (typeof timeout === "undefined") {
+      timeout = setTimeout(runTrailing, ms);
       fn();
-    }, wait);
-    if (typeof maxWait !== "undefined") {
-      maxTimeout ??= setTimeout(() => {
-        cancel();
-        fn();
-      }, maxWait);
+    } else {
+      pending = true;
+    }
+  }
+
+  function runTrailing() {
+    timeout = undefined;
+    if (pending) {
+      pending = false;
+      timeout = setTimeout(runTrailing, ms);
+      fn();
     }
   }
 
@@ -27,14 +26,11 @@ export function debounce(
       clearTimeout(timeout);
       timeout = undefined;
     }
-    if (typeof maxTimeout !== "undefined") {
-      clearTimeout(maxTimeout);
-      maxTimeout = undefined;
-    }
+    pending = false;
   }
 
   function flush() {
-    const shouldRun = typeof timeout !== "undefined";
+    const shouldRun = pending;
     cancel();
     if (shouldRun) {
       fn();


### PR DESCRIPTION
Continuous edits currently keep resetting the autosave debounce, so project state may never reach storage.

This PR replaces the debounce with a one-second leading-and-trailing throttle. The first change is persisted immediately, continuous edits are saved at most once per second, and the latest pending state is written on the trailing edge or by an explicit flush.