### PR TITLE
feat: add floating score preview

### DIFF
--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -1,5 +1,6 @@
 import {
   CircleHelpIcon,
+  FileMusicIcon,
   FolderIcon,
   MoreVerticalIcon,
   SettingsIcon,
@@ -17,6 +18,7 @@ import { AudioToMidi } from "./audio-to-midi";
 import { HelpOverlay } from "./help-overlay";
 import { Mixer } from "./mixer";
 import { PianoRoll } from "./piano-roll";
+import { ScorePreview } from "./score-preview";
 import { Settings } from "./settings";
 import { Transport } from "./transport";
 import { Button } from "./ui/button";
@@ -39,6 +41,7 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isMixerOpen, setIsMixerOpen] = useState(false);
+  const [isScorePreviewOpen, setIsScorePreviewOpen] = useState(false);
   const [projectName, setProjectName] = useState(initialProjectName);
   const [audioToMidiTrackId, setAudioToMidiTrackId] = useState<string>();
   const audioToMidiTrack = useProjectStore((state) =>
@@ -88,6 +91,19 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
               <SettingsIcon className="size-5" />
             </Button>
             <Button
+              data-testid="score-preview-button"
+              onClick={() => setIsScorePreviewOpen((open) => !open)}
+              aria-pressed={isScorePreviewOpen}
+              title="Score Preview"
+              className={cn(
+                "size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+                isScorePreviewOpen &&
+                  "bg-primary text-primary-foreground hover:bg-primary/90",
+              )}
+            >
+              <FileMusicIcon className="size-5" />
+            </Button>
+            <Button
               data-testid="mixer-button"
               onClick={() => setIsMixerOpen((open) => !open)}
               aria-pressed={isMixerOpen}
@@ -135,6 +151,17 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
       />
       <PianoRoll />
       <HelpOverlay isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} />
+      {isScorePreviewOpen && (
+        <FloatingPanel
+          closeLabel="Close Score Preview"
+          onClose={() => setIsScorePreviewOpen(false)}
+          title="Score Preview"
+          testId="score-preview-panel"
+          className="left-4 right-auto"
+        >
+          <ScorePreview />
+        </FloatingPanel>
+      )}
       {isMixerOpen && (
         <FloatingPanel
           closeLabel="Close Mixer"

--- a/src/components/score-preview.tsx
+++ b/src/components/score-preview.tsx
@@ -1,0 +1,77 @@
+import { OpenSheetMusicDisplay } from "opensheetmusicdisplay";
+import { useEffect, useRef, useState } from "react";
+import { exportMusicXml } from "../lib/musicxml-export";
+import { useProjectStore } from "../lib/project-store";
+
+export function ScorePreview() {
+  const notes = useProjectStore((state) => state.notes);
+  const tempo = useProjectStore((state) => state.tempo);
+  const timeSignature = useProjectStore((state) => state.timeSignature);
+  const keySignature = useProjectStore((state) => state.keySignature);
+  const openStringPitches = useProjectStore(
+    (state) => state.tabOpenStringPitches,
+  );
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [error, setError] = useState<unknown>();
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) {
+      return;
+    }
+
+    const renderer = new OpenSheetMusicDisplay(root, {
+      autoBeam: true,
+      autoGenerateMultipleRestMeasuresFromRestMeasures: false,
+      backend: "svg",
+      disableCursor: true,
+      drawMeasureNumbersOnlyAtSystemStart: true,
+      drawPartNames: false,
+      drawTitle: false,
+      pageBackgroundColor: "#ffffff",
+    });
+    setError(undefined);
+    const xml = exportMusicXml({
+      notes,
+      tempo,
+      timeSignature,
+      keySignature,
+      openStringPitches,
+    });
+    let disposed = false;
+
+    const render = async () => {
+      await renderer.load(xml);
+      if (!disposed) {
+        renderer.setPageFormat("Endless");
+        renderer.render();
+      }
+    };
+    void render().catch((error: unknown) => {
+      if (!disposed) {
+        setError(error);
+      }
+    });
+
+    return () => {
+      disposed = true;
+      renderer.clear();
+      root.replaceChildren();
+    };
+  }, [keySignature, notes, openStringPitches, tempo, timeSignature]);
+
+  return (
+    <div className="h-[26rem] w-[44rem] overflow-auto bg-neutral-300 p-3">
+      {error !== undefined && (
+        <p className="mb-3 rounded bg-red-950 px-3 py-2 text-sm text-red-200">
+          Failed to render score preview.
+        </p>
+      )}
+      <div
+        ref={rootRef}
+        data-testid="score-preview-renderer"
+        className="min-h-full bg-white px-3 shadow-lg"
+      />
+    </div>
+  );
+}

--- a/src/components/ui/floating-panel.tsx
+++ b/src/components/ui/floating-panel.tsx
@@ -1,5 +1,6 @@
 import { XIcon } from "lucide-react";
 import type { ReactNode } from "react";
+import { cn } from "./utils";
 
 type FloatingPanelProps = {
   title: ReactNode;
@@ -7,6 +8,7 @@ type FloatingPanelProps = {
   onClose: () => void;
   children: ReactNode;
   testId?: string;
+  className?: string;
 };
 
 export function FloatingPanel({
@@ -15,11 +17,15 @@ export function FloatingPanel({
   onClose,
   children,
   testId,
+  className,
 }: FloatingPanelProps) {
   return (
     <section
       data-testid={testId}
-      className="fixed bottom-4 right-4 z-40 max-w-[calc(100vw-2rem)] rounded-lg border border-neutral-700 bg-neutral-800 shadow-2xl"
+      className={cn(
+        "fixed bottom-4 right-4 z-40 max-w-[calc(100vw-2rem)] rounded-lg border border-neutral-700 bg-neutral-800 shadow-2xl",
+        className,
+      )}
     >
       <div className="flex items-center justify-between border-b border-neutral-700 px-4 py-3">
         <h2 className="text-sm font-semibold text-neutral-100">{title}</h2>


### PR DESCRIPTION
The separate score route interrupts the piano-roll editing loop when notation is only needed as quick visual feedback.\n\nThis PR adds a read-only score preview as a floating panel inside the active project editor. It renders the current project state through the existing MusicXML export and OSMD pipeline, updates while the panel is open, and stays independent from the mixer so both panels can be visible during iteration.