### PR TITLE
ci: publish wasm package previews

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,34 @@
+name: pkg.pr.new
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: pkg-pr-new-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "lts/*"
+
+      - run: corepack enable
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build-wasm
+
+      - run: pnpm exec pkg-pr-new publish --no-compact ./crates/bass-pitch-wasm

--- a/crates/bass-pitch-wasm/package.json
+++ b/crates/bass-pitch-wasm/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@hiogawa/bass-pitch-wasm",
   "version": "0.0.0",
-  "private": true,
   "files": [
     "pkg"
   ],

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
     "fallow": "^2.50.0",
+    "pkg-pr-new": "0.0.75",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3",
     "vite": "^7.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       fallow:
         specifier: ^2.50.0
         version: 2.75.0
+      pkg-pr-new:
+        specifier: 0.0.75
+        version: 0.0.75
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
@@ -2099,6 +2102,10 @@ packages:
     resolution: {integrity: sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==}
     hasBin: true
 
+  pkg-pr-new@0.0.75:
+    resolution: {integrity: sha512-u9mdErTewKSMsr+ceCt8VcNuNP0ro5AXiPXhUVApuEyqr2Zlvt+DdCFBcm+yGWN8mhOdZJ27meIDbnoZgfzpOw==}
+    hasBin: true
+
   playwright-core@1.60.0:
     resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
@@ -2120,6 +2127,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   proc-log@6.1.0:
@@ -4320,6 +4328,8 @@ snapshots:
   pixelmatch@7.2.0:
     dependencies:
       pngjs: 7.0.0
+
+  pkg-pr-new@0.0.75: {}
 
   playwright-core@1.60.0: {}
 


### PR DESCRIPTION
- part of https://github.com/hi-ogawa/toy-midi/issues/253

The WASM package currently only gets exercised inside this workspace, which makes it awkward to test package-boundary behavior from downstream applications.

This PR publishes `@hiogawa/bass-pitch-wasm` previews for pull requests and `main` commits through pkg.pr.new, following the setup used by demucs-onnx. The workflow builds the generated WASM package before publishing its package directory.