### PR TITLE
refactor: align mixer mute toggle label

### DIFF
--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -197,12 +197,12 @@ function TrackToggles({
         aria-label={`Toggle ${label} mute`}
         title={muted ? `Unmute ${label}` : `Mute ${label}`}
         className={cn(
-          "h-8 min-w-8 px-1.5",
+          "h-8 min-w-8 px-1.5 text-xs font-semibold",
           muted &&
             "bg-red-900/50 border-red-700 text-red-400 hover:bg-red-900/70 hover:text-red-300",
         )}
       >
-        <VolumeXIcon className="size-4" />
+        M
       </Toggle>
       <Toggle
         value={soloed}


### PR DESCRIPTION
- follow-up to https://github.com/hi-ogawa/toy-midi/pull/243\n\nThe mixer used an icon for track mute while the piano roll used an M label, even though solo is labeled S in both places. This PR switches the mixer track mute toggle to M so the paired M/S controls are consistent across both surfaces. The metronome keeps its standalone mute icon.