### PR TITLE
fix: trim leading empty score measures

### DIFF
--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -236,10 +236,10 @@ describe("MusicXML export", () => {
 
     // Two complete bars disappear while the four eighth-note rest before the note remains.
     expect(model.measures).toHaveLength(1);
-    expect(model.measures[0][0]).toMatchObject({
-      type: "rest",
-      duration: 24,
-    });
+    expect(model.measures[0]).toMatchObject([
+      { type: "rest", duration: 24 },
+      { type: "note", duration: 12 },
+    ]);
   });
 
   it("resolves notes against four-string tuning", () => {

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -173,6 +173,50 @@ describe("MusicXML export", () => {
     ]);
   });
 
+  it("removes complete empty measures before the first note", () => {
+    const model = buildModel([
+      makeNote({ id: "first", start: 12 }),
+      makeNote({ id: "later", start: 20 }),
+    ]);
+
+    expect(model.measures).toHaveLength(3);
+    expect(model.measures[0][0]).toMatchObject({
+      type: "note",
+      duration: 12,
+    });
+    expect(model.measures[2][0]).toMatchObject({
+      type: "note",
+      duration: 12,
+    });
+  });
+
+  it("preserves silence within the first retained measure", () => {
+    const model = buildModel([makeNote({ start: 14 })]);
+
+    expect(model.measures).toHaveLength(1);
+    expect(model.measures[0]).toEqual([
+      {
+        type: "rest",
+        duration: 24,
+        notation: { type: "half" },
+      },
+      {
+        type: "note",
+        pitch: { step: "A", alter: 0, octave: 2 },
+        duration: 12,
+        notation: { type: "quarter" },
+        tabPosition: { tabString: 3, fret: 0 },
+        tieStart: false,
+        tieStop: false,
+      },
+      {
+        type: "rest",
+        duration: 12,
+        notation: { type: "quarter" },
+      },
+    ]);
+  });
+
   it("uses the time signature to split measures", () => {
     const model = buildModel([makeNote({ start: 2.5, duration: 1 })], {
       timeSignature: { numerator: 6, denominator: 8 },
@@ -180,6 +224,19 @@ describe("MusicXML export", () => {
 
     expect(model.measureDuration).toBe(36);
     expect(model.measures).toHaveLength(2);
+  });
+
+  it("uses the time signature when trimming empty measures", () => {
+    const model = buildModel([makeNote({ start: 8 })], {
+      timeSignature: { numerator: 6, denominator: 8 },
+    });
+
+    expect(model.measureDuration).toBe(36);
+    expect(model.measures).toHaveLength(1);
+    expect(model.measures[0][0]).toMatchObject({
+      type: "rest",
+      duration: 24,
+    });
   });
 
   it("resolves notes against four-string tuning", () => {

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -235,7 +235,6 @@ describe("MusicXML export", () => {
     });
 
     // Two complete bars disappear while the four eighth-note rest before the note remains.
-    expect(model.measureDuration).toBe(36);
     expect(model.measures).toHaveLength(1);
     expect(model.measures[0][0]).toMatchObject({
       type: "rest",

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -175,8 +175,8 @@ describe("MusicXML export", () => {
 
   it("removes complete empty measures before the first note", () => {
     const model = buildModel([
-      makeNote({ id: "first", start: 12 }), // Project bar 4, beat 1
-      makeNote({ id: "later", start: 20 }), // Project bar 6, beat 1
+      makeNote({ id: "first", start: 12 }), // Bar 4, beat 1
+      makeNote({ id: "later", start: 20 }), // Bar 6, beat 1
     ]);
 
     // The three-bar count-in disappears, so project bars 4 and 6 become score bars 1 and 3.
@@ -192,7 +192,7 @@ describe("MusicXML export", () => {
   });
 
   it("preserves silence within the first retained measure", () => {
-    const model = buildModel([makeNote({ start: 14 })]); // Project bar 4, beat 3
+    const model = buildModel([makeNote({ start: 14 })]); // Bar 4, beat 3
 
     // Complete earlier bars disappear, but beats 1 and 2 remain as a half rest.
     expect(model.measures).toHaveLength(1);

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -185,11 +185,11 @@ describe("MusicXML export", () => {
     expect(model.measures).toHaveLength(3);
     expect(model.measures[0][0]).toMatchObject({
       type: "note",
-      duration: 12,
+      duration: QUARTER_NOTE_DURATION,
     });
     expect(model.measures[2][0]).toMatchObject({
       type: "note",
-      duration: 12,
+      duration: QUARTER_NOTE_DURATION,
     });
   });
 
@@ -201,13 +201,13 @@ describe("MusicXML export", () => {
     expect(model.measures[0]).toEqual([
       {
         type: "rest",
-        duration: 24,
+        duration: 2 * QUARTER_NOTE_DURATION,
         notation: { type: "half" },
       },
       {
         type: "note",
         pitch: { step: "A", alter: 0, octave: 2 },
-        duration: 12,
+        duration: QUARTER_NOTE_DURATION,
         notation: { type: "quarter" },
         tabPosition: { tabString: 3, fret: 0 },
         tieStart: false,
@@ -215,7 +215,7 @@ describe("MusicXML export", () => {
       },
       {
         type: "rest",
-        duration: 12,
+        duration: QUARTER_NOTE_DURATION,
         notation: { type: "quarter" },
       },
     ]);
@@ -239,8 +239,8 @@ describe("MusicXML export", () => {
     // Two complete bars disappear while the four eighth-note rest before the note remains.
     expect(model.measures).toHaveLength(1);
     expect(model.measures[0]).toMatchObject([
-      { type: "rest", duration: 24 },
-      { type: "note", duration: 12 },
+      { type: "rest", duration: 2 * QUARTER_NOTE_DURATION },
+      { type: "note", duration: QUARTER_NOTE_DURATION },
     ]);
   });
 

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -175,10 +175,11 @@ describe("MusicXML export", () => {
 
   it("removes complete empty measures before the first note", () => {
     const model = buildModel([
-      makeNote({ id: "first", start: 12 }),
-      makeNote({ id: "later", start: 20 }),
+      makeNote({ id: "first", start: 12 }), // Project bar 4, beat 1
+      makeNote({ id: "later", start: 20 }), // Project bar 6, beat 1
     ]);
 
+    // The three-bar count-in disappears, so project bars 4 and 6 become score bars 1 and 3.
     expect(model.measures).toHaveLength(3);
     expect(model.measures[0][0]).toMatchObject({
       type: "note",
@@ -191,8 +192,9 @@ describe("MusicXML export", () => {
   });
 
   it("preserves silence within the first retained measure", () => {
-    const model = buildModel([makeNote({ start: 14 })]);
+    const model = buildModel([makeNote({ start: 14 })]); // Project bar 4, beat 3
 
+    // Complete earlier bars disappear, but beats 1 and 2 remain as a half rest.
     expect(model.measures).toHaveLength(1);
     expect(model.measures[0]).toEqual([
       {
@@ -227,10 +229,12 @@ describe("MusicXML export", () => {
   });
 
   it("uses the time signature when trimming empty measures", () => {
+    // In 6/8, each bar spans three quarter-note units, so this note is at bar 3, beat 5.
     const model = buildModel([makeNote({ start: 8 })], {
       timeSignature: { numerator: 6, denominator: 8 },
     });
 
+    // Two complete bars disappear while the four eighth-note rest before the note remains.
     expect(model.measureDuration).toBe(36);
     expect(model.measures).toHaveLength(1);
     expect(model.measures[0][0]).toMatchObject({

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -99,7 +99,14 @@ export function buildMusicXmlModel({
     timeSignature.numerator * (4 / timeSignature.denominator),
     "time signature",
   );
-  const quantizedNotes = prepareNotes({ notes, openStringPitches });
+  const preparedNotes = prepareNotes({ notes, openStringPitches });
+  const trimOffset =
+    Math.floor(preparedNotes[0].start / measureDuration) * measureDuration;
+  const quantizedNotes = preparedNotes.map((note) => ({
+    ...note,
+    start: note.start - trimOffset,
+    end: note.end - trimOffset,
+  }));
   const measureCount = Math.ceil(
     quantizedNotes[quantizedNotes.length - 1].end / measureDuration,
   );

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -100,12 +100,12 @@ export function buildMusicXmlModel({
     "time signature",
   );
   const preparedNotes = prepareNotes({ notes, openStringPitches });
-  const trimOffset =
+  const firstMeasureStart =
     Math.floor(preparedNotes[0].start / measureDuration) * measureDuration;
   const quantizedNotes = preparedNotes.map((note) => ({
     ...note,
-    start: note.start - trimOffset,
-    end: note.end - trimOffset,
+    start: note.start - firstMeasureStart,
+    end: note.end - firstMeasureStart,
   }));
   const measureCount = Math.ceil(
     quantizedNotes[quantizedNotes.length - 1].end / measureDuration,


### PR DESCRIPTION
- part of https://github.com/hi-ogawa/toy-midi/issues/224

Scores currently include every empty project measure before the first note, which makes exported and project-backed scores start with unnecessary rest measures.

This PR trims complete leading empty measures while preserving the first note's position within its retained measure. MusicXML measure numbering and viewer playback therefore begin at score-local measure 1 without changing project timing.