### PR TITLE
chore: remove basic pitch package script

### DIFF
--- a/e2e/fixtures/README.md
+++ b/e2e/fixtures/README.md
@@ -34,7 +34,7 @@ node --input-type=module -e 'import { readFile, writeFile } from "node:fs/promis
 
 ## test-tones.pcm
 
-Raw f32le mono 22050 Hz PCM (the exact layout the Basic Pitch model consumes, accepted directly by `pnpm basic-pitch`) with a C4/E4/G4/C5 arpeggio (MIDI 60/64/67/72) for 1s each, built from three harmonics plus a 10 ms attack and 20 ms release. No pitch repeats and the release is sharp because slow fades make the decoder split note tails into spurious retriggers; this shape transcribes cleanly to exactly the four expected notes. In the expression, `st(0,…)` holds the current note's frequency and `st(1,…)` the per-note time driving the envelope:
+Raw f32le mono 22050 Hz PCM (the exact layout the Basic Pitch model consumes, accepted directly by `node tools/basic-pitch.mjs`) with a C4/E4/G4/C5 arpeggio (MIDI 60/64/67/72) for 1s each, built from three harmonics plus a 10 ms attack and 20 ms release. No pitch repeats and the release is sharp because slow fades make the decoder split note tails into spurious retriggers; this shape transcribes cleanly to exactly the four expected notes. In the expression, `st(0,…)` holds the current note's frequency and `st(1,…)` the per-note time driving the envelope:
 
 ```sh
 ffmpeg -hide_banner -loglevel error -f lavfi \

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "lint-check": "vp check && pnpm lint-dead-code && pnpm typecheck",
     "lint-dead-code": "fallow dead-code --unused-exports --unused-types",
     "test": "vitest",
-    "test-e2e": "playwright test",
-    "basic-pitch": "node tools/basic-pitch.mjs"
+    "test-e2e": "playwright test"
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/tools/basic-pitch.mjs
+++ b/tools/basic-pitch.mjs
@@ -2,8 +2,8 @@
 // browser. Prints the detected notes.
 //
 // Usage:
-//   pnpm basic-pitch input.wav    # any audio format supported by ffmpeg
-//   pnpm basic-pitch input.wav --onset 0.5 --frame 0.3 --min-length 5
+//   node tools/basic-pitch.mjs input.wav    # any audio format supported by ffmpeg
+//   node tools/basic-pitch.mjs input.wav --onset 0.5 --frame 0.3 --min-length 5
 //
 // A synthetic C4/E4/G4/C5 test input lives at e2e/fixtures/test-tones.pcm
 // (regeneration documented in e2e/fixtures/README.md).
@@ -34,7 +34,7 @@ const MODEL_SAMPLE_RATE = 22050;
 const TMP_DIR = path.join(import.meta.dirname, "../.tmp");
 
 const USAGE = `\
-usage: pnpm basic-pitch <input-audio> [options]
+usage: node tools/basic-pitch.mjs <input-audio> [options]
 
 options:
   --onset <0-1>        onset threshold, higher = fewer note splits (default 0.5)


### PR DESCRIPTION
The Basic Pitch CLI is already a standalone Node tool, so the package script is an unnecessary alias that obscures how it runs.

This PR removes the `pnpm basic-pitch` script and updates the tool usage text and fixture documentation to invoke `node tools/basic-pitch.mjs` directly.