### PR TITLE
feat: export locators as rehearsal marks

### DIFF
--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -162,6 +162,20 @@ test("switches between generated score samples", async ({ page }) => {
   await expect(page.getByLabel("BPM")).toHaveValue("200");
 });
 
+test("toggles rehearsal marks", async ({ page }) => {
+  await page.goto("/score-viewer");
+  await loadSample(page, "Rehearsal marks");
+
+  const renderer = page.getByTestId("score-viewer-renderer");
+  await expect(renderer.getByText("A", { exact: true })).toBeVisible();
+
+  await page.getByLabel("Section labels").selectOption("hide");
+  await expect(renderer.getByText("A", { exact: true })).toHaveCount(0);
+
+  await page.getByLabel("Section labels").selectOption("show");
+  await expect(renderer.getByText("A", { exact: true })).toBeVisible();
+});
+
 test("seeks to the start of a clicked measure", async ({ page }) => {
   await page.goto("/score-viewer");
   await loadSample(page, "Cursor and wrapping");

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -182,6 +182,22 @@ export class ScoreViewerRuntime {
     this.#scroller.scrollTo({ top: 0 });
   }
 
+  setRehearsalMarksVisible(visible: boolean) {
+    this.#osmd.EngravingRules.RenderRehearsalMarks = visible;
+    if (!this.#state.isReady) {
+      return;
+    }
+    this.#osmd.render();
+    this.#positions = buildCursorPositions(this.#osmd, this.#container);
+    buildMeasureTargets(this.#osmd, this.#measureLayers, this.#container);
+    this.#updateCursor(
+      secondsToScoreTime(
+        this.#clock.getSnapshot().currentTime,
+        this.#state.tempo,
+      ),
+    );
+  }
+
   setTempo(tempo: number) {
     if (!Number.isFinite(tempo) || tempo <= 0) {
       return;

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -140,12 +140,21 @@ export class ScoreViewerRuntime {
     });
   }
 
-  async load({ score, layout }: { score: ScoreSource; layout: ScoreLayout }) {
+  async load({
+    score,
+    layout,
+    showRehearsalMarks,
+  }: {
+    score: ScoreSource;
+    layout: ScoreLayout;
+    showRehearsalMarks: boolean;
+  }) {
     this.#clock.stop();
     this.#setState({ isReady: false });
 
     this.#osmd.clear();
     this.#osmd.setPageFormat(layout === "paged" ? "A4_P" : "Endless");
+    this.#osmd.EngravingRules.RenderRehearsalMarks = showRehearsalMarks;
     await this.#osmd.load(score.xml);
     this.#sheet.hidden = false;
     this.#osmd.render();
@@ -180,22 +189,6 @@ export class ScoreViewerRuntime {
   restart() {
     this.#clock.stop();
     this.#scroller.scrollTo({ top: 0 });
-  }
-
-  setRehearsalMarksVisible(visible: boolean) {
-    this.#osmd.EngravingRules.RenderRehearsalMarks = visible;
-    if (!this.#state.isReady) {
-      return;
-    }
-    this.#osmd.render();
-    this.#positions = buildCursorPositions(this.#osmd, this.#container);
-    buildMeasureTargets(this.#osmd, this.#measureLayers, this.#container);
-    this.#updateCursor(
-      secondsToScoreTime(
-        this.#clock.getSnapshot().currentTime,
-        this.#state.tempo,
-      ),
-    );
   }
 
   setTempo(tempo: number) {

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -77,16 +77,18 @@ export function ScoreViewer({
   const loadMutation = useMutation({
     mutationFn: async ({
       layout,
+      showRehearsalMarks,
       source,
     }: {
       layout: ScoreLayout;
+      showRehearsalMarks: boolean;
       source: File | ScoreSource;
     }) => {
       const nextScore =
         source instanceof File
           ? { name: source.name, xml: await source.text() }
           : source;
-      await runtime.load({ score: nextScore, layout });
+      await runtime.load({ score: nextScore, layout, showRehearsalMarks });
       setScore(nextScore);
     },
   });
@@ -99,6 +101,7 @@ export function ScoreViewer({
     queryFn: async () => {
       loadMutation.mutate({
         layout,
+        showRehearsalMarks,
         source: initialSource!,
       });
       return true;
@@ -113,6 +116,21 @@ export function ScoreViewer({
     if (score) {
       loadMutation.mutate({
         layout: nextLayout,
+        showRehearsalMarks,
+        source: score,
+      });
+    }
+  }
+
+  function changeRehearsalMarksVisible(visible: boolean) {
+    if (visible === showRehearsalMarks) {
+      return;
+    }
+    setShowRehearsalMarks(visible);
+    if (score) {
+      loadMutation.mutate({
+        layout,
+        showRehearsalMarks: visible,
         source: score,
       });
     }
@@ -194,11 +212,11 @@ export function ScoreViewer({
             <select
               aria-label="Section labels"
               value={showRehearsalMarks ? "show" : "hide"}
-              onChange={(event) => {
-                const visible = event.currentTarget.value === "show";
-                setShowRehearsalMarks(visible);
-                runtime.setRehearsalMarksVisible(visible);
-              }}
+              onChange={(event) =>
+                changeRehearsalMarksVisible(
+                  event.currentTarget.value === "show",
+                )
+              }
               className="h-8 rounded border border-border bg-input px-2 text-sm text-foreground"
             >
               <option value="show">Show</option>
@@ -225,7 +243,13 @@ export function ScoreViewer({
               accept=".musicxml,.xml,application/vnd.recordare.musicxml+xml"
               disabled={loadMutation.isPending}
               inputProps={{ "aria-label": "Open MusicXML" }}
-              onFile={(file) => loadMutation.mutate({ layout, source: file })}
+              onFile={(file) =>
+                loadMutation.mutate({
+                  layout,
+                  showRehearsalMarks,
+                  source: file,
+                })
+              }
               className="h-8 gap-1.5 px-3 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
             >
               <FolderOpenIcon className="size-4" />
@@ -245,6 +269,7 @@ export function ScoreViewer({
                     onSelect={() =>
                       loadMutation.mutate({
                         layout,
+                        showRehearsalMarks,
                         source: { name: sample.name, xml: sample.xml },
                       })
                     }
@@ -289,7 +314,13 @@ export function ScoreViewer({
               accept=".musicxml,.xml,application/vnd.recordare.musicxml+xml"
               disabled={loadMutation.isPending}
               inputProps={{ "aria-label": "Upload MusicXML" }}
-              onFile={(file) => loadMutation.mutate({ layout, source: file })}
+              onFile={(file) =>
+                loadMutation.mutate({
+                  layout,
+                  showRehearsalMarks,
+                  source: file,
+                })
+              }
               className="group h-48 w-full max-w-4xl flex-col gap-3 rounded-sm border border-dashed border-neutral-500 bg-neutral-200/60 text-center text-neutral-700 shadow-none hover:border-neutral-700 hover:bg-neutral-100 hover:text-neutral-900 data-[drag-over=true]:border-blue-600 data-[drag-over=true]:bg-blue-50 data-[drag-over=true]:text-blue-900"
             >
               <span className="flex size-11 items-center justify-center rounded-full border border-neutral-400 bg-white shadow-sm group-data-[drag-over=true]:border-blue-400">

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -39,6 +39,7 @@ export function ScoreViewer({
 
   const [score, setScore] = useState<ScoreSource | undefined>(initialSource);
   const [layout, setLayout] = useState<ScoreLayout>("continuous");
+  const [showRehearsalMarks, setShowRehearsalMarks] = useState(true);
   const [isRuntimeAttached, setIsRuntimeAttached] = useState(false);
 
   // initialize runtime
@@ -185,6 +186,23 @@ export function ScoreViewer({
             >
               <option value="continuous">Continuous</option>
               <option value="paged">Paged</option>
+            </select>
+          </label>
+
+          <label className="flex items-center gap-1.5 text-sm">
+            <span className="text-muted-foreground">Section labels</span>
+            <select
+              aria-label="Section labels"
+              value={showRehearsalMarks ? "show" : "hide"}
+              onChange={(event) => {
+                const visible = event.currentTarget.value === "show";
+                setShowRehearsalMarks(visible);
+                runtime.setRehearsalMarksVisible(visible);
+              }}
+              className="h-8 rounded border border-border bg-input px-2 text-sm text-foreground"
+            >
+              <option value="show">Show</option>
+              <option value="hide">Hide</option>
             </select>
           </label>
         </div>

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -60,6 +60,7 @@ export function Settings({
     timeSignature,
     keySignature,
     notes,
+    locators,
     autoScrollEnabled,
     linkAudioOffsetsEnabled,
     tabAnnotationEnabled,
@@ -191,6 +192,7 @@ export function Settings({
     mutationFn: async () => {
       const xml = exportMusicXml({
         notes,
+        locators,
         tempo,
         timeSignature,
         keySignature,

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -84,7 +84,7 @@ describe("MusicXML export", () => {
       [{ label: "A", offset: 0 }],
       [
         { label: "C", offset: 0 },
-        { label: "B", offset: 24 },
+        { label: "B", offset: 2 * QUARTER_NOTE_DURATION },
       ],
     ]);
   });
@@ -99,9 +99,9 @@ describe("MusicXML export", () => {
     });
 
     expect(model.measures[0].locators).toEqual([
-      { label: "A", offset: 12 },
-      { label: "B", offset: 12 },
-      { label: "C", offset: 36 },
+      { label: "A", offset: QUARTER_NOTE_DURATION },
+      { label: "B", offset: QUARTER_NOTE_DURATION },
+      { label: "C", offset: 3 * QUARTER_NOTE_DURATION },
     ]);
   });
 

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -121,19 +121,13 @@ describe("MusicXML export", () => {
     expect(model.measures[0].locators).toEqual([{ label: "A", offset: 0 }]);
   });
 
-  it.each([
-    { position: -1, error: "position of locator section-a" },
-    { position: 0.1, error: "position of locator section-a is not aligned" },
-  ])(
-    "rejects an invalid rehearsal mark at $position",
-    ({ position, error }) => {
-      expect(() =>
-        buildModel([makeNote()], {
-          locators: [{ id: "section-a", position, label: "A" }],
-        }),
-      ).toThrow(error);
-    },
-  );
+  it("rejects an off-grid rehearsal mark", () => {
+    expect(() =>
+      buildModel([makeNote()], {
+        locators: [{ id: "section-a", position: 0.1, label: "A" }],
+      }),
+    ).toThrow("position of locator section-a is not aligned");
+  });
 
   it("splits notes at bar lines and ties the pieces", () => {
     const model = buildModel([makeNote({ start: 3.5, duration: 1 })]);

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -113,6 +113,14 @@ describe("MusicXML export", () => {
     expect(model.measures.map((measure) => measure.locators)).toEqual([[]]);
   });
 
+  it("shifts rehearsal marks with trimmed empty measures", () => {
+    const model = buildModel([makeNote({ start: 12 })], {
+      locators: [{ id: "section-a", position: 12, label: "A" }],
+    });
+
+    expect(model.measures[0].locators).toEqual([{ label: "A", offset: 0 }]);
+  });
+
   it.each([
     { position: -1, error: "position of locator section-a" },
     { position: 0.1, error: "position of locator section-a is not aligned" },
@@ -243,11 +251,11 @@ describe("MusicXML export", () => {
 
     // The three-bar count-in disappears, so project bars 4 and 6 become score bars 1 and 3.
     expect(model.measures).toHaveLength(3);
-    expect(model.measures[0][0]).toMatchObject({
+    expect(model.measures[0].events[0]).toMatchObject({
       type: "note",
       duration: QUARTER_NOTE_DURATION,
     });
-    expect(model.measures[2][0]).toMatchObject({
+    expect(model.measures[2].events[0]).toMatchObject({
       type: "note",
       duration: QUARTER_NOTE_DURATION,
     });
@@ -258,7 +266,7 @@ describe("MusicXML export", () => {
 
     // Complete earlier bars disappear, but beats 1 and 2 remain as a half rest.
     expect(model.measures).toHaveLength(1);
-    expect(model.measures[0]).toEqual([
+    expect(model.measures[0].events).toEqual([
       {
         type: "rest",
         duration: 2 * QUARTER_NOTE_DURATION,
@@ -298,7 +306,7 @@ describe("MusicXML export", () => {
 
     // Two complete bars disappear while the four eighth-note rest before the note remains.
     expect(model.measures).toHaveLength(1);
-    expect(model.measures[0]).toMatchObject([
+    expect(model.measures[0].events).toMatchObject([
       { type: "rest", duration: 2 * QUARTER_NOTE_DURATION },
       { type: "note", duration: QUARTER_NOTE_DURATION },
     ]);

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -61,11 +61,67 @@ describe("MusicXML export", () => {
   it("preserves an explicit TAB string assignment", () => {
     const model = buildModel([makeNote({ tabString: 4 })]);
 
-    expect(model.measures[0][0]).toMatchObject({
+    expect(model.measures[0].events[0]).toMatchObject({
       type: "note",
       tabPosition: { tabString: 4, fret: 5 },
     });
   });
+
+  it("places rehearsal marks at measure boundaries and local offsets", () => {
+    const model = buildModel([makeNote({ duration: 8 })], {
+      locators: [
+        { id: "section-a", position: 0, label: "A" },
+        { id: "section-b", position: 6, label: "B" },
+        { id: "section-c", position: 4, label: "C" },
+      ],
+    });
+
+    expect(model.measures.map((measure) => measure.locators)).toEqual([
+      [{ label: "A", offset: 0 }],
+      [
+        { label: "C", offset: 0 },
+        { label: "B", offset: 24 },
+      ],
+    ]);
+  });
+
+  it("orders rehearsal marks while preserving duplicate positions", () => {
+    const model = buildModel([makeNote({ duration: 4 })], {
+      locators: [
+        { id: "section-c", position: 3, label: "C" },
+        { id: "section-a", position: 1, label: "A" },
+        { id: "section-b", position: 1, label: "B" },
+      ],
+    });
+
+    expect(model.measures[0].locators).toEqual([
+      { label: "A", offset: 12 },
+      { label: "B", offset: 12 },
+      { label: "C", offset: 36 },
+    ]);
+  });
+
+  it("ignores rehearsal marks after the final note", () => {
+    const model = buildModel([makeNote()], {
+      locators: [{ id: "section-b", position: 4, label: "B" }],
+    });
+
+    expect(model.measures.map((measure) => measure.locators)).toEqual([[]]);
+  });
+
+  it.each([
+    { position: -1, error: "position of locator section-a" },
+    { position: 0.1, error: "position of locator section-a is not aligned" },
+  ])(
+    "rejects an invalid rehearsal mark at $position",
+    ({ position, error }) => {
+      expect(() =>
+        buildModel([makeNote()], {
+          locators: [{ id: "section-a", position, label: "A" }],
+        }),
+      ).toThrow(error);
+    },
+  );
 
   it("splits notes at bar lines and ties the pieces", () => {
     const model = buildModel([makeNote({ start: 3.5, duration: 1 })]);
@@ -73,7 +129,7 @@ describe("MusicXML export", () => {
     expect(model.measureDuration).toBe(48);
     expect(
       model.measures.map((events) =>
-        events.filter((event) => event.type === "note"),
+        events.events.filter((event) => event.type === "note"),
       ),
     ).toEqual([
       [
@@ -101,7 +157,7 @@ describe("MusicXML export", () => {
     ]);
     expect(
       model.measures.map((events) =>
-        events.reduce((total, event) => total + event.duration, 0),
+        events.events.reduce((total, event) => total + event.duration, 0),
       ),
     ).toEqual([48, 48]);
   });
@@ -120,7 +176,9 @@ describe("MusicXML export", () => {
       }),
     ]);
 
-    expect(model.measures[0].filter((event) => event.type === "note")).toEqual([
+    expect(
+      model.measures[0].events.filter((event) => event.type === "note"),
+    ).toEqual([
       {
         type: "note",
         pitch: { step: "A", alter: 0, octave: 2 },
@@ -150,7 +208,7 @@ describe("MusicXML export", () => {
       }),
     ]);
 
-    expect(model.measures[0]).toEqual([
+    expect(model.measures[0].events).toEqual([
       {
         type: "rest",
         duration: 12,
@@ -187,7 +245,7 @@ describe("MusicXML export", () => {
       openStringPitches: FOUR_STRING_PITCHES,
     });
 
-    expect(model.measures[0][0]).toMatchObject({
+    expect(model.measures[0].events[0]).toMatchObject({
       type: "note",
       tabPosition: { tabString: 3, fret: 0 },
     });
@@ -198,7 +256,7 @@ describe("MusicXML export", () => {
       openStringPitches: [42, 37, 32, 27], // Gb2 Db2 Ab1 Eb1, down 1 semitone
     });
 
-    expect(model.measures[0][0]).toMatchObject({
+    expect(model.measures[0].events[0]).toMatchObject({
       type: "note",
       tabPosition: { tabString: 3, fret: 1 },
     });

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -28,6 +28,7 @@ function exportNotes(
 ): string {
   return exportMusicXml({
     notes,
+    locators: [],
     tempo: 120,
     keySignature: { fifths: 0, mode: "major" },
     timeSignature: { numerator: 4, denominator: 4 },
@@ -42,6 +43,7 @@ function buildModel(
 ) {
   return buildMusicXmlModel({
     notes,
+    locators: [],
     timeSignature: { numerator: 4, denominator: 4 },
     keySignature: { fifths: 0, mode: "major" },
     openStringPitches: FIVE_STRING_PITCHES,

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -1,4 +1,4 @@
-import type { Note, TimeSignature } from "../types";
+import type { Locator, Note, TimeSignature } from "../types";
 import {
   type KeySignature,
   type SpelledPitch,
@@ -24,10 +24,16 @@ export type MusicXmlModelOptions = {
   timeSignature: TimeSignature;
   keySignature: KeySignature;
   openStringPitches: readonly number[];
+  locators?: Locator[];
 };
 
 export type MusicXmlExportOptions = MusicXmlModelOptions & {
   tempo: number;
+};
+
+export type MusicXmlMeasure = {
+  events: MusicXmlMeasureEvent[];
+  locators: { label: string; offset: number }[];
 };
 
 type QuantizedNote = {
@@ -85,9 +91,10 @@ export function buildMusicXmlModel({
   timeSignature,
   keySignature,
   openStringPitches,
+  locators = [],
 }: MusicXmlModelOptions): {
   measureDuration: number;
-  measures: MusicXmlMeasureEvent[][];
+  measures: MusicXmlMeasure[];
 } {
   if (notes.length === 0) {
     throw new Error("Add at least one note before exporting MusicXML");
@@ -116,14 +123,44 @@ export function buildMusicXmlModel({
   }
   return {
     measureDuration,
-    measures: notesByMeasure.map((notes, index) =>
-      buildMeasureEvents({
-        notes,
-        measureStart: index * measureDuration,
-        measureDuration,
-        keySignature,
-      }),
-    ),
+    measures: notesByMeasure.map((notes, index) => {
+      const measureStart = index * measureDuration;
+      return {
+        events: buildMeasureEvents({
+          notes,
+          measureStart,
+          measureDuration,
+          keySignature,
+        }),
+        locators: locators
+          .map((locator) => ({
+            id: locator.id,
+            label: locator.label,
+            position: toGridUnits(
+              locator.position,
+              `position of locator ${locator.id}`,
+            ),
+          }))
+          .map((locator) => {
+            if (locator.position < 0) {
+              throw new Error(
+                `position of locator ${locator.id} must not be negative`,
+              );
+            }
+            return locator;
+          })
+          .filter(
+            ({ position }) =>
+              position >= measureStart &&
+              position < measureStart + measureDuration,
+          )
+          .sort((a, b) => a.position - b.position)
+          .map(({ label, position }) => ({
+            label,
+            offset: position - measureStart,
+          })),
+      };
+    }),
   };
 }
 
@@ -313,12 +350,14 @@ export function exportMusicXml({
   timeSignature,
   keySignature,
   openStringPitches,
+  locators = [],
 }: MusicXmlExportOptions): string {
   const { measureDuration, measures } = buildMusicXmlModel({
     notes,
     timeSignature,
     keySignature,
     openStringPitches,
+    locators,
   });
   // MusicXML places score-level configuration inside the first measure.
   const initialMeasureChildren = [
@@ -394,9 +433,9 @@ export function exportMusicXml({
     h(
       "part",
       { id: "P1" },
-      ...measures.map((events, index) =>
+      ...measures.map((measure, index) =>
         renderMeasure({
-          events,
+          measure,
           index,
           measureDuration,
           initialChildren: index === 0 ? initialMeasureChildren : [],
@@ -413,12 +452,12 @@ ${renderXml(document)}
 }
 
 function renderMeasure({
-  events,
+  measure,
   index,
   measureDuration,
   initialChildren,
 }: {
-  events: MusicXmlMeasureEvent[];
+  measure: MusicXmlMeasure;
   index: number;
   measureDuration: number;
   initialChildren: XmlNode[];
@@ -428,9 +467,26 @@ function renderMeasure({
     "measure",
     { number: index + 1 },
     ...initialChildren,
-    ...events.map((event) => renderEvent(event, 1)),
+    ...measure.locators.map(renderRehearsalDirection),
+    ...measure.events.map((event) => renderEvent(event, 1)),
     hx("backup", hx("duration", measureDuration)),
-    ...events.map((event) => renderEvent(event, 2)),
+    ...measure.events.map((event) => renderEvent(event, 2)),
+  );
+}
+
+function renderRehearsalDirection({
+  label,
+  offset,
+}: {
+  label: string;
+  offset: number;
+}): XmlElement {
+  return h(
+    "direction",
+    { placement: "above" },
+    hx("direction-type", hx("rehearsal", label)),
+    offset > 0 && hx("offset", offset),
+    hx("staff", 1),
   );
 }
 

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -139,37 +139,53 @@ export function buildMusicXmlModel({
           measureDuration,
           keySignature,
         }),
-        locators: locators
-          .map((locator) => ({
-            id: locator.id,
-            label: locator.label,
-            position:
-              toGridUnits(
-                locator.position,
-                `position of locator ${locator.id}`,
-              ) - firstMeasureStart,
-          }))
-          .map((locator) => {
-            if (locator.position < 0) {
-              throw new Error(
-                `position of locator ${locator.id} must not be negative`,
-              );
-            }
-            return locator;
-          })
-          .filter(
-            ({ position }) =>
-              position >= measureStart &&
-              position < measureStart + measureDuration,
-          )
-          .sort((a, b) => a.position - b.position)
-          .map(({ label, position }) => ({
-            label,
-            offset: position - measureStart,
-          })),
+        locators: buildMeasureLocators({
+          locators,
+          firstMeasureStart,
+          measureStart,
+          measureDuration,
+        }),
       };
     }),
   };
+}
+
+function buildMeasureLocators({
+  locators,
+  firstMeasureStart,
+  measureStart,
+  measureDuration,
+}: {
+  locators: Locator[];
+  firstMeasureStart: number;
+  measureStart: number;
+  measureDuration: number;
+}): MusicXmlMeasure["locators"] {
+  return locators
+    .map((locator) => ({
+      id: locator.id,
+      label: locator.label,
+      position:
+        toGridUnits(locator.position, `position of locator ${locator.id}`) -
+        firstMeasureStart,
+    }))
+    .map((locator) => {
+      if (locator.position < 0) {
+        throw new Error(
+          `position of locator ${locator.id} must not be negative`,
+        );
+      }
+      return locator;
+    })
+    .filter(
+      ({ position }) =>
+        position >= measureStart && position < measureStart + measureDuration,
+    )
+    .sort((a, b) => a.position - b.position)
+    .map(({ label, position }) => ({
+      label,
+      offset: position - measureStart,
+    }));
 }
 
 /** Quantizes notes, resolves TAB positions, orders them, and rejects polyphony. */

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -164,19 +164,13 @@ function buildMeasureLocators({
   return locators
     .map((locator) => ({
       label: locator.label,
-      position:
+      offset:
         toGridUnits(locator.position, `position of locator ${locator.id}`) -
-        firstMeasureStart,
+        firstMeasureStart -
+        measureStart,
     }))
-    .filter(
-      ({ position }) =>
-        position >= measureStart && position < measureStart + measureDuration,
-    )
-    .sort((a, b) => a.position - b.position)
-    .map(({ label, position }) => ({
-      label,
-      offset: position - measureStart,
-    }));
+    .filter(({ offset }) => offset >= 0 && offset < measureDuration)
+    .sort((a, b) => a.offset - b.offset);
 }
 
 /** Quantizes notes, resolves TAB positions, orders them, and rejects polyphony. */

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -143,10 +143,11 @@ export function buildMusicXmlModel({
           .map((locator) => ({
             id: locator.id,
             label: locator.label,
-            position: toGridUnits(
-              locator.position,
-              `position of locator ${locator.id}`,
-            ),
+            position:
+              toGridUnits(
+                locator.position,
+                `position of locator ${locator.id}`,
+              ) - firstMeasureStart,
           }))
           .map((locator) => {
             if (locator.position < 0) {

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -163,20 +163,11 @@ function buildMeasureLocators({
 }): MusicXmlMeasure["locators"] {
   return locators
     .map((locator) => ({
-      id: locator.id,
       label: locator.label,
       position:
         toGridUnits(locator.position, `position of locator ${locator.id}`) -
         firstMeasureStart,
     }))
-    .map((locator) => {
-      if (locator.position < 0) {
-        throw new Error(
-          `position of locator ${locator.id} must not be negative`,
-        );
-      }
-      return locator;
-    })
     .filter(
       ({ position }) =>
         position >= measureStart && position < measureStart + measureDuration,

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -24,7 +24,7 @@ export type MusicXmlModelOptions = {
   timeSignature: TimeSignature;
   keySignature: KeySignature;
   openStringPitches: readonly number[];
-  locators?: Locator[];
+  locators: Locator[];
 };
 
 export type MusicXmlExportOptions = MusicXmlModelOptions & {
@@ -91,7 +91,7 @@ export function buildMusicXmlModel({
   timeSignature,
   keySignature,
   openStringPitches,
-  locators = [],
+  locators,
 }: MusicXmlModelOptions): {
   measureDuration: number;
   measures: MusicXmlMeasure[];
@@ -350,7 +350,7 @@ export function exportMusicXml({
   timeSignature,
   keySignature,
   openStringPitches,
-  locators = [],
+  locators,
 }: MusicXmlExportOptions): string {
   const { measureDuration, measures } = buildMusicXmlModel({
     notes,

--- a/src/lib/project-score.ts
+++ b/src/lib/project-score.ts
@@ -27,6 +27,7 @@ function getProjectScoreSourceImpl(projectId: string): ProjectScoreResult {
         name: `${metadata.name}.musicxml`,
         xml: exportMusicXml({
           notes: project.notes,
+          locators: project.locators,
           tempo: project.tempo,
           timeSignature: project.timeSignature,
           keySignature: project.keySignature,

--- a/src/lib/score-viewer-samples.ts
+++ b/src/lib/score-viewer-samples.ts
@@ -21,6 +21,7 @@ export const SCORE_VIEWER_SAMPLES: ScoreViewerSample[] = [
     tempo: 120,
     xml: exportSample({
       tempo: 120,
+      locators: [],
       notes: createSequentialNotes({ count: 64, duration: 0.5 }),
     }),
   },
@@ -31,6 +32,7 @@ export const SCORE_VIEWER_SAMPLES: ScoreViewerSample[] = [
     tempo: 120,
     xml: exportSample({
       tempo: 120,
+      locators: [],
       notes: [
         createNote({ pitch: 40, start: 0, duration: 1 }),
         createNote({ pitch: 43, start: 1, duration: 0.5 }),
@@ -51,6 +53,7 @@ export const SCORE_VIEWER_SAMPLES: ScoreViewerSample[] = [
     tempo: 120,
     xml: exportSample({
       tempo: 120,
+      locators: [],
       notes: [
         createNote({ pitch: 40, start: 0, duration: 2.5 }),
         createNote({ pitch: 43, start: 2.5, duration: 2.5 }),
@@ -67,6 +70,7 @@ export const SCORE_VIEWER_SAMPLES: ScoreViewerSample[] = [
     tempo: 120,
     xml: exportSample({
       tempo: 120,
+      locators: [],
       notes: [
         createNote({ pitch: 40, start: 0, duration: 1 }),
         createNote({ pitch: 45, start: 1, duration: 1 }),
@@ -96,6 +100,7 @@ export const SCORE_VIEWER_SAMPLES: ScoreViewerSample[] = [
     tempo: 110,
     xml: exportSample({
       tempo: 110,
+      locators: [],
       notes: createSequentialNotes({ count: 96, duration: 0.25 }),
     }),
   },
@@ -107,6 +112,7 @@ export const SCORE_VIEWER_SAMPLES: ScoreViewerSample[] = [
     xml: exportSample({
       notes: createSequentialNotes({ count: 96, duration: 0.5 }),
       tempo: 200,
+      locators: [],
       keySignature: { fifths: -3, mode: "minor" },
     }),
   },
@@ -118,6 +124,7 @@ export const SCORE_VIEWER_SAMPLES: ScoreViewerSample[] = [
     xml: exportSample({
       notes: createPrintNotes(),
       tempo: 110,
+      locators: [],
       keySignature: { fifths: -3, mode: "minor" },
     }),
   },
@@ -174,12 +181,12 @@ function createPrintNotes() {
 function exportSample({
   notes,
   tempo,
-  locators = [],
+  locators,
   keySignature = { fifths: 0, mode: "major" },
 }: {
   notes: Note[];
   tempo: number;
-  locators?: Locator[];
+  locators: Locator[];
   keySignature?: KeySignature;
 }) {
   return exportMusicXml({

--- a/src/lib/score-viewer-samples.ts
+++ b/src/lib/score-viewer-samples.ts
@@ -1,4 +1,4 @@
-import type { Note } from "../types";
+import type { Locator, Note } from "../types";
 import { exportMusicXml } from "./musicxml-export";
 import type { KeySignature } from "./pitch-spelling";
 import { TAB_STRING_PRESETS } from "./tab-annotation";
@@ -121,6 +121,21 @@ export const SCORE_VIEWER_SAMPLES: ScoreViewerSample[] = [
       keySignature: { fifths: -3, mode: "minor" },
     }),
   },
+  {
+    id: "rehearsal-marks",
+    name: "Rehearsal marks",
+    description: "Boxed section labels at measure and mid-measure positions",
+    tempo: 120,
+    xml: exportSample({
+      tempo: 120,
+      notes: createSequentialNotes({ count: 32, duration: 0.5 }),
+      locators: [
+        createLocator({ position: 0, label: "A" }),
+        createLocator({ position: 6, label: "B" }),
+        createLocator({ position: 12, label: "C" }),
+      ],
+    }),
+  },
 ];
 
 function createSequentialNotes({
@@ -159,19 +174,26 @@ function createPrintNotes() {
 function exportSample({
   notes,
   tempo,
+  locators = [],
   keySignature = { fifths: 0, mode: "major" },
 }: {
   notes: Note[];
   tempo: number;
+  locators?: Locator[];
   keySignature?: KeySignature;
 }) {
   return exportMusicXml({
     keySignature,
     notes,
     tempo,
+    locators,
     openStringPitches: TAB_STRING_PRESETS[0].openStringPitches,
     timeSignature: { numerator: 4, denominator: 4 },
   });
+}
+
+function createLocator(locator: Omit<Locator, "id">): Locator {
+  return { ...locator, id: crypto.randomUUID() };
 }
 
 function createNote(note: Omit<Note, "id" | "velocity">): Note {


### PR DESCRIPTION
- part of https://github.com/hi-ogawa/toy-midi/issues/224

Toy MIDI locators isn't currently integrated with score viewer.

This PR exports locators as measure-local MusicXML rehearsal directions from both project export paths. The score viewer renders them through OSMD, includes a generated sample for visual review, and adds a Section labels control to hide or show all rehearsal marks. Locators beyond the final exported note remain outside the generated score and are ignored.