### PR TITLE
feat: add track solo toggles

### DIFF
--- a/e2e/mute-shortcuts.spec.ts
+++ b/e2e/mute-shortcuts.spec.ts
@@ -105,6 +105,7 @@ test.describe("Track Mute Shortcuts", () => {
   test("solo and mute states remain independent and persist", async ({
     page,
   }) => {
+    // Load audio so both musical tracks can be soloed
     await loadAudioFile(page);
 
     const midiSolo = page.getByRole("button", {
@@ -114,6 +115,7 @@ test.describe("Track Mute Shortcuts", () => {
       name: "Toggle Audio solo",
     });
 
+    // Solo both tracks, then mute MIDI without changing either solo state
     await midiSolo.click();
     await audioSolo.click();
     await page.keyboard.press("Shift+1");
@@ -122,10 +124,12 @@ test.describe("Track Mute Shortcuts", () => {
     await expect(audioSolo).toHaveAttribute("aria-pressed", "true");
     expect((await getMuteState(page)).midiMuted).toBe(true);
 
+    // Wait for auto-save, then reload the project
     await page.waitForTimeout(100);
     await page.reload();
     await waitForEditor(page);
 
+    // Solo and explicit mute states should be restored independently
     await expect(midiSolo).toHaveAttribute("aria-pressed", "true");
     await expect(audioSolo).toHaveAttribute("aria-pressed", "true");
     expect((await getMuteState(page)).midiMuted).toBe(true);

--- a/e2e/mute-shortcuts.spec.ts
+++ b/e2e/mute-shortcuts.spec.ts
@@ -102,6 +102,35 @@ test.describe("Track Mute Shortcuts", () => {
     expect(muteState.audioMuted).toBe(true);
   });
 
+  test("solo and mute states remain independent and persist", async ({
+    page,
+  }) => {
+    await loadAudioFile(page);
+
+    const midiSolo = page.getByRole("button", {
+      name: "Toggle MIDI solo",
+    });
+    const audioSolo = page.getByRole("button", {
+      name: "Toggle Audio solo",
+    });
+
+    await midiSolo.click();
+    await audioSolo.click();
+    await page.keyboard.press("Shift+1");
+
+    await expect(midiSolo).toHaveAttribute("aria-pressed", "true");
+    await expect(audioSolo).toHaveAttribute("aria-pressed", "true");
+    expect((await getMuteState(page)).midiMuted).toBe(true);
+
+    await page.waitForTimeout(100);
+    await page.reload();
+    await waitForEditor(page);
+
+    await expect(midiSolo).toHaveAttribute("aria-pressed", "true");
+    await expect(audioSolo).toHaveAttribute("aria-pressed", "true");
+    expect((await getMuteState(page)).midiMuted).toBe(true);
+  });
+
   test("mute shortcuts don't trigger in text input", async ({ page }) => {
     // Open settings dialog
     await page.getByTestId("settings-button").click();

--- a/e2e/mute-shortcuts.spec.ts
+++ b/e2e/mute-shortcuts.spec.ts
@@ -2,6 +2,7 @@ import { expect, type Page, test } from "@playwright/test";
 import {
   waitForEditor,
   clickNewProject,
+  evaluateFlushAutoSave,
   evaluateStore,
   loadAudioFile,
 } from "./helpers";
@@ -124,8 +125,8 @@ test.describe("Track Mute Shortcuts", () => {
     await expect(audioSolo).toHaveAttribute("aria-pressed", "true");
     expect((await getMuteState(page)).midiMuted).toBe(true);
 
-    // Wait for auto-save, then reload the project
-    await page.waitForTimeout(100);
+    // Flush auto-save, then reload the project
+    await evaluateFlushAutoSave(page);
     await page.reload();
     await waitForEditor(page);
 

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -121,7 +121,7 @@ export function Mixer() {
               "h-8 min-w-8 px-1.5 text-xs font-semibold",
               !metronomeEnabled
                 ? "bg-secondary text-secondary-foreground hover:bg-secondary/80 hover:text-secondary-foreground"
-                : "bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground",
+                : undefined,
             )}
           >
             M
@@ -201,7 +201,7 @@ function TrackToggles({
           "h-8 min-w-8 px-1.5 text-xs font-semibold",
           muted
             ? "bg-secondary text-secondary-foreground hover:bg-secondary/80 hover:text-secondary-foreground"
-            : "bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground",
+            : undefined,
         )}
       >
         M
@@ -215,7 +215,7 @@ function TrackToggles({
           "h-8 min-w-8 px-1.5 text-xs font-semibold",
           soloed
             ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
-            : "bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground",
+            : undefined,
         )}
       >
         S

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -22,12 +22,14 @@ export function Mixer() {
     midiVolume,
     metronomeVolume,
     midiMuted,
+    midiSoloed,
     metronomeEnabled,
     audioTracks,
     setMasterVolume,
     setMidiVolume,
     setMetronomeVolume,
     setMidiMuted,
+    setMidiSoloed,
     setMetronomeEnabled,
   } = useProjectStore();
   const zeroDbPercent = dbToPercent(0);
@@ -91,19 +93,13 @@ export function Mixer() {
         dbInputProps={midiDbInput.props}
         zeroDbPercent={zeroDbPercent}
         action={
-          <Toggle
-            value={midiMuted}
-            onChange={setMidiMuted}
-            aria-label="Toggle MIDI mute"
-            title={midiMuted ? "Unmute MIDI" : "Mute MIDI"}
-            className={cn(
-              "h-8 min-w-8 px-1.5",
-              midiMuted &&
-                "bg-red-900/50 border-red-700 text-red-400 hover:bg-red-900/70 hover:text-red-300",
-            )}
-          >
-            <VolumeXIcon className="size-4" />
-          </Toggle>
+          <TrackToggles
+            label="MIDI"
+            muted={midiMuted}
+            soloed={midiSoloed}
+            onMutedChange={setMidiMuted}
+            onSoloedChange={setMidiSoloed}
+          />
         }
       />
 
@@ -168,21 +164,60 @@ function AudioMixerChannel({
       dbInputProps={dbInput.props}
       zeroDbPercent={zeroDbPercent}
       action={
-        <Toggle
-          value={track.muted}
-          onChange={(muted) => updateAudioTrack(track.id, { muted })}
-          aria-label={`Toggle ${label} mute`}
-          title={track.muted ? `Unmute ${label}` : `Mute ${label}`}
-          className={cn(
-            "h-8 min-w-8 px-1.5",
-            track.muted &&
-              "bg-red-900/50 border-red-700 text-red-400 hover:bg-red-900/70 hover:text-red-300",
-          )}
-        >
-          <VolumeXIcon className="size-4" />
-        </Toggle>
+        <TrackToggles
+          label={label}
+          muted={track.muted}
+          soloed={track.soloed ?? false}
+          onMutedChange={(muted) => updateAudioTrack(track.id, { muted })}
+          onSoloedChange={(soloed) => updateAudioTrack(track.id, { soloed })}
+        />
       }
     />
+  );
+}
+
+function TrackToggles({
+  label,
+  muted,
+  soloed,
+  onMutedChange,
+  onSoloedChange,
+}: {
+  label: string;
+  muted: boolean;
+  soloed: boolean;
+  onMutedChange: (muted: boolean) => void;
+  onSoloedChange: (soloed: boolean) => void;
+}) {
+  return (
+    <div className="flex gap-1">
+      <Toggle
+        value={muted}
+        onChange={onMutedChange}
+        aria-label={`Toggle ${label} mute`}
+        title={muted ? `Unmute ${label}` : `Mute ${label}`}
+        className={cn(
+          "h-8 min-w-8 px-1.5",
+          muted &&
+            "bg-red-900/50 border-red-700 text-red-400 hover:bg-red-900/70 hover:text-red-300",
+        )}
+      >
+        <VolumeXIcon className="size-4" />
+      </Toggle>
+      <Toggle
+        value={soloed}
+        onChange={onSoloedChange}
+        aria-label={`Toggle ${label} solo`}
+        title={soloed ? `Disable ${label} solo` : `Solo ${label}`}
+        className={cn(
+          "h-8 min-w-8 px-1.5 text-xs font-semibold",
+          soloed &&
+            "border-amber-500 bg-amber-500/20 text-amber-300 hover:bg-amber-500/30 hover:text-amber-200",
+        )}
+      >
+        S
+      </Toggle>
+    </div>
   );
 }
 

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -119,8 +119,9 @@ export function Mixer() {
             title={metronomeEnabled ? "Mute metronome" : "Unmute metronome"}
             className={cn(
               "h-8 min-w-8 px-1.5 text-xs font-semibold",
-              !metronomeEnabled &&
-                "bg-neutral-200 text-neutral-900 hover:bg-neutral-300 hover:text-neutral-900",
+              !metronomeEnabled
+                ? "bg-secondary text-secondary-foreground hover:bg-secondary/80 hover:text-secondary-foreground"
+                : "bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground",
             )}
           >
             M
@@ -198,8 +199,9 @@ function TrackToggles({
         title={muted ? `Unmute ${label}` : `Mute ${label}`}
         className={cn(
           "h-8 min-w-8 px-1.5 text-xs font-semibold",
-          muted &&
-            "bg-neutral-200 text-neutral-900 hover:bg-neutral-300 hover:text-neutral-900",
+          muted
+            ? "bg-secondary text-secondary-foreground hover:bg-secondary/80 hover:text-secondary-foreground"
+            : "bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground",
         )}
       >
         M
@@ -211,8 +213,9 @@ function TrackToggles({
         title={soloed ? `Disable ${label} solo` : `Solo ${label}`}
         className={cn(
           "h-8 min-w-8 px-1.5 text-xs font-semibold",
-          soloed &&
-            "bg-amber-500 text-neutral-950 hover:bg-amber-400 hover:text-neutral-950",
+          soloed
+            ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
+            : "bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground",
         )}
       >
         S

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -117,12 +117,7 @@ export function Mixer() {
             onChange={(muted) => setMetronomeEnabled(!muted)}
             aria-label="Toggle metronome mute"
             title={metronomeEnabled ? "Mute metronome" : "Unmute metronome"}
-            className={cn(
-              "h-8 min-w-8 px-1.5 text-xs font-semibold",
-              !metronomeEnabled
-                ? "bg-secondary text-secondary-foreground hover:bg-secondary/80 hover:text-secondary-foreground"
-                : undefined,
-            )}
+            className="h-8 min-w-8 px-1.5 text-xs font-semibold"
           >
             M
           </Toggle>
@@ -197,26 +192,17 @@ function TrackToggles({
         onChange={onMutedChange}
         aria-label={`Toggle ${label} mute`}
         title={muted ? `Unmute ${label}` : `Mute ${label}`}
-        className={cn(
-          "h-8 min-w-8 px-1.5 text-xs font-semibold",
-          muted
-            ? "bg-secondary text-secondary-foreground hover:bg-secondary/80 hover:text-secondary-foreground"
-            : undefined,
-        )}
+        className="h-8 min-w-8 px-1.5 text-xs font-semibold"
       >
         M
       </Toggle>
       <Toggle
         value={soloed}
+        variant="primary"
         onChange={onSoloedChange}
         aria-label={`Toggle ${label} solo`}
         title={soloed ? `Disable ${label} solo` : `Solo ${label}`}
-        className={cn(
-          "h-8 min-w-8 px-1.5 text-xs font-semibold",
-          soloed
-            ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
-            : undefined,
-        )}
+        className="h-8 min-w-8 px-1.5 text-xs font-semibold"
       >
         S
       </Toggle>

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -190,7 +190,7 @@ function TrackToggles({
   onSoloedChange: (soloed: boolean) => void;
 }) {
   return (
-    <div className="flex gap-1">
+    <div className="flex flex-col gap-1">
       <Toggle
         value={muted}
         onChange={onMutedChange}

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -1,4 +1,4 @@
-import { GaugeIcon, MusicIcon, Volume2Icon, VolumeXIcon } from "lucide-react";
+import { GaugeIcon, MusicIcon, Volume2Icon } from "lucide-react";
 import { type ComponentProps, type ReactNode, useCallback } from "react";
 import { useDraftInput } from "../hooks/use-draft-input";
 import {
@@ -118,12 +118,12 @@ export function Mixer() {
             aria-label="Toggle metronome mute"
             title={metronomeEnabled ? "Mute metronome" : "Unmute metronome"}
             className={cn(
-              "h-8 min-w-8 px-1.5",
+              "h-8 min-w-8 px-1.5 text-xs font-semibold",
               !metronomeEnabled &&
                 "bg-neutral-200 text-neutral-900 hover:bg-neutral-300 hover:text-neutral-900",
             )}
           >
-            <VolumeXIcon className="size-4" />
+            M
           </Toggle>
         }
       />
@@ -197,12 +197,12 @@ function TrackToggles({
         aria-label={`Toggle ${label} mute`}
         title={muted ? `Unmute ${label}` : `Mute ${label}`}
         className={cn(
-          "h-8 min-w-8 px-1.5",
+          "h-8 min-w-8 px-1.5 text-xs font-semibold",
           muted &&
             "bg-neutral-200 text-neutral-900 hover:bg-neutral-300 hover:text-neutral-900",
         )}
       >
-        <VolumeXIcon className="size-4" />
+        M
       </Toggle>
       <Toggle
         value={soloed}

--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -120,7 +120,7 @@ export function Mixer() {
             className={cn(
               "h-8 min-w-8 px-1.5",
               !metronomeEnabled &&
-                "bg-red-900/50 border-red-700 text-red-400 hover:bg-red-900/70 hover:text-red-300",
+                "bg-neutral-200 text-neutral-900 hover:bg-neutral-300 hover:text-neutral-900",
             )}
           >
             <VolumeXIcon className="size-4" />
@@ -199,7 +199,7 @@ function TrackToggles({
         className={cn(
           "h-8 min-w-8 px-1.5",
           muted &&
-            "bg-red-900/50 border-red-700 text-red-400 hover:bg-red-900/70 hover:text-red-300",
+            "bg-neutral-200 text-neutral-900 hover:bg-neutral-300 hover:text-neutral-900",
         )}
       >
         <VolumeXIcon className="size-4" />
@@ -212,7 +212,7 @@ function TrackToggles({
         className={cn(
           "h-8 min-w-8 px-1.5 text-xs font-semibold",
           soloed &&
-            "border-amber-500 bg-amber-500/20 text-amber-300 hover:bg-amber-500/30 hover:text-amber-200",
+            "bg-amber-500 text-neutral-950 hover:bg-amber-400 hover:text-neutral-950",
         )}
       >
         S

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -1372,7 +1372,7 @@ function TrackControl({
               className={cn(
                 "size-4.5",
                 muted &&
-                  "bg-red-900/50 border-red-700 text-red-300 hover:bg-red-900/70 hover:text-red-200",
+                  "bg-neutral-200 text-neutral-900 hover:bg-neutral-300 hover:text-neutral-900",
               )}
             >
               M
@@ -1385,7 +1385,7 @@ function TrackControl({
               className={cn(
                 "size-4.5",
                 soloed &&
-                  "border-amber-500 bg-amber-500/20 text-amber-300 hover:bg-amber-500/30 hover:text-amber-200",
+                  "bg-amber-500 text-neutral-950 hover:bg-amber-400 hover:text-neutral-950",
               )}
             >
               S

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -1373,7 +1373,7 @@ function TrackControl({
                 "size-4.5",
                 muted
                   ? "bg-secondary text-secondary-foreground hover:bg-secondary/80 hover:text-secondary-foreground"
-                  : "bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground",
+                  : undefined,
               )}
             >
               M
@@ -1387,7 +1387,7 @@ function TrackControl({
                 "size-4.5",
                 soloed
                   ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
-                  : "bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground",
+                  : undefined,
               )}
             >
               S

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -1369,26 +1369,17 @@ function TrackControl({
               onChange={onMutedChange}
               aria-label={`Toggle ${label} mute`}
               title={muteTitle}
-              className={cn(
-                "size-4.5",
-                muted
-                  ? "bg-secondary text-secondary-foreground hover:bg-secondary/80 hover:text-secondary-foreground"
-                  : undefined,
-              )}
+              className="size-4.5"
             >
               M
             </Toggle>
             <Toggle
               value={soloed ?? false}
+              variant="primary"
               onChange={onSoloedChange}
               aria-label={`Toggle ${label} solo`}
               title={soloed ? `Disable ${label} solo` : `Solo ${label}`}
-              className={cn(
-                "size-4.5",
-                soloed
-                  ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
-                  : undefined,
-              )}
+              className="size-4.5"
             >
               S
             </Toggle>

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -1371,8 +1371,9 @@ function TrackControl({
               title={muteTitle}
               className={cn(
                 "size-4.5",
-                muted &&
-                  "bg-neutral-200 text-neutral-900 hover:bg-neutral-300 hover:text-neutral-900",
+                muted
+                  ? "bg-secondary text-secondary-foreground hover:bg-secondary/80 hover:text-secondary-foreground"
+                  : "bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground",
               )}
             >
               M
@@ -1384,8 +1385,9 @@ function TrackControl({
               title={soloed ? `Disable ${label} solo` : `Solo ${label}`}
               className={cn(
                 "size-4.5",
-                soloed &&
-                  "bg-amber-500 text-neutral-950 hover:bg-amber-400 hover:text-neutral-950",
+                soloed
+                  ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
+                  : "bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground",
               )}
             >
               S

--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -126,6 +126,7 @@ export function PianoRoll() {
     masterVolume,
     midiVolume,
     midiMuted,
+    midiSoloed,
     autoScrollEnabled,
     addNote,
     updateNote,
@@ -165,6 +166,7 @@ export function PianoRoll() {
     setMasterVolume,
     setMidiVolume,
     setMidiMuted,
+    setMidiSoloed,
   } = useProjectStore();
 
   const totalWaveformHeight = audioTracks.reduce(
@@ -978,6 +980,7 @@ export function PianoRoll() {
                 height={track.waveformHeight}
                 volume={track.volume}
                 muted={track.muted}
+                soloed={track.soloed}
                 muteTitle={
                   track.muted
                     ? "Unmute audio (Shift+2)"
@@ -987,17 +990,22 @@ export function PianoRoll() {
                   updateAudioTrack(track.id, { volume })
                 }
                 onMutedChange={(muted) => updateAudioTrack(track.id, { muted })}
+                onSoloedChange={(soloed) =>
+                  updateAudioTrack(track.id, { soloed })
+                }
               />
             ))}
             <TrackControl
               label="MIDI"
               volume={midiVolume}
               muted={midiMuted}
+              soloed={midiSoloed}
               muteTitle={
                 midiMuted ? "Unmute MIDI (Shift+1)" : "Mute MIDI (Shift+1)"
               }
               onVolumeChange={setMidiVolume}
               onMutedChange={setMidiMuted}
+              onSoloedChange={setMidiSoloed}
             />
           </div>
           <div
@@ -1318,10 +1326,12 @@ type TrackControlProps = {
   height?: number;
   volume: number;
   muted?: boolean;
+  soloed?: boolean;
   muteTitle?: string;
   sliderTestId?: string;
   onVolumeChange: (volume: number) => void;
   onMutedChange?: (muted: boolean) => void;
+  onSoloedChange?: (soloed: boolean) => void;
 };
 
 function TrackControl({
@@ -1330,10 +1340,12 @@ function TrackControl({
   height,
   volume,
   muted,
+  soloed,
   muteTitle,
   sliderTestId,
   onVolumeChange,
   onMutedChange,
+  onSoloedChange,
 }: TrackControlProps) {
   return (
     <div
@@ -1350,20 +1362,35 @@ function TrackControl({
         >
           {label}
         </span>
-        {onMutedChange && (
-          <Toggle
-            value={muted ?? false}
-            onChange={onMutedChange}
-            aria-label={`Toggle ${label} mute`}
-            title={muteTitle}
-            className={cn(
-              "size-4.5",
-              muted &&
-                "bg-red-900/50 border-red-700 text-red-300 hover:bg-red-900/70 hover:text-red-200",
-            )}
-          >
-            M
-          </Toggle>
+        {onMutedChange && onSoloedChange && (
+          <div className="flex gap-1">
+            <Toggle
+              value={muted ?? false}
+              onChange={onMutedChange}
+              aria-label={`Toggle ${label} mute`}
+              title={muteTitle}
+              className={cn(
+                "size-4.5",
+                muted &&
+                  "bg-red-900/50 border-red-700 text-red-300 hover:bg-red-900/70 hover:text-red-200",
+              )}
+            >
+              M
+            </Toggle>
+            <Toggle
+              value={soloed ?? false}
+              onChange={onSoloedChange}
+              aria-label={`Toggle ${label} solo`}
+              title={soloed ? `Disable ${label} solo` : `Solo ${label}`}
+              className={cn(
+                "size-4.5",
+                soloed &&
+                  "border-amber-500 bg-amber-500/20 text-amber-300 hover:bg-amber-500/30 hover:text-amber-200",
+              )}
+            >
+              S
+            </Toggle>
+          </div>
         )}
       </div>
       <div className="relative">

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -144,6 +144,7 @@ export function Settings({
           offset: 0,
           volume: 0.8,
           muted: false,
+          soloed: false,
           waveformHeight: DEFAULT_WAVEFORM_HEIGHT,
           audioWaveform: audioView
             ? { status: "ready", view: audioView }

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -6,6 +6,7 @@ type ToggleProps = Omit<
   "aria-pressed" | "onChange" | "type" | "value"
 > & {
   value: boolean;
+  variant?: "neutral" | "primary";
   onChange: (value: boolean) => void;
 };
 
@@ -14,6 +15,7 @@ export function Toggle({
   onChange,
   onClick,
   value,
+  variant = "neutral",
   ...props
 }: ToggleProps) {
   return (
@@ -21,9 +23,10 @@ export function Toggle({
       aria-pressed={value}
       type="button"
       className={cn(
-        "inline-flex items-center justify-center rounded-md border border-input shadow-xs transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:pointer-events-none disabled:opacity-50",
-        !value &&
-          "bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground",
+        "inline-flex items-center justify-center rounded-md border border-input bg-transparent text-foreground shadow-xs transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:pointer-events-none disabled:opacity-50",
+        variant === "neutral"
+          ? "aria-pressed:bg-foreground aria-pressed:text-background aria-pressed:hover:bg-foreground/80 aria-pressed:hover:text-background"
+          : "aria-pressed:bg-primary aria-pressed:text-primary-foreground aria-pressed:hover:bg-primary/80 aria-pressed:hover:text-primary-foreground",
         className,
       )}
       onClick={(event) => {

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -23,7 +23,7 @@ export function Toggle({
       aria-pressed={value}
       type="button"
       className={cn(
-        "inline-flex items-center justify-center rounded-md border border-input bg-transparent text-foreground shadow-xs transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:pointer-events-none disabled:opacity-50",
+        "inline-flex items-center justify-center rounded-md border border-input bg-transparent text-foreground shadow-xs transition-[color,box-shadow] hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:pointer-events-none disabled:opacity-50",
         variant === "neutral"
           ? "aria-pressed:bg-foreground aria-pressed:text-background aria-pressed:hover:bg-foreground/80 aria-pressed:hover:text-background"
           : "aria-pressed:bg-primary aria-pressed:text-primary-foreground aria-pressed:hover:bg-primary/80 aria-pressed:hover:text-primary-foreground",

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -23,7 +23,7 @@ export function Toggle({
       aria-pressed={value}
       type="button"
       className={cn(
-        "inline-flex items-center justify-center rounded-md border border-input bg-transparent text-foreground shadow-xs transition-[color,box-shadow] hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:pointer-events-none disabled:opacity-50",
+        "inline-flex items-center justify-center rounded-md border border-input bg-transparent shadow-xs transition-[color,box-shadow] hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:pointer-events-none disabled:opacity-50",
         variant === "neutral"
           ? "aria-pressed:bg-foreground aria-pressed:text-background aria-pressed:hover:bg-foreground/80 aria-pressed:hover:text-background"
           : "aria-pressed:bg-primary aria-pressed:text-primary-foreground aria-pressed:hover:bg-primary/80 aria-pressed:hover:text-primary-foreground",

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -21,7 +21,9 @@ export function Toggle({
       aria-pressed={value}
       type="button"
       className={cn(
-        "inline-flex items-center justify-center rounded-md border border-input bg-transparent shadow-xs transition-[color,box-shadow] hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:pointer-events-none disabled:opacity-50",
+        "inline-flex items-center justify-center rounded-md border border-input shadow-xs transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:pointer-events-none disabled:opacity-50",
+        !value &&
+          "bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground",
         className,
       )}
       onClick={(event) => {

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -24,9 +24,10 @@ export function Toggle({
       type="button"
       className={cn(
         "inline-flex items-center justify-center rounded-md border border-input bg-transparent shadow-xs transition-[color,box-shadow] hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:pointer-events-none disabled:opacity-50",
-        variant === "neutral"
-          ? "aria-pressed:bg-foreground aria-pressed:text-background aria-pressed:hover:bg-foreground/80 aria-pressed:hover:text-background"
-          : "aria-pressed:bg-primary aria-pressed:text-primary-foreground aria-pressed:hover:bg-primary/80 aria-pressed:hover:text-primary-foreground",
+        variant === "neutral" &&
+          "aria-pressed:bg-foreground aria-pressed:text-background aria-pressed:hover:bg-foreground/80 aria-pressed:hover:text-background",
+        variant === "primary" &&
+          "aria-pressed:bg-primary aria-pressed:text-primary-foreground aria-pressed:hover:bg-primary/80 aria-pressed:hover:text-primary-foreground",
         className,
       )}
       onClick={(event) => {

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -140,7 +140,9 @@ class AudioManager {
     // Cheap operations - always apply
     this.setMasterVolume(state.masterVolume);
     this.setMidiVolume(state.midiVolume);
-    this.setMidiMuted(state.midiMuted);
+    const anyTrackSoloed =
+      state.midiSoloed || state.audioTracks.some((track) => track.soloed);
+    this.setMidiMuted(state.midiMuted || (anyTrackSoloed && !state.midiSoloed));
     this.setMetronomeVolume(state.metronomeVolume);
     this.setMetronomeEnabled(state.metronomeEnabled);
     Tone.getTransport().bpm.value = state.tempo;
@@ -155,7 +157,17 @@ class AudioManager {
       this.setNotes(state.notes);
     }
     if (state.audioTracks !== prevState?.audioTracks) {
-      this.syncAudioTracks(state.audioTracks, prevState?.audioTracks);
+      this.syncAudioTracks(
+        state.audioTracks,
+        prevState?.audioTracks,
+        anyTrackSoloed,
+      );
+    } else if (state.midiSoloed !== prevState?.midiSoloed) {
+      this.syncAudioTracks(
+        state.audioTracks,
+        state.audioTracks,
+        anyTrackSoloed,
+      );
     }
     if (state.timeSignature.numerator !== prevState?.timeSignature.numerator) {
       this.setMetronomeSequence(state.timeSignature.numerator);
@@ -217,6 +229,7 @@ class AudioManager {
   private syncAudioTracks(
     tracks: AudioTrack[],
     prevTracks?: AudioTrack[],
+    anyTrackSoloed = tracks.some((track) => track.soloed),
   ): void {
     const prevById = new Map((prevTracks ?? []).map((t) => [t.id, t]));
     const currentIds = new Set(tracks.map((t) => t.id));
@@ -234,7 +247,7 @@ class AudioManager {
       const prev = prevById.get(track.id);
       const playback = this.getAudioTrack(track.id);
       playback.setVolume(track.volume);
-      playback.setMuted(track.muted);
+      playback.setMuted(track.muted || (anyTrackSoloed && !track.soloed));
       // Re-sync to Transport when newly added or offset changed
       if (!prev || prev.offset !== track.offset) {
         playback.sync(track.offset);

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -156,16 +156,13 @@ class AudioManager {
     if (state.notes !== prevState?.notes) {
       this.setNotes(state.notes);
     }
-    if (state.audioTracks !== prevState?.audioTracks) {
+    if (
+      state.audioTracks !== prevState?.audioTracks ||
+      state.midiSoloed !== prevState?.midiSoloed
+    ) {
       this.syncAudioTracks({
         tracks: state.audioTracks,
         prevTracks: prevState?.audioTracks,
-        anyTrackSoloed,
-      });
-    } else if (state.midiSoloed !== prevState?.midiSoloed) {
-      this.syncAudioTracks({
-        tracks: state.audioTracks,
-        prevTracks: state.audioTracks,
         anyTrackSoloed,
       });
     }

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -157,17 +157,17 @@ class AudioManager {
       this.setNotes(state.notes);
     }
     if (state.audioTracks !== prevState?.audioTracks) {
-      this.syncAudioTracks(
-        state.audioTracks,
-        prevState?.audioTracks,
+      this.syncAudioTracks({
+        tracks: state.audioTracks,
+        prevTracks: prevState?.audioTracks,
         anyTrackSoloed,
-      );
+      });
     } else if (state.midiSoloed !== prevState?.midiSoloed) {
-      this.syncAudioTracks(
-        state.audioTracks,
-        state.audioTracks,
+      this.syncAudioTracks({
+        tracks: state.audioTracks,
+        prevTracks: state.audioTracks,
         anyTrackSoloed,
-      );
+      });
     }
     if (state.timeSignature.numerator !== prevState?.timeSignature.numerator) {
       this.setMetronomeSequence(state.timeSignature.numerator);
@@ -226,11 +226,15 @@ class AudioManager {
   }
 
   // Reconcile the player map with the store's audio tracks
-  private syncAudioTracks(
-    tracks: AudioTrack[],
-    prevTracks?: AudioTrack[],
-    anyTrackSoloed = tracks.some((track) => track.soloed),
-  ): void {
+  private syncAudioTracks({
+    tracks,
+    prevTracks,
+    anyTrackSoloed,
+  }: {
+    tracks: AudioTrack[];
+    prevTracks?: AudioTrack[];
+    anyTrackSoloed: boolean;
+  }): void {
     const prevById = new Map((prevTracks ?? []).map((t) => [t.id, t]));
     const currentIds = new Set(tracks.map((t) => t.id));
 

--- a/src/lib/project-store.ts
+++ b/src/lib/project-store.ts
@@ -47,6 +47,7 @@ export interface ProjectState {
   masterVolume: number;
   midiVolume: number; // 0-1
   midiMuted: boolean;
+  midiSoloed: boolean;
   midiProgram: number; // GM program number 0-127
   metronomeEnabled: boolean;
   metronomeVolume: number; // 0-1
@@ -115,6 +116,7 @@ export interface ProjectState {
   setMasterVolume: (volume: number) => void;
   setMidiVolume: (volume: number) => void;
   setMidiMuted: (muted: boolean) => void;
+  setMidiSoloed: (soloed: boolean) => void;
   setMidiProgram: (program: number) => void;
   setMetronomeEnabled: (enabled: boolean) => void;
   setMetronomeVolume: (volume: number) => void;
@@ -147,6 +149,7 @@ export interface AudioTrack {
   offset: number; // in seconds - timeline position where audio starts (>= 0)
   volume: number; // 0-1
   muted: boolean;
+  soloed?: boolean;
   waveformHeight: number;
   audioWaveform: AudioWaveform;
 }
@@ -196,6 +199,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   masterVolume: 1,
   midiVolume: 0.8,
   midiMuted: false,
+  midiSoloed: false,
   midiProgram: 0, // Acoustic Grand Piano
   metronomeEnabled: false,
   metronomeVolume: 0.5,
@@ -495,6 +499,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   setMasterVolume: (volume) => set({ masterVolume: volume }),
   setMidiVolume: (volume) => set({ midiVolume: volume }),
   setMidiMuted: (muted) => set({ midiMuted: muted }),
+  setMidiSoloed: (soloed) => set({ midiSoloed: soloed }),
   setMidiProgram: (program) => set({ midiProgram: program }),
   setMetronomeEnabled: (enabled) => set({ metronomeEnabled: enabled }),
   setMetronomeVolume: (volume) => set({ metronomeVolume: volume }),
@@ -689,6 +694,7 @@ export interface SavedProject {
   masterVolume?: number;
   midiVolume: number;
   midiMuted?: boolean; // Optional for backward compatibility
+  midiSoloed?: boolean;
   midiProgram?: number; // Optional for backward compatibility
   metronomeEnabled: boolean;
   metronomeVolume: number;
@@ -730,6 +736,7 @@ const DEFAULTS = {
   masterVolume: 1,
   midiVolume: 0.8,
   midiMuted: false,
+  midiSoloed: false,
   midiProgram: 0,
   metronomeEnabled: false,
   metronomeVolume: 0.5,
@@ -765,6 +772,7 @@ export function toSavedProject(state: ProjectState): SavedProject {
     masterVolume: state.masterVolume,
     midiVolume: state.midiVolume,
     midiMuted: state.midiMuted,
+    midiSoloed: state.midiSoloed,
     midiProgram: state.midiProgram,
     metronomeEnabled: state.metronomeEnabled,
     metronomeVolume: state.metronomeVolume,
@@ -793,6 +801,7 @@ export function migrateSavedProject(data: AnySavedProject): SavedProject {
                 offset: data.audioOffset,
                 volume: data.audioVolume,
                 muted: data.audioMuted ?? false,
+                soloed: false,
               },
             ]
           : [],
@@ -830,12 +839,14 @@ export function fromSavedProject(data: AnySavedProject) {
     // Reattach transient waveform data slot (loaded lazily on project open)
     audioTracks: merged.audioTracks.map((t) => ({
       ...t,
+      soloed: t.soloed ?? false,
       waveformHeight: t.waveformHeight ?? legacyWaveformHeight,
       audioWaveform: { status: "pending" as const },
     })),
     masterVolume: merged.masterVolume ?? DEFAULTS.masterVolume,
     midiVolume: merged.midiVolume,
     midiMuted: merged.midiMuted ?? DEFAULTS.midiMuted,
+    midiSoloed: merged.midiSoloed ?? DEFAULTS.midiSoloed,
     midiProgram: merged.midiProgram ?? DEFAULTS.midiProgram,
     metronomeEnabled: merged.metronomeEnabled,
     metronomeVolume: merged.metronomeVolume,


### PR DESCRIPTION
This PR adds persistent solo toggles for MIDI and audio tracks in the piano roll and mixer. The logic and design are mostly ported from https://github.com/hi-ogawa/youtube-audio-replacement