### PR TITLE
refactor: centralize application routes

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,25 +1,30 @@
 import { Editor } from "./components/editor";
 import { ProjectListView } from "./components/project-list-view";
 import { ScoreViewer } from "./components/score-viewer";
+import { appPath, parseAppRoute } from "./lib/app-route";
 import { getProjectScoreSource } from "./lib/project-score";
 import { getProjectSession } from "./lib/project-session";
 import { projectStorage } from "./lib/project-storage";
 
 export function App() {
-  if (window.location.pathname === "/score-viewer") {
-    return <ScoreViewer />;
+  const route = parseAppRoute(window.location.pathname);
+
+  switch (route.type) {
+    case "projects": {
+      return <StartupApp />;
+    }
+    case "score-viewer": {
+      return <ScoreViewer />;
+    }
+    case "project": {
+      return <ProjectRoute projectId={route.projectId} />;
+    }
+    case "project-score": {
+      return <ProjectScoreRoute projectId={route.projectId} />;
+    }
   }
-  const scoreMatch = window.location.pathname.match(
-    /^\/project\/([^/]+)\/score$/,
-  );
-  if (scoreMatch) {
-    return <ProjectScoreRoute projectId={scoreMatch[1]} />;
-  }
-  const match = window.location.pathname.match(/^\/project\/([^/]+)$/);
-  if (match) {
-    return <ProjectRoute projectId={match[1]} />;
-  }
-  return <StartupApp />;
+
+  route satisfies never;
 }
 
 function ProjectScoreRoute({ projectId }: { projectId: string }) {
@@ -29,7 +34,7 @@ function ProjectScoreRoute({ projectId }: { projectId: string }) {
     return (
       <RouteError
         error={score.error}
-        backHref={`/project/${projectId}`}
+        backHref={appPath.project({ projectId })}
         backLabel="Back to project"
       />
     );
@@ -41,7 +46,7 @@ function ProjectScoreRoute({ projectId }: { projectId: string }) {
 // All project opens are full-page navigation; ProjectRoute is the only way
 // into the editor.
 function openProject(projectId: string) {
-  window.location.href = `/project/${projectId}`;
+  window.location.href = appPath.project({ projectId });
 }
 
 // Deep-link entry: load the project named by the URL directly, no startup
@@ -62,7 +67,7 @@ function ProjectRoute({ projectId }: { projectId: string }) {
     return (
       <RouteError
         error={session.error}
-        backHref="/"
+        backHref={appPath.projects}
         backLabel="Back to projects"
       />
     );

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -8,6 +8,7 @@ import {
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useWindowEvent } from "../hooks/use-window-event";
+import { appPath } from "../lib/app-route";
 import { isShortcutTextInputTarget, matchKeyboardEvent } from "../lib/keyboard";
 import { flushAutoSave } from "../lib/project-session";
 import { projectStorage } from "../lib/project-storage";
@@ -112,7 +113,10 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 <DropdownMenuItem asChild>
-                  <a href="/" data-testid="all-projects-menu-item">
+                  <a
+                    href={appPath.projects}
+                    data-testid="all-projects-menu-item"
+                  >
                     <FolderIcon />
                     All Projects
                   </a>
@@ -166,7 +170,7 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
       >
         <Settings
           projectName={projectName}
-          projectScoreHref={`/project/${projectId}/score`}
+          projectScoreHref={appPath.projectScore({ projectId })}
           onProjectNameChange={(name) => {
             if (name && name !== projectName) {
               projectStorage.updateMetadata(projectId, { name });

--- a/src/components/project-list-view.tsx
+++ b/src/components/project-list-view.tsx
@@ -3,6 +3,7 @@ import { Github, Music2Icon, Pencil, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useDraftTextInput } from "../hooks/use-draft-text-input";
+import { appPath } from "../lib/app-route";
 import { matchKeyboardEvent } from "../lib/keyboard";
 import { parseProjectFile } from "../lib/project-file";
 import { type ProjectMetadata, projectStorage } from "../lib/project-storage";
@@ -106,7 +107,7 @@ export function ProjectListView({
           </div>
           <nav className="flex items-center gap-4 text-sm text-neutral-500">
             <a
-              href="/score-viewer"
+              href={appPath.scoreViewer}
               data-testid="score-viewer-link"
               className="inline-flex items-center gap-1.5 hover:text-emerald-400 transition-colors"
             >
@@ -238,7 +239,10 @@ function ProjectListItem({
         />
       ) : (
         <div className="flex flex-1 items-center justify-between">
-          <a href={`/project/${project.id}`} className="flex-1 text-left">
+          <a
+            href={appPath.project({ projectId: project.id })}
+            className="flex-1 text-left"
+          >
             <div className="font-medium text-neutral-100">{project.name}</div>
             <div className="mt-1 text-xs text-neutral-500">
               Last edited{" "}

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -12,6 +12,7 @@ import {
 import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { useDraftInput } from "../hooks/use-draft-input";
 import { useWindowEvent } from "../hooks/use-window-event";
+import { appPath } from "../lib/app-route";
 import { isShortcutTextInputTarget, matchKeyboardEvent } from "../lib/keyboard";
 import { SCORE_VIEWER_SAMPLES } from "../lib/score-viewer-samples";
 import { FileDropInput } from "./file-drop-input";
@@ -255,7 +256,7 @@ export function ScoreViewer({
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuItem asChild>
-              <a href="/" data-testid="all-projects-menu-item">
+              <a href={appPath.projects} data-testid="all-projects-menu-item">
                 <FolderIcon />
                 All Projects
               </a>

--- a/src/lib/app-route.test.ts
+++ b/src/lib/app-route.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { appPath, parseAppRoute } from "./app-route";
+
+describe("appPath", () => {
+  it("builds application paths", () => {
+    expect(appPath.projects).toBe("/");
+    expect(appPath.scoreViewer).toBe("/score-viewer");
+    expect(appPath.project({ projectId: "project-id" })).toBe(
+      "/project/project-id",
+    );
+    expect(appPath.projectScore({ projectId: "project-id" })).toBe(
+      "/project/project-id/score",
+    );
+  });
+});
+
+describe("parseAppRoute", () => {
+  it.each([
+    ["/", { type: "projects" }],
+    ["/score-viewer", { type: "score-viewer" }],
+    ["/project/project-id", { type: "project", projectId: "project-id" }],
+    [
+      "/project/project-id/score",
+      { type: "project-score", projectId: "project-id" },
+    ],
+  ])("parses %s", (pathname, expected) => {
+    expect(parseAppRoute(pathname)).toEqual(expected);
+  });
+
+  it.each([
+    "/unknown",
+    "/score-viewer/",
+    "/project/",
+    "/project/project-id/",
+    "/project/project-id/score/extra",
+  ])("falls back to projects for %s", (pathname) => {
+    expect(parseAppRoute(pathname)).toEqual({ type: "projects" });
+  });
+});

--- a/src/lib/app-route.ts
+++ b/src/lib/app-route.ts
@@ -1,0 +1,31 @@
+export const appPath = {
+  projects: "/",
+  scoreViewer: "/score-viewer",
+  project: ({ projectId }: { projectId: string }) => `/project/${projectId}`,
+  projectScore: ({ projectId }: { projectId: string }) =>
+    `/project/${projectId}/score`,
+};
+
+export type AppRoute =
+  | { type: "projects" }
+  | { type: "score-viewer" }
+  | { type: "project"; projectId: string }
+  | { type: "project-score"; projectId: string };
+
+export function parseAppRoute(pathname: string): AppRoute {
+  if (pathname === appPath.scoreViewer) {
+    return { type: "score-viewer" };
+  }
+
+  const projectScore = pathname.match(/^\/project\/([^/]+)\/score$/);
+  if (projectScore) {
+    return { type: "project-score", projectId: projectScore[1] };
+  }
+
+  const project = pathname.match(/^\/project\/([^/]+)$/);
+  if (project) {
+    return { type: "project", projectId: project[1] };
+  }
+
+  return { type: "projects" };
+}


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/toy-midi/issues/237

Application URL shapes were duplicated across root parsing, links, and imperative navigation.

This PR adds a small application-specific route module with path builders and a discriminated parser, then renders routes through an exhaustive switch in `App` and uses the builders throughout production navigation. Focused unit coverage verifies the public path shapes and fallback parsing behavior, while E2E URLs remain literal so they continue to test the public contract independently.