### PR TITLE
refactor: centralize application routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slider": "^1.3.6",
     "@remix-run/fetch-router": "^0.20.1",
+    "@remix-run/route-pattern": "^0.23.0",
     "@spotify/basic-pitch": "^1.0.1",
     "@tanstack/react-query": "^5.90.16",
     "@tensorflow/tfjs": "^3.21.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slider": "^1.3.6",
+    "@remix-run/fetch-router": "^0.20.1",
     "@spotify/basic-pitch": "^1.0.1",
     "@tanstack/react-query": "^5.90.16",
     "@tensorflow/tfjs": "^3.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@remix-run/fetch-router':
         specifier: ^0.20.1
         version: 0.20.1
+      '@remix-run/route-pattern':
+        specifier: ^0.23.0
+        version: 0.23.0
       '@spotify/basic-pitch':
         specifier: ^1.0.1
         version: 1.0.1(seedrandom@3.0.5)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@radix-ui/react-slider':
         specifier: ^1.3.6
         version: 1.3.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@remix-run/fetch-router':
+        specifier: ^0.20.1
+        version: 0.20.1
       '@spotify/basic-pitch':
         specifier: ^1.0.1
         version: 1.0.1(seedrandom@3.0.5)
@@ -1006,6 +1009,12 @@ packages:
 
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+
+  '@remix-run/fetch-router@0.20.1':
+    resolution: {integrity: sha512-vxlIu4LHY5KyqOdlXFjJeUefUJxgc7499/cSsBl2bzhQnU5DayPHN/dklBOiG+U7GIYQMmObAinmubkwzaXyuw==}
+
+  '@remix-run/route-pattern@0.23.0':
+    resolution: {integrity: sha512-8eZfG9owfdvC1OqWemjyIqbFTjWbKTW8RrcbppXrnv1GHMIpFOQx9Ly6F1OXNM03aK1c923JypacoRjamyfVEw==}
 
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
@@ -3268,6 +3277,12 @@ snapshots:
       '@types/react': 19.2.7
 
   '@radix-ui/rect@1.1.1': {}
+
+  '@remix-run/fetch-router@0.20.1':
+    dependencies:
+      '@remix-run/route-pattern': 0.23.0
+
+  '@remix-run/route-pattern@0.23.0': {}
 
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,6 +4,7 @@ import { ScoreViewer } from "./components/score-viewer";
 import { getProjectScoreSource } from "./lib/project-score";
 import { getProjectSession } from "./lib/project-session";
 import { projectStorage } from "./lib/project-storage";
