### PR TITLE
feat: render optional score titles

### DIFF
--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -46,6 +46,12 @@ test("opens the latest project state as a score in a new tab", async ({
     scorePage.getByTestId("score-viewer-renderer").locator("svg"),
   ).toBeVisible();
   await expect(scorePage.getByLabel("BPM")).toHaveValue("137");
+  const renderer = scorePage.getByTestId("score-viewer-renderer");
+  await expect(renderer.getByText("Untitled", { exact: true })).toHaveCount(0);
+  await scorePage.getByLabel("Title").selectOption("show");
+  await expect(renderer.getByText("Untitled", { exact: true })).toBeVisible();
+  await scorePage.getByLabel("Title").selectOption("hide");
+  await expect(renderer.getByText("Untitled", { exact: true })).toHaveCount(0);
   await expect(scorePage.getByRole("button", { name: "Samples" })).toHaveCount(
     0,
   );

--- a/e2e/settings-export.spec.ts
+++ b/e2e/settings-export.spec.ts
@@ -92,7 +92,6 @@ test.describe("Settings Dialog - Project Export", () => {
       xml,
     );
     expect(parseError).toBeNull();
-    expect(xml).toContain("<work-title>Untitled</work-title>");
     expect(xml).toContain("<staves>2</staves>");
     expect(xml).toContain("<sign>TAB</sign>");
     expect(xml).toContain("<string>4</string>");

--- a/e2e/settings-export.spec.ts
+++ b/e2e/settings-export.spec.ts
@@ -92,6 +92,7 @@ test.describe("Settings Dialog - Project Export", () => {
       xml,
     );
     expect(parseError).toBeNull();
+    expect(xml).toContain("<work-title>Untitled</work-title>");
     expect(xml).toContain("<staves>2</staves>");
     expect(xml).toContain("<sign>TAB</sign>");
     expect(xml).toContain("<string>4</string>");

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -140,12 +140,21 @@ export class ScoreViewerRuntime {
     });
   }
 
-  async load({ score, layout }: { score: ScoreSource; layout: ScoreLayout }) {
+  async load({
+    score,
+    layout,
+    showTitle,
+  }: {
+    score: ScoreSource;
+    layout: ScoreLayout;
+    showTitle: boolean;
+  }) {
     this.#clock.stop();
     this.#setState({ isReady: false });
 
     this.#osmd.clear();
     this.#osmd.setPageFormat(layout === "paged" ? "A4_P" : "Endless");
+    this.#osmd.setOptions({ drawTitle: showTitle });
     await this.#osmd.load(score.xml);
     this.#sheet.hidden = false;
     this.#osmd.render();

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -39,6 +39,7 @@ export function ScoreViewer({
 
   const [score, setScore] = useState<ScoreSource | undefined>(initialSource);
   const [layout, setLayout] = useState<ScoreLayout>("continuous");
+  const [showTitle, setShowTitle] = useState(false);
   const [isRuntimeAttached, setIsRuntimeAttached] = useState(false);
 
   // initialize runtime
@@ -76,16 +77,18 @@ export function ScoreViewer({
   const loadMutation = useMutation({
     mutationFn: async ({
       layout,
+      showTitle,
       source,
     }: {
       layout: ScoreLayout;
+      showTitle: boolean;
       source: File | ScoreSource;
     }) => {
       const nextScore =
         source instanceof File
           ? { name: source.name, xml: await source.text() }
           : source;
-      await runtime.load({ score: nextScore, layout });
+      await runtime.load({ score: nextScore, layout, showTitle });
       setScore(nextScore);
     },
   });
@@ -98,6 +101,7 @@ export function ScoreViewer({
     queryFn: async () => {
       loadMutation.mutate({
         layout,
+        showTitle,
         source: initialSource!,
       });
       return true;
@@ -112,6 +116,21 @@ export function ScoreViewer({
     if (score) {
       loadMutation.mutate({
         layout: nextLayout,
+        showTitle,
+        source: score,
+      });
+    }
+  }
+
+  function changeTitleVisible(visible: boolean) {
+    if (visible === showTitle) {
+      return;
+    }
+    setShowTitle(visible);
+    if (score) {
+      loadMutation.mutate({
+        layout,
+        showTitle: visible,
         source: score,
       });
     }
@@ -187,6 +206,21 @@ export function ScoreViewer({
               <option value="paged">Paged</option>
             </select>
           </label>
+
+          <label className="flex items-center gap-1.5 text-sm">
+            <span className="text-muted-foreground">Title</span>
+            <select
+              aria-label="Title"
+              value={showTitle ? "show" : "hide"}
+              onChange={(event) =>
+                changeTitleVisible(event.currentTarget.value === "show")
+              }
+              className="h-8 rounded border border-border bg-input px-2 text-sm text-foreground"
+            >
+              <option value="show">Show</option>
+              <option value="hide">Hide</option>
+            </select>
+          </label>
         </div>
 
         <div className="flex-1" />
@@ -207,7 +241,9 @@ export function ScoreViewer({
               accept=".musicxml,.xml,application/vnd.recordare.musicxml+xml"
               disabled={loadMutation.isPending}
               inputProps={{ "aria-label": "Open MusicXML" }}
-              onFile={(file) => loadMutation.mutate({ layout, source: file })}
+              onFile={(file) =>
+                loadMutation.mutate({ layout, showTitle, source: file })
+              }
               className="h-8 gap-1.5 px-3 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
             >
               <FolderOpenIcon className="size-4" />
@@ -227,6 +263,7 @@ export function ScoreViewer({
                     onSelect={() =>
                       loadMutation.mutate({
                         layout,
+                        showTitle,
                         source: { name: sample.name, xml: sample.xml },
                       })
                     }
@@ -271,7 +308,9 @@ export function ScoreViewer({
               accept=".musicxml,.xml,application/vnd.recordare.musicxml+xml"
               disabled={loadMutation.isPending}
               inputProps={{ "aria-label": "Upload MusicXML" }}
-              onFile={(file) => loadMutation.mutate({ layout, source: file })}
+              onFile={(file) =>
+                loadMutation.mutate({ layout, showTitle, source: file })
+              }
               className="group h-48 w-full max-w-4xl flex-col gap-3 rounded-sm border border-dashed border-neutral-500 bg-neutral-200/60 text-center text-neutral-700 shadow-none hover:border-neutral-700 hover:bg-neutral-100 hover:text-neutral-900 data-[drag-over=true]:border-blue-600 data-[drag-over=true]:bg-blue-50 data-[drag-over=true]:text-blue-900"
             >
               <span className="flex size-11 items-center justify-center rounded-full border border-neutral-400 bg-white shadow-sm group-data-[drag-over=true]:border-blue-400">

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -192,6 +192,7 @@ export function Settings({
       const xml = exportMusicXml({
         notes,
         tempo,
+        title: projectName,
         timeSignature,
         keySignature,
         openStringPitches: tabOpenStringPitches,

--- a/src/lib/__snapshots__/five-string-tab.musicxml
+++ b/src/lib/__snapshots__/five-string-tab.musicxml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="4.0">
+  <work>
+    <work-title>Rock &amp; Roll &lt;Bass&gt;</work-title>
+  </work>
   <part-list>
     <score-part id="P1">
       <score-instrument id="P1-I1">

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -32,6 +32,7 @@ function exportNotes(
     notes,
     locators: [],
     tempo: 120,
+    title: "Test Score",
     keySignature: { fifths: 0, mode: "major" },
     timeSignature: { numerator: 4, denominator: 4 },
     openStringPitches: FIVE_STRING_PITCHES,

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -60,6 +60,14 @@ describe("MusicXML export", () => {
     );
   });
 
+  it("exports an optional escaped score title", () => {
+    const xml = exportNotes([makeNote()], { title: "Rock & Roll <Bass>" });
+
+    expect(xml).toContain(
+      "<work-title>Rock &amp; Roll &lt;Bass&gt;</work-title>",
+    );
+  });
+
   it("preserves an explicit TAB string assignment", () => {
     const model = buildModel([makeNote({ tabString: 4 })]);
 

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -54,19 +54,11 @@ function buildModel(
 }
 
 describe("MusicXML export", () => {
-  it("exports synchronized standard and five-string TAB staves", async () => {
-    const xml = exportNotes([makeNote()]);
+  it("exports a title with synchronized standard and five-string TAB staves", async () => {
+    const xml = exportNotes([makeNote()], { title: "Rock & Roll <Bass>" });
 
     await expect(xml).toMatchFileSnapshot(
       "__snapshots__/five-string-tab.musicxml",
-    );
-  });
-
-  it("exports an optional escaped score title", () => {
-    const xml = exportNotes([makeNote()], { title: "Rock & Roll <Bass>" });
-
-    expect(xml).toContain(
-      "<work-title>Rock &amp; Roll &lt;Bass&gt;</work-title>",
     );
   });
 

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -54,7 +54,7 @@ function buildModel(
 }
 
 describe("MusicXML export", () => {
-  it("exports a title with synchronized standard and five-string TAB staves", async () => {
+  it("exports synchronized standard and five-string TAB staves", async () => {
     const xml = exportNotes([makeNote()], { title: "Rock & Roll <Bass>" });
 
     await expect(xml).toMatchFileSnapshot(

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -29,7 +29,7 @@ export type MusicXmlModelOptions = {
 
 export type MusicXmlExportOptions = MusicXmlModelOptions & {
   tempo: number;
-  title?: string;
+  title: string;
 };
 
 export type MusicXmlMeasure = {
@@ -418,7 +418,7 @@ export function exportMusicXml({
   const document = h(
     "score-partwise",
     { version: "4.0" },
-    title && hx("work", hx("work-title", title)),
+    hx("work", hx("work-title", title)),
     // TODO: Populate part and MIDI instrument metadata from Toy MIDI instrument
     // data instead of hard-coding Electric Bass when non-bass export is supported.
     hx(

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -28,6 +28,7 @@ export type MusicXmlModelOptions = {
 
 export type MusicXmlExportOptions = MusicXmlModelOptions & {
   tempo: number;
+  title?: string;
 };
 
 type QuantizedNote = {
@@ -317,6 +318,7 @@ function validateOpenStringPitches(pitches: readonly number[]): void {
 export function exportMusicXml({
   notes,
   tempo,
+  title,
   timeSignature,
   keySignature,
   openStringPitches,
@@ -372,11 +374,10 @@ export function exportMusicXml({
     ),
   ];
 
-  // TODO: Add optional <work-title> and <part-name> metadata when export naming
-  // is designed. Both are intentionally omitted for now.
   const document = h(
     "score-partwise",
     { version: "4.0" },
+    title && hx("work", hx("work-title", title)),
     // TODO: Populate part and MIDI instrument metadata from Toy MIDI instrument
     // data instead of hard-coding Electric Bass when non-bass export is supported.
     hx(

--- a/src/lib/project-score.ts
+++ b/src/lib/project-score.ts
@@ -28,6 +28,7 @@ function getProjectScoreSourceImpl(projectId: string): ProjectScoreResult {
         xml: exportMusicXml({
           notes: project.notes,
           tempo: project.tempo,
+          title: metadata.name,
           timeSignature: project.timeSignature,
           keySignature: project.keySignature,
           openStringPitches: project.tabOpenStringPitches,

--- a/src/lib/score-viewer-samples.ts
+++ b/src/lib/score-viewer-samples.ts
@@ -20,6 +20,7 @@ export const SCORE_VIEWER_SAMPLES: ScoreViewerSample[] = [
     description: "64 eighth notes at 120 BPM",
     tempo: 120,
     xml: exportSample({
+      title: "Cursor and wrapping",
       tempo: 120,
       locators: [],
       notes: createSequentialNotes({ count: 64, duration: 0.5 }),
@@ -31,6 +32,7 @@ export const SCORE_VIEWER_SAMPLES: ScoreViewerSample[] = [
     description: "Mixed durations, gaps, and a full-measure rest",
     tempo: 120,
     xml: exportSample({
+      title: "Rhythm and rests",
       tempo: 120,
       locators: [],
       notes: [
@@ -52,6 +54,7 @@ export const SCORE_VIEWER_SAMPLES: ScoreViewerSample[] = [
     description: "Durations split within and across measures",
     tempo: 120,
     xml: exportSample({
+      title: "Ties and barlines",
       tempo: 120,
       locators: [],
       notes: [
@@ -69,6 +72,7 @@ export const SCORE_VIEWER_SAMPLES: ScoreViewerSample[] = [
     description: "Open strings and explicit alternate-string frets",
     tempo: 120,
     xml: exportSample({
+      title: "TAB positions",
       tempo: 120,
       locators: [],
       notes: [
@@ -99,6 +103,7 @@ export const SCORE_VIEWER_SAMPLES: ScoreViewerSample[] = [
     description: "16th-note funk density at 110 BPM",
     tempo: 110,
     xml: exportSample({
+      title: "Dense sixteenths",
       tempo: 110,
       locators: [],
       notes: createSequentialNotes({ count: 96, duration: 0.25 }),
@@ -110,6 +115,7 @@ export const SCORE_VIEWER_SAMPLES: ScoreViewerSample[] = [
     description: "Fast cursor and following at 200 BPM",
     tempo: 200,
     xml: exportSample({
+      title: "Fast eighths",
       notes: createSequentialNotes({ count: 96, duration: 0.5 }),
       tempo: 200,
       locators: [],
@@ -122,6 +128,7 @@ export const SCORE_VIEWER_SAMPLES: ScoreViewerSample[] = [
     description: "64 measures of mixed eighths and sixteenths",
     tempo: 110,
     xml: exportSample({
+      title: "Long score",
       notes: createPrintNotes(),
       tempo: 110,
       locators: [],
@@ -134,6 +141,7 @@ export const SCORE_VIEWER_SAMPLES: ScoreViewerSample[] = [
     description: "Boxed section labels at measure and mid-measure positions",
     tempo: 120,
     xml: exportSample({
+      title: "Rehearsal marks",
       tempo: 120,
       notes: createSequentialNotes({ count: 32, duration: 0.5 }),
       locators: [
@@ -181,11 +189,13 @@ function createPrintNotes() {
 function exportSample({
   notes,
   tempo,
+  title,
   locators,
   keySignature = { fifths: 0, mode: "major" },
 }: {
   notes: Note[];
   tempo: number;
+  title: string;
   locators: Locator[];
   keySignature?: KeySignature;
 }) {
@@ -193,6 +203,7 @@ function exportSample({
     keySignature,
     notes,
     tempo,
+    title,
     locators,
     openStringPitches: TAB_STRING_PRESETS[0].openStringPitches,
     timeSignature: { numerator: 4, denominator: 4 },


### PR DESCRIPTION
- part of https://github.com/hi-ogawa/toy-midi/issues/224

Toy MIDI’s generated MusicXML currently has no score title metadata, so project scores cannot show their project name when viewed or printed.

This PR exports the project name as the MusicXML work title and adds a session-local Title control to the score viewer. Titles remain hidden by default, while enabling them affects both the interactive score and browser-printed output.