### PR TITLE
test: remove redundant e2e timeouts

### DIFF
--- a/e2e/multiple-projects.spec.ts
+++ b/e2e/multiple-projects.spec.ts
@@ -226,9 +226,6 @@ test.describe("Multiple Projects", () => {
     // Click the Save button instead of pressing Enter
     await page.getByRole("button", { name: "Save" }).click();
 
-    // Wait a bit for the update to happen
-    await page.waitForTimeout(100);
-
     // Should update the card
     await expect(page.getByText("My Song")).toBeVisible();
   });

--- a/e2e/persistence.spec.ts
+++ b/e2e/persistence.spec.ts
@@ -122,9 +122,8 @@ test.describe("Project Persistence", () => {
     ]);
     await fileChooser.setFiles("e2e/fixtures/test-audio.wav");
 
-    // Close settings dialog and wait for audio to load
+    // Close settings dialog
     await page.keyboard.press("Escape");
-    await page.waitForTimeout(1000);
 
     // Check waveform is visible (audio loaded)
     const waveform = page.locator(".bg-emerald-700, .bg-emerald-600").first();

--- a/e2e/settings-export.spec.ts
+++ b/e2e/settings-export.spec.ts
@@ -234,8 +234,6 @@ test.describe("Settings Dialog - Project Export", () => {
     );
     await fileChooser.setFiles(testAudioPath);
 
-    // Wait for audio to load - waveform should be visible
-    await page.waitForTimeout(500);
     const waveform = page.locator(".bg-emerald-700, .bg-emerald-600").first();
     await expect(waveform).toBeVisible();
   });


### PR DESCRIPTION
These tests used fixed delays immediately before locator assertions that already retry until the expected UI appears. The delays made the suite slower without adding synchronization.

This PR removes those waits and relies on Playwright's assertion auto-waiting for project rename and waveform readiness.