+import { routes } from "./lib/routes";
 
 export function App() {
   if (window.location.pathname === "/score-viewer") {
@@ -29,7 +30,7 @@ function ProjectScoreRoute({ projectId }: { projectId: string }) {
     return (
       <RouteError
         error={score.error}
-        backHref={`/project/${projectId}`}
+        backHref={routes.project.href({ projectId })}
         backLabel="Back to project"
       />
     );
@@ -41,7 +42,7 @@ function ProjectScoreRoute({ projectId }: { projectId: string }) {
 // All project opens are full-page navigation; ProjectRoute is the only way
 // into the editor.
 function openProject(projectId: string) {
-  window.location.href = `/project/${projectId}`;
+  window.location.href = routes.project.href({ projectId });
 }
 
 // Deep-link entry: load the project named by the URL directly, no startup
@@ -62,7 +63,7 @@ function ProjectRoute({ projectId }: { projectId: string }) {
     return (
       <RouteError
         error={session.error}
-        backHref="/"
+        backHref={routes.home.href()}
         backLabel="Back to projects"
       />
     );

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,23 +4,26 @@ import { ScoreViewer } from "./components/score-viewer";
 import { getProjectScoreSource } from "./lib/project-score";
 import { getProjectSession } from "./lib/project-session";
 import { projectStorage } from "./lib/project-storage";
-import { routes } from "./lib/routes";
+import { routeMatcher, routes } from "./lib/routes";
 
 export function App() {
-  if (window.location.pathname === "/score-viewer") {
-    return <ScoreViewer />;
+  const match = routeMatcher.match(window.location.href);
+
+  switch (match?.data) {
+    case "scoreViewer": {
+      return <ScoreViewer />;
+    }
+    case "projectScore": {
+      return <ProjectScoreRoute projectId={match.params.projectId!} />;
+    }
+    case "project": {
+      return <ProjectRoute projectId={match.params.projectId!} />;
+    }
+    case "home":
+    default: {
+      return <StartupApp />;
+    }
   }
-  const scoreMatch = window.location.pathname.match(
-    /^\/project\/([^/]+)\/score$/,
-  );
-  if (scoreMatch) {
-    return <ProjectScoreRoute projectId={scoreMatch[1]} />;
-  }
-  const match = window.location.pathname.match(/^\/project\/([^/]+)$/);
-  if (match) {
-    return <ProjectRoute projectId={match[1]} />;
-  }
-  return <StartupApp />;
 }
 
 function ProjectScoreRoute({ projectId }: { projectId: string }) {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,10 +4,10 @@ import { ScoreViewer } from "./components/score-viewer";
 import { getProjectScoreSource } from "./lib/project-score";
 import { getProjectSession } from "./lib/project-session";
 import { projectStorage } from "./lib/project-storage";
-import { routeMatcher, routes } from "./lib/routes";
+import { matchRoute, routes } from "./lib/routes";
 
 export function App() {
-  const match = routeMatcher.match(window.location.href);
+  const match = matchRoute(window.location.href);
 
   switch (match?.data) {
     case "scoreViewer": {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -14,10 +14,10 @@ export function App() {
       return <ScoreViewer />;
     }
     case "projectScore": {
-      return <ProjectScoreRoute projectId={match.params.projectId!} />;
+      return <ProjectScoreRoute projectId={match.params.projectId} />;
     }
     case "project": {
-      return <ProjectRoute projectId={match.params.projectId!} />;
+      return <ProjectRoute projectId={match.params.projectId} />;
     }
     case "home":
     default: {

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -12,6 +12,7 @@ import { isShortcutTextInputTarget, matchKeyboardEvent } from "../lib/keyboard";
 import { flushAutoSave } from "../lib/project-session";
 import { projectStorage } from "../lib/project-storage";
 import { useProjectStore } from "../lib/project-store";
+import { routes } from "../lib/routes";
 import { AudioToMidi } from "./audio-to-midi";
 import { HelpOverlay } from "./help-overlay";
 import { Mixer } from "./mixer";
@@ -112,7 +113,10 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 <DropdownMenuItem asChild>
-                  <a href="/" data-testid="all-projects-menu-item">
+                  <a
+                    href={routes.home.href()}
+                    data-testid="all-projects-menu-item"
+                  >
                     <FolderIcon />
                     All Projects
                   </a>
@@ -166,7 +170,7 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
       >
         <Settings
           projectName={projectName}
-          projectScoreHref={`/project/${projectId}/score`}
+          projectScoreHref={routes.projectScore.href({ projectId })}
           onProjectNameChange={(name) => {
             if (name && name !== projectName) {
               projectStorage.updateMetadata(projectId, { name });

--- a/src/components/project-list-view.tsx
+++ b/src/components/project-list-view.tsx
@@ -6,6 +6,7 @@ import { useDraftTextInput } from "../hooks/use-draft-text-input";
 import { matchKeyboardEvent } from "../lib/keyboard";
 import { parseProjectFile } from "../lib/project-file";
 import { type ProjectMetadata, projectStorage } from "../lib/project-storage";
+import { routes } from "../lib/routes";
 import { Button } from "./ui/button";
 
 type ProjectListViewProps = {
@@ -106,7 +107,7 @@ export function ProjectListView({
           </div>
           <nav className="flex items-center gap-4 text-sm text-neutral-500">
             <a
-              href="/score-viewer"
+              href={routes.scoreViewer.href()}
               data-testid="score-viewer-link"
               className="inline-flex items-center gap-1.5 hover:text-emerald-400 transition-colors"
             >
@@ -238,7 +239,10 @@ function ProjectListItem({
         />
       ) : (
         <div className="flex flex-1 items-center justify-between">
-          <a href={`/project/${project.id}`} className="flex-1 text-left">
+          <a
+            href={routes.project.href({ projectId: project.id })}
+            className="flex-1 text-left"
+          >
             <div className="font-medium text-neutral-100">{project.name}</div>
             <div className="mt-1 text-xs text-neutral-500">
               Last edited{" "}

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -13,6 +13,7 @@ import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { useDraftInput } from "../hooks/use-draft-input";
 import { useWindowEvent } from "../hooks/use-window-event";
 import { isShortcutTextInputTarget, matchKeyboardEvent } from "../lib/keyboard";
+import { routes } from "../lib/routes";
 import { SCORE_VIEWER_SAMPLES } from "../lib/score-viewer-samples";
 import { FileDropInput } from "./file-drop-input";
 import {
@@ -255,7 +256,7 @@ export function ScoreViewer({
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuItem asChild>
-              <a href="/" data-testid="all-projects-menu-item">
+              <a href={routes.home.href()} data-testid="all-projects-menu-item">
                 <FolderIcon />
                 All Projects
               </a>

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,5 +1,5 @@
-import { route } from "@remix-run/fetch-router/routes";
-import { createMultiMatcher } from "@remix-run/route-pattern/match";
+import { type Route, route } from "@remix-run/fetch-router/routes";
+import { createMultiMatcher, type Match } from "@remix-run/route-pattern/match";
 
 export const routes = route({
   home: "/",
@@ -8,8 +8,24 @@ export const routes = route({
   projectScore: "/project/:projectId/score",
 });
 
-export const routeMatcher = createMultiMatcher<keyof typeof routes>();
+type RouteName = keyof typeof routes;
+type RouteMatch = {
+  [name in RouteName]: (typeof routes)[name] extends Route<
+    infer _method,
+    infer pattern
+  >
+    ? Match<pattern, name>
+    : never;
+}[RouteName];
 
-for (const [name, route] of Object.entries(routes)) {
-  routeMatcher.add(route.pattern, name as any);
+const matcher = createMultiMatcher<RouteName>();
+
+for (const name of Object.keys(routes) as RouteName[]) {
+  matcher.add(routes[name].pattern, name);
 }
+
+export const routeMatcher = {
+  match(url: string | URL) {
+    return matcher.match(url) as RouteMatch | null;
+  },
+};

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -24,10 +24,8 @@ for (const name of Object.keys(routes) as RouteName[]) {
   matcher.add(routes[name].pattern, name);
 }
 
-export const routeMatcher = {
-  match(url: string | URL) {
-    // MultiMatcher tracks pattern and data as independent unions. These entries
-    // are registered together above, so restore their correlation for callers.
-    return matcher.match(url) as RouteMatch | null;
-  },
-};
+export function matchRoute(url: string | URL) {
+  // MultiMatcher tracks pattern and data as independent unions. These entries
+  // are registered together above, so restore their correlation for callers.
+  return matcher.match(url) as RouteMatch | null;
+}

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,4 +1,5 @@
 import { route } from "@remix-run/fetch-router/routes";
+import { createMultiMatcher } from "@remix-run/route-pattern/match";
 
 export const routes = route({
   home: "/",
@@ -6,3 +7,9 @@ export const routes = route({
   project: "/project/:projectId",
   projectScore: "/project/:projectId/score",
 });
+
+export const routeMatcher = createMultiMatcher<keyof typeof routes>();
+
+for (const [name, route] of Object.entries(routes)) {
+  routeMatcher.add(route.pattern, name as any);
+}

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,0 +1,8 @@
+import { route } from "@remix-run/fetch-router/routes";
+
+export const routes = route({
+  home: "/",
+  scoreViewer: "/score-viewer",
+  project: "/project/:projectId",
+  projectScore: "/project/:projectId/score",
+});

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -12,6 +12,7 @@ export const routes = route({
 });
 
 type RouteName = keyof typeof routes;
+
 type RouteMatch = {
   [name in RouteName]: (typeof routes)[name] extends Route<
     infer _method,

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,6 +1,9 @@
 import { type Route, route } from "@remix-run/fetch-router/routes";
 import { createMultiMatcher, type Match } from "@remix-run/route-pattern/match";
 
+// borrow type-safe routing utils from remix
+// with minor twist to make it work as standalone route mathcing helper
+
 export const routes = route({
   home: "/",
   scoreViewer: "/score-viewer",

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -26,6 +26,8 @@ for (const name of Object.keys(routes) as RouteName[]) {
 
 export const routeMatcher = {
   match(url: string | URL) {
+    // MultiMatcher tracks pattern and data as independent unions. These entries
+    // are registered together above, so restore their correlation for callers.
     return matcher.match(url) as RouteMatch | null;
   },
 };


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/toy-midi/issues/237

Route URLs were duplicated across parsing, links, and imperative navigation, which made route changes easy to apply inconsistently. This PR tries out some router utility from https://github.com/remix-run/remix/ with minor adaption for our standalone use case.