### PR TITLE
feat: improve key signature selector

### DIFF
--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -13,7 +13,6 @@ import { buildExportFileName, downloadBlob } from "../lib/export-utils";
 import { exportMidi } from "../lib/midi-export";
 import { importMidiNotes, type MidiImportOptions } from "../lib/midi-import";
 import { exportMusicXml } from "../lib/musicxml-export";
-import { KEY_SIGNATURES } from "../lib/pitch-spelling";
 import { exportProjectFile } from "../lib/project-file";
 import { projectStorage } from "../lib/project-storage";
 import {
@@ -29,6 +28,51 @@ import {
 } from "../lib/tab-annotation";
 import { FileDropInput } from "./file-drop-input";
 import { Button } from "./ui/button";
+
+const KEY_SIGNATURE_OPTION_GROUPS = [
+  {
+    label: "Major",
+    mode: "major",
+    options: [
+      { fifths: 0, label: "C major" },
+      { fifths: 1, label: "G major" },
+      { fifths: 2, label: "D major" },
+      { fifths: 3, label: "A major" },
+      { fifths: 4, label: "E major" },
+      { fifths: 5, label: "B major" },
+      { fifths: 6, label: "F♯ major" },
+      { fifths: 7, label: "C♯ major" },
+      { fifths: -1, label: "F major" },
+      { fifths: -2, label: "B♭ major" },
+      { fifths: -3, label: "E♭ major" },
+      { fifths: -4, label: "A♭ major" },
+      { fifths: -5, label: "D♭ major" },
+      { fifths: -6, label: "G♭ major" },
+      { fifths: -7, label: "C♭ major" },
+    ],
+  },
+  {
+    label: "Minor",
+    mode: "minor",
+    options: [
+      { fifths: 0, label: "A minor" },
+      { fifths: 1, label: "E minor" },
+      { fifths: 2, label: "B minor" },
+      { fifths: 3, label: "F♯ minor" },
+      { fifths: 4, label: "C♯ minor" },
+      { fifths: 5, label: "G♯ minor" },
+      { fifths: 6, label: "D♯ minor" },
+      { fifths: 7, label: "A♯ minor" },
+      { fifths: -1, label: "D minor" },
+      { fifths: -2, label: "G minor" },
+      { fifths: -3, label: "C minor" },
+      { fifths: -4, label: "F minor" },
+      { fifths: -5, label: "B♭ minor" },
+      { fifths: -6, label: "E♭ minor" },
+      { fifths: -7, label: "A♭ minor" },
+    ],
+  },
+] as const;
 
 type SettingsProps = {
   // Project section
@@ -305,13 +349,17 @@ export function Settings({
               }}
               className="h-8 rounded border border-neutral-600 bg-neutral-900 px-2 text-sm text-neutral-100 focus:border-neutral-500 focus:outline-none"
             >
-              {KEY_SIGNATURES.map((key) => (
-                <option
-                  key={`${key.fifths}:${key.mode}`}
-                  value={`${key.fifths}:${key.mode}`}
-                >
-                  {key.label}
-                </option>
+              {KEY_SIGNATURE_OPTION_GROUPS.map((group) => (
+                <optgroup key={group.mode} label={group.label}>
+                  {group.options.map((key) => (
+                    <option
+                      key={`${key.fifths}:${group.mode}`}
+                      value={`${key.fifths}:${group.mode}`}
+                    >
+                      {key.label}
+                    </option>
+                  ))}
+                </optgroup>
               ))}
             </select>
           </div>

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -13,6 +13,7 @@ import { buildExportFileName, downloadBlob } from "../lib/export-utils";
 import { exportMidi } from "../lib/midi-export";
 import { importMidiNotes, type MidiImportOptions } from "../lib/midi-import";
 import { exportMusicXml } from "../lib/musicxml-export";
+import { KEY_SIGNATURE_OPTION_GROUPS } from "../lib/pitch-spelling";
 import { exportProjectFile } from "../lib/project-file";
 import { projectStorage } from "../lib/project-storage";
 import {
@@ -28,51 +29,6 @@ import {
 } from "../lib/tab-annotation";
 import { FileDropInput } from "./file-drop-input";
 import { Button } from "./ui/button";
-
-const KEY_SIGNATURE_OPTION_GROUPS = [
-  {
-    label: "Major",
-    mode: "major",
-    options: [
-      { fifths: 0, label: "C major" },
-      { fifths: 1, label: "G major" },
-      { fifths: 2, label: "D major" },
-      { fifths: 3, label: "A major" },
-      { fifths: 4, label: "E major" },
-      { fifths: 5, label: "B major" },
-      { fifths: 6, label: "F♯ major" },
-      { fifths: 7, label: "C♯ major" },
-      { fifths: -1, label: "F major" },
-      { fifths: -2, label: "B♭ major" },
-      { fifths: -3, label: "E♭ major" },
-      { fifths: -4, label: "A♭ major" },
-      { fifths: -5, label: "D♭ major" },
-      { fifths: -6, label: "G♭ major" },
-      { fifths: -7, label: "C♭ major" },
-    ],
-  },
-  {
-    label: "Minor",
-    mode: "minor",
-    options: [
-      { fifths: 0, label: "A minor" },
-      { fifths: 1, label: "E minor" },
-      { fifths: 2, label: "B minor" },
-      { fifths: 3, label: "F♯ minor" },
-      { fifths: 4, label: "C♯ minor" },
-      { fifths: 5, label: "G♯ minor" },
-      { fifths: 6, label: "D♯ minor" },
-      { fifths: 7, label: "A♯ minor" },
-      { fifths: -1, label: "D minor" },
-      { fifths: -2, label: "G minor" },
-      { fifths: -3, label: "C minor" },
-      { fifths: -4, label: "F minor" },
-      { fifths: -5, label: "B♭ minor" },
-      { fifths: -6, label: "E♭ minor" },
-      { fifths: -7, label: "A♭ minor" },
-    ],
-  },
-] as const;
 
 type SettingsProps = {
   // Project section

--- a/src/lib/pitch-spelling.ts
+++ b/src/lib/pitch-spelling.ts
@@ -17,6 +17,51 @@ type SpelledPitchClass = {
   alter: number;
 };
 
+export const KEY_SIGNATURE_OPTION_GROUPS = [
+  {
+    label: "Major",
+    mode: "major",
+    options: [
+      { fifths: 0, label: "C major" },
+      { fifths: 1, label: "G major" },
+      { fifths: 2, label: "D major" },
+      { fifths: 3, label: "A major" },
+      { fifths: 4, label: "E major" },
+      { fifths: 5, label: "B major" },
+      { fifths: 6, label: "F♯ major" },
+      { fifths: 7, label: "C♯ major" },
+      { fifths: -1, label: "F major" },
+      { fifths: -2, label: "B♭ major" },
+      { fifths: -3, label: "E♭ major" },
+      { fifths: -4, label: "A♭ major" },
+      { fifths: -5, label: "D♭ major" },
+      { fifths: -6, label: "G♭ major" },
+      { fifths: -7, label: "C♭ major" },
+    ],
+  },
+  {
+    label: "Minor",
+    mode: "minor",
+    options: [
+      { fifths: 0, label: "A minor" },
+      { fifths: 1, label: "E minor" },
+      { fifths: 2, label: "B minor" },
+      { fifths: 3, label: "F♯ minor" },
+      { fifths: 4, label: "C♯ minor" },
+      { fifths: 5, label: "G♯ minor" },
+      { fifths: 6, label: "D♯ minor" },
+      { fifths: 7, label: "A♯ minor" },
+      { fifths: -1, label: "D minor" },
+      { fifths: -2, label: "G minor" },
+      { fifths: -3, label: "C minor" },
+      { fifths: -4, label: "F minor" },
+      { fifths: -5, label: "B♭ minor" },
+      { fifths: -6, label: "E♭ minor" },
+      { fifths: -7, label: "A♭ minor" },
+    ],
+  },
+] as const;
+
 const NATURAL_PITCH_CLASS_BY_LETTER: Record<NoteLetter, number> = {
   C: 0,
   D: 2,

--- a/src/lib/pitch-spelling.ts
+++ b/src/lib/pitch-spelling.ts
@@ -17,39 +17,6 @@ type SpelledPitchClass = {
   alter: number;
 };
 
-export const KEY_SIGNATURES: (KeySignature & { label: string })[] = [
-  { fifths: -7, mode: "major", label: "C-flat major" },
-  { fifths: -6, mode: "major", label: "G-flat major" },
-  { fifths: -5, mode: "major", label: "D-flat major" },
-  { fifths: -4, mode: "major", label: "A-flat major" },
-  { fifths: -3, mode: "major", label: "E-flat major" },
-  { fifths: -2, mode: "major", label: "B-flat major" },
-  { fifths: -1, mode: "major", label: "F major" },
-  { fifths: 0, mode: "major", label: "C major" },
-  { fifths: 1, mode: "major", label: "G major" },
-  { fifths: 2, mode: "major", label: "D major" },
-  { fifths: 3, mode: "major", label: "A major" },
-  { fifths: 4, mode: "major", label: "E major" },
-  { fifths: 5, mode: "major", label: "B major" },
-  { fifths: 6, mode: "major", label: "F-sharp major" },
-  { fifths: 7, mode: "major", label: "C-sharp major" },
-  { fifths: -7, mode: "minor", label: "A-flat minor" },
-  { fifths: -6, mode: "minor", label: "E-flat minor" },
-  { fifths: -5, mode: "minor", label: "B-flat minor" },
-  { fifths: -4, mode: "minor", label: "F minor" },
-  { fifths: -3, mode: "minor", label: "C minor" },
-  { fifths: -2, mode: "minor", label: "G minor" },
-  { fifths: -1, mode: "minor", label: "D minor" },
-  { fifths: 0, mode: "minor", label: "A minor" },
-  { fifths: 1, mode: "minor", label: "E minor" },
-  { fifths: 2, mode: "minor", label: "B minor" },
-  { fifths: 3, mode: "minor", label: "F-sharp minor" },
-  { fifths: 4, mode: "minor", label: "C-sharp minor" },
-  { fifths: 5, mode: "minor", label: "G-sharp minor" },
-  { fifths: 6, mode: "minor", label: "D-sharp minor" },
-  { fifths: 7, mode: "minor", label: "A-sharp minor" },
-];
-
 const NATURAL_PITCH_CLASS_BY_LETTER: Record<NoteLetter, number> = {
   C: 0,
   D: 2,


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/toy-midi/issues/238

This PR groups key-signature options into Major and Minor, orders each group from the natural key through sharps and then flats, and uses conventional musical accidental symbols in the labels.
