### PR TITLE
test: flush autosave in persistence e2e tests

### DIFF
--- a/e2e/locators.spec.ts
+++ b/e2e/locators.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "@playwright/test";
-import { clickNewProject, waitForEditor } from "./helpers";
+import {
+  clickNewProject,
+  evaluateFlushAutoSave,
+  waitForEditor,
+} from "./helpers";
 
 // TODO: consolidate into fewer user-flow tests (combine add/select/delete/deselect)
 test.describe("Locators", () => {
@@ -139,8 +143,7 @@ test.describe("Locators", () => {
     );
     await page.keyboard.press("l");
 
-    // Wait for auto-save
-    await page.waitForTimeout(1000);
+    await evaluateFlushAutoSave(page);
 
     // Verify locators exist
     await expect(page.getByText("Section 1")).toBeVisible();

--- a/e2e/mute-shortcuts.spec.ts
+++ b/e2e/mute-shortcuts.spec.ts
@@ -2,6 +2,7 @@ import { expect, type Page, test } from "@playwright/test";
 import {
   waitForEditor,
   clickNewProject,
+  evaluateFlushAutoSave,
   evaluateStore,
   loadAudioFile,
 } from "./helpers";
@@ -88,8 +89,7 @@ test.describe("Track Mute Shortcuts", () => {
     expect(muteState.midiMuted).toBe(true);
     expect(muteState.audioMuted).toBe(true);
 
-    // Wait for auto-save
-    await page.waitForTimeout(100);
+    await evaluateFlushAutoSave(page);
 
     // Reload page
     await page.reload();


### PR DESCRIPTION
The locator and mute persistence tests were waiting arbitrary amounts of time for debounced autosave, which makes them slower and dependent on timing.\n\nThis PR uses the existing `evaluateFlushAutoSave` helper before reload so both tests synchronize directly with persistence.