### PR TITLE
feat: support key changes in score export

### DIFF
--- a/src/lib/__snapshots__/five-string-tab.musicxml
+++ b/src/lib/__snapshots__/five-string-tab.musicxml
@@ -20,10 +20,6 @@
     <measure number="1">
       <attributes>
         <divisions>12</divisions>
-        <key>
-          <fifths>0</fifths>
-          <mode>major</mode>
-        </key>
         <time>
           <beats>4</beats>
           <beat-type>4</beat-type>
@@ -75,6 +71,12 @@
         <staff>1</staff>
         <sound tempo="120"/>
       </direction>
+      <attributes>
+        <key>
+          <fifths>0</fifths>
+          <mode>major</mode>
+        </key>
+      </attributes>
       <note>
         <pitch>
           <step>A</step>

--- a/src/lib/locators.ts
+++ b/src/lib/locators.ts
@@ -1,0 +1,60 @@
+import type { Locator } from "../types";
+import {
+  KEY_SIGNATURE_OPTION_GROUPS,
+  type KeySignature,
+} from "./pitch-spelling";
+
+export function parseLocatorLabel(locator: Locator): {
+  label: string;
+  keySignature?: KeySignature;
+} {
+  let keySignature: KeySignature | undefined;
+  const labelWithoutDirectives = locator.label.replace(
+    /\[!([a-z][a-z0-9-]*):\s*([^\]]*)\]/gi,
+    (_directive, name: string, value: string) => {
+      if (name.toLowerCase() !== "key") {
+        throw new Error(
+          `Unknown score directive ${name} in locator ${locator.id}`,
+        );
+      }
+      if (keySignature) {
+        throw new Error(
+          `Locator ${locator.id} has multiple key signature directives`,
+        );
+      }
+      keySignature = parseKeySignature(value, locator.id);
+      return "";
+    },
+  );
+  if (labelWithoutDirectives.includes("[!")) {
+    throw new Error(`Malformed score directive in locator ${locator.id}`);
+  }
+  const label = keySignature
+    ? labelWithoutDirectives.replace(/\s+/g, " ").trim()
+    : locator.label;
+  return { label, keySignature };
+}
+
+function parseKeySignature(value: string, locatorId: string): KeySignature {
+  const normalized = normalizeKeySignatureLabel(value);
+  for (const group of KEY_SIGNATURE_OPTION_GROUPS) {
+    const option = group.options.find(
+      (candidate) => normalizeKeySignatureLabel(candidate.label) === normalized,
+    );
+    if (option) {
+      return { fifths: option.fifths, mode: group.mode };
+    }
+  }
+  throw new Error(
+    `Unsupported key signature "${value.trim()}" in locator ${locatorId}`,
+  );
+}
+
+function normalizeKeySignatureLabel(value: string): string {
+  return value
+    .trim()
+    .replaceAll("♯", "#")
+    .replaceAll("♭", "b")
+    .replace(/\s+/g, " ")
+    .toLowerCase();
+}

--- a/src/lib/locators.ts
+++ b/src/lib/locators.ts
@@ -12,18 +12,18 @@ export function parseLocatorLabel(locator: Locator): {
   const labelWithoutDirectives = locator.label.replace(
     /\[!([a-z][a-z0-9-]*):\s*([^\]]*)\]/gi,
     (_directive, name: string, value: string) => {
-      if (name.toLowerCase() !== "key") {
-        throw new Error(
-          `Unknown score directive ${name} in locator ${locator.id}`,
-        );
+      if (name.toLowerCase() === "key") {
+        if (keySignature) {
+          throw new Error(
+            `Locator ${locator.id} has multiple key signature directives`,
+          );
+        }
+        keySignature = parseKeySignature(value, locator.id);
+        return "";
       }
-      if (keySignature) {
-        throw new Error(
-          `Locator ${locator.id} has multiple key signature directives`,
-        );
-      }
-      keySignature = parseKeySignature(value, locator.id);
-      return "";
+      throw new Error(
+        `Unknown score directive ${name} in locator ${locator.id}`,
+      );
     },
   );
   if (labelWithoutDirectives.includes("[!")) {

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -153,18 +153,22 @@ describe("MusicXML export", () => {
       locators: [{ label: "Last chorus", offset: 0 }],
     });
     expect(
-      model.measures.flatMap((measure) =>
+      model.measures.map((measure) =>
         measure.events
           .filter((event) => event.type === "note")
           .map((event) => event.pitch),
       ),
     ).toEqual([
-      // A# start in 1st bar in C major (non diatonic)
-      { step: "A", alter: 1, octave: 2 },
-      // Tied note in 2nd bar is still spelled A# though already in Gb major
-      { step: "A", alter: 1, octave: 2 },
-      // New note at the same pitch is now spelled as Bb in Gb major (diatonic)
-      { step: "B", alter: -1, octave: 2 },
+      [
+        // A# start in 1st bar in C major (non diatonic)
+        { step: "A", alter: 1, octave: 2 },
+      ],
+      [
+        // Tied note in 2nd bar is still spelled A# though already in Gb major
+        { step: "A", alter: 1, octave: 2 },
+        // New note at the same pitch is now spelled as Bb in Gb major (diatonic)
+        { step: "B", alter: -1, octave: 2 },
+      ],
     ]);
   });
 

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -172,7 +172,7 @@ describe("MusicXML export", () => {
     ]);
   });
 
-  it("uses a directive before trimmed measures as the initial score key", () => {
+  it("preserves a leading key directive measure", () => {
     const model = buildModel(
       [
         // Bb at bar 3
@@ -186,14 +186,14 @@ describe("MusicXML export", () => {
       },
     );
 
-    expect(model.measures.length).toBe(1);
+    expect(model.measures.length).toBe(2);
     expect(model.measures[0].keySignature).toEqual({
       fifths: -3,
       mode: "major",
     });
     expect(model.measures[0].locators).toEqual([]);
     expect(
-      model.measures[0].events.find((event) => event.type === "note"),
+      model.measures[1].events.find((event) => event.type === "note"),
     ).toMatchObject({
       type: "note",
       pitch: { step: "B", alter: -1, octave: 2 },

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -132,10 +132,14 @@ describe("MusicXML export", () => {
 
   it("applies an embedded key directive and preserves its rehearsal label", () => {
     const notes = [
+      // MIDI pitch 34 (A-sharp/B-flat 2)
+      // bar 1 beat 4.5 ties into bar 2
       makeNote({ id: "tied", pitch: 34, start: 3.5, duration: 1 }),
+      // bar 2 beat 2
       makeNote({ id: "after", pitch: 34, start: 5, duration: 1 }),
     ];
     const locators = [
+      // bar 2 in G-flat
       {
         id: "last-chorus",
         position: 4,
@@ -155,8 +159,11 @@ describe("MusicXML export", () => {
           .map((event) => event.pitch),
       ),
     ).toEqual([
+      // A# start in 1st bar in C major (non diatonic)
       { step: "A", alter: 1, octave: 2 },
+      // Tied note in 2nd bar is still spelled A# though already in Gb major
       { step: "A", alter: 1, octave: 2 },
+      // New note at the same pitch is now spelled as Bb in Gb major (diatonic)
       { step: "B", alter: -1, octave: 2 },
     ]);
   });

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -159,11 +159,6 @@ describe("MusicXML export", () => {
       { step: "A", alter: 1, octave: 2 },
       { step: "B", alter: -1, octave: 2 },
     ]);
-
-    const xml = exportNotes(notes, { locators });
-    expect(xml).toMatch(
-      /<measure number="2">[\s\S]*?<attributes>[\s\S]*?<fifths>-6<\/fifths>/,
-    );
   });
 
   it("uses a directive before trimmed measures as the initial score key", () => {

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -173,10 +173,20 @@ describe("MusicXML export", () => {
   });
 
   it("uses a directive before trimmed measures as the initial score key", () => {
-    const model = buildModel([makeNote({ pitch: 34, start: 12 })], {
-      locators: [{ id: "earlier-key", position: 8, label: "[!key: E♭ major]" }],
-    });
+    const model = buildModel(
+      [
+        // bar 3
+        makeNote({ pitch: 34, start: 12 }),
+      ],
+      {
+        locators: [
+          // bar 2
+          { id: "earlier-key", position: 8, label: "[!key: E♭ major]" },
+        ],
+      },
+    );
 
+    expect(model.measures.length).toBe(1);
     expect(model.measures[0].keySignature).toEqual({
       fifths: -3,
       mode: "major",

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -242,9 +242,7 @@ describe("MusicXML export", () => {
           { id: "second", position: 4, label: "[!key: Eb minor]" },
         ],
       }),
-    ).toThrow(
-      "Key signature locators first and second are at the same measure",
-    );
+    ).toThrow("Multiple key signature locators are at the same measure");
   });
 
   it("splits notes at bar lines and ties the pieces", () => {

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -129,6 +129,104 @@ describe("MusicXML export", () => {
     ).toThrow("position of locator section-a is not aligned");
   });
 
+  it("applies an embedded key directive and preserves its rehearsal label", () => {
+    const notes = [
+      makeNote({ id: "tied", pitch: 34, start: 3.5, duration: 1 }),
+      makeNote({ id: "after", pitch: 34, start: 5, duration: 1 }),
+    ];
+    const locators = [
+      {
+        id: "last-chorus",
+        position: 4,
+        label: "Last chorus [!key: Gb major]",
+      },
+    ];
+    const model = buildModel(notes, { locators });
+
+    expect(model.measures[1]).toMatchObject({
+      keySignature: { fifths: -6, mode: "major" },
+      locators: [{ label: "Last chorus", offset: 0 }],
+    });
+    expect(
+      model.measures.flatMap((measure) =>
+        measure.events
+          .filter((event) => event.type === "note")
+          .map((event) => event.pitch),
+      ),
+    ).toEqual([
+      { step: "A", alter: 1, octave: 2 },
+      { step: "A", alter: 1, octave: 2 },
+      { step: "B", alter: -1, octave: 2 },
+    ]);
+
+    const xml = exportNotes(notes, { locators });
+    expect(xml).toMatch(
+      /<measure number="2">[\s\S]*?<attributes>[\s\S]*?<fifths>-6<\/fifths>/,
+    );
+  });
+
+  it("uses a directive before trimmed measures as the initial score key", () => {
+    const model = buildModel([makeNote({ pitch: 34, start: 12 })], {
+      locators: [{ id: "earlier-key", position: 8, label: "[!key: E♭ major]" }],
+    });
+
+    expect(model.initialKeySignature).toEqual({ fifths: -3, mode: "major" });
+    expect(model.measures[0].locators).toEqual([]);
+    expect(
+      model.measures[0].events.find((event) => event.type === "note"),
+    ).toMatchObject({
+      type: "note",
+      pitch: { step: "B", alter: -1, octave: 2 },
+    });
+  });
+
+  it.each([
+    {
+      label: "[!key: F# major]",
+      position: 0,
+      error: "must be after beat 0",
+    },
+    {
+      label: "[!key: F# major]",
+      position: 2,
+      error: "must be at the start of a measure",
+    },
+    {
+      label: "[!tempo: 120]",
+      position: 4,
+      error: "Unknown score directive tempo",
+    },
+    {
+      label: "[!key F# major]",
+      position: 4,
+      error: "Malformed score directive",
+    },
+    {
+      label: "[!key: D# major]",
+      position: 4,
+      error: 'Unsupported key signature "D# major"',
+    },
+  ])("rejects invalid score directive $label", ({ label, position, error }) => {
+    expect(() =>
+      buildModel([makeNote({ duration: 8 })], {
+        locators: [{ id: "invalid", position, label }],
+      }),
+    ).toThrow(error);
+  });
+
+  it("rejects multiple key directives at one measure", () => {
+    expect(() =>
+      buildModel([makeNote({ duration: 8 })], {
+        locators: [
+          { id: "first", position: 4, label: "[!key: F# major]" },
+          { id: "second", position: 4, label: "[!key: Eb minor]" },
+        ],
+      }),
+    ).toThrow(
+      "Key signature locators first and second are at the same measure",
+    );
+  });
+
   it("splits notes at bar lines and ties the pieces", () => {
     const model = buildModel([makeNote({ start: 3.5, duration: 1 })]);
 

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -175,7 +175,7 @@ describe("MusicXML export", () => {
   it("uses a directive before trimmed measures as the initial score key", () => {
     const model = buildModel(
       [
-        // bar 3
+        // Bb at bar 3
         makeNote({ pitch: 34, start: 12 }),
       ],
       {

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -171,7 +171,10 @@ describe("MusicXML export", () => {
       locators: [{ id: "earlier-key", position: 8, label: "[!key: E♭ major]" }],
     });
 
-    expect(model.initialKeySignature).toEqual({ fifths: -3, mode: "major" });
+    expect(model.measures[0].keySignature).toEqual({
+      fifths: -3,
+      mode: "major",
+    });
     expect(model.measures[0].locators).toEqual([]);
     expect(
       model.measures[0].events.find((event) => event.type === "note"),

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -357,23 +357,18 @@ function buildLocatorsByMeasure({
   measureCount: number;
   measureDuration: number;
 }): MusicXmlMeasure["locators"][] {
-  const result: MusicXmlMeasure["locators"][] = range(measureCount).map(
-    () => [],
+  return range(measureCount).map((measureIndex) =>
+    locators
+      .filter(
+        (locator) =>
+          locator.label !== "" &&
+          Math.floor(locator.position / measureDuration) === measureIndex,
+      )
+      .map((locator) => ({
+        label: locator.label,
+        offset: locator.position - measureIndex * measureDuration,
+      })),
   );
-  for (const locator of locators) {
-    if (locator.label === "") {
-      continue;
-    }
-    const measureIndex = Math.floor(locator.position / measureDuration);
-    if (measureIndex < 0 || measureIndex >= measureCount) {
-      continue;
-    }
-    result[measureIndex].push({
-      label: locator.label,
-      offset: locator.position - measureIndex * measureDuration,
-    });
-  }
-  return result;
 }
 
 /** Clips notes to one measure and fills its timeline with notated notes and rests. */

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -53,7 +53,7 @@ type QuantizedNote = PreparedNote & {
 type PreparedLocator = {
   id: string;
   position: number;
-  label?: string;
+  label: string;
   keySignature?: KeySignature;
 };
 
@@ -280,7 +280,7 @@ function prepareLocators({
 }
 
 function parseLocatorLabel(locator: Locator): {
-  label?: string;
+  label: string;
   keySignature?: KeySignature;
 } {
   let keySignature: KeySignature | undefined;
@@ -307,7 +307,7 @@ function parseLocatorLabel(locator: Locator): {
   const label = keySignature
     ? labelWithoutDirectives.replace(/\s+/g, " ").trim()
     : locator.label;
-  return { label: label || undefined, keySignature };
+  return { label, keySignature };
 }
 
 function parseKeySignature(value: string, locatorId: string): KeySignature {
@@ -346,10 +346,7 @@ function buildMeasureLocators({
   measureDuration: number;
 }): MusicXmlMeasure["locators"] {
   return locators
-    .filter(
-      (locator): locator is PreparedLocator & { label: string } =>
-        locator.label !== undefined,
-    )
+    .filter((locator) => locator.label !== "")
     .map((locator) => ({
       label: locator.label,
       offset: locator.position - firstMeasureStart - measureStart,

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -201,36 +201,6 @@ export function buildMusicXmlModel({
   };
 }
 
-function buildMeasureKeySignatures({
-  initialKeySignature,
-  events,
-  firstMeasureStart,
-  measureCount,
-  measureDuration,
-}: {
-  initialKeySignature: KeySignature;
-  events: KeySignatureEvent[];
-  firstMeasureStart: number;
-  measureCount: number;
-  measureDuration: number;
-}): MeasureKeySignature[] {
-  let active = initialKeySignature;
-  let eventIndex = 0;
-  return Array.from({ length: measureCount }, (_, measureIndex) => {
-    const position = firstMeasureStart + measureIndex * measureDuration;
-    let emit = false;
-    while (events[eventIndex]?.position <= position) {
-      const event = events[eventIndex];
-      active = event.keySignature;
-      if (event.position === position) {
-        emit = true;
-      }
-      eventIndex++;
-    }
-    return { active, emit: measureIndex === 0 || emit };
-  });
-}
-
 function prepareLocators({
   locators,
   measureDuration,
@@ -273,6 +243,36 @@ function prepareLocators({
     preparedLocators.push({ id: locator.id, position, ...parsed });
   }
   return { preparedLocators, keySignatureEvents };
+}
+
+function buildMeasureKeySignatures({
+  initialKeySignature,
+  events,
+  firstMeasureStart,
+  measureCount,
+  measureDuration,
+}: {
+  initialKeySignature: KeySignature;
+  events: KeySignatureEvent[];
+  firstMeasureStart: number;
+  measureCount: number;
+  measureDuration: number;
+}): MeasureKeySignature[] {
+  let active = initialKeySignature;
+  let eventIndex = 0;
+  return Array.from({ length: measureCount }, (_, measureIndex) => {
+    const position = firstMeasureStart + measureIndex * measureDuration;
+    let emit = false;
+    while (events[eventIndex]?.position <= position) {
+      const event = events[eventIndex];
+      active = event.keySignature;
+      if (event.position === position) {
+        emit = true;
+      }
+      eventIndex++;
+    }
+    return { active, emit: measureIndex === 0 || emit };
+  });
 }
 
 function buildMeasureLocators({

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -248,10 +248,8 @@ function buildKeySignaturesByMeasure({
   measureCount: number;
   measureDuration: number;
 }): MeasureKeySignature[] {
-  const eventsByMeasure = Array.from(
-    { length: measureCount },
-    (_, measureIndex) =>
-      events.find((event) => event.position / measureDuration === measureIndex),
+  const eventsByMeasure = range(measureCount).map((measureIndex) =>
+    events.find((event) => event.position / measureDuration === measureIndex),
   );
   const result: MeasureKeySignature[] = [];
   for (let index = 0; index < measureCount; index++) {
@@ -277,9 +275,8 @@ function buildLocatorsByMeasure({
   measureCount: number;
   measureDuration: number;
 }): MusicXmlMeasure["locators"][] {
-  const result = Array.from(
-    { length: measureCount },
-    () => [] as MusicXmlMeasure["locators"],
+  const result: MusicXmlMeasure["locators"][] = range(measureCount).map(
+    () => [],
   );
   for (const locator of locators) {
     if (locator.label === "") {
@@ -308,10 +305,7 @@ function buildNotesByMeasure({
   measureCount: number;
   measureDuration: number;
 }): QuantizedNote[][] {
-  const result = Array.from(
-    { length: measureCount },
-    () => [] as QuantizedNote[],
-  );
+  const result: QuantizedNote[][] = range(measureCount).map(() => []);
   // Spell each note in the key where it begins, then assign it to every
   // measure it spans so tied segments retain the original spelling.
   for (const note of notes) {
@@ -492,6 +486,10 @@ function toGridUnits(value: number, label: string): number {
     throw new Error(`${label} is not aligned to a supported grid`);
   }
   return units;
+}
+
+function range(length: number): number[] {
+  return [...Array(length).keys()];
 }
 
 /** Validates a non-empty tuning of MIDI note numbers. */

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -257,7 +257,8 @@ function buildMeasureKeySignatures({
 }): MeasureKeySignature[] {
   let active = initialKeySignature;
   let eventIndex = 0;
-  return Array.from({ length: measureCount }, (_, measureIndex) => {
+  const result: MeasureKeySignature[] = [];
+  for (let measureIndex = 0; measureIndex < measureCount; measureIndex++) {
     const position = firstMeasureStart + measureIndex * measureDuration;
     let emit = false;
     while (events[eventIndex]?.position <= position) {
@@ -268,8 +269,9 @@ function buildMeasureKeySignatures({
       }
       eventIndex++;
     }
-    return { active, emit: measureIndex === 0 || emit };
-  });
+    result.push({ active, emit: measureIndex === 0 || emit });
+  }
+  return result;
 }
 
 function buildMeasureLocators({

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -128,26 +128,37 @@ export function buildMusicXmlModel({
     "time signature",
   );
   const preparedNotes = prepareNotes({ notes, openStringPitches });
-  // Trim empty leading measures and rebase notes to the exported score.
+  const { preparedLocators, keySignatureEvents } = prepareLocators({
+    locators,
+    measureDuration,
+  });
+  // Trim empty leading measures and rebase score items to the exported score.
+  const firstPosition = Math.min(
+    preparedNotes[0].start,
+    preparedLocators[0]?.position ?? Infinity,
+  );
   const firstMeasureStart =
-    Math.floor(preparedNotes[0].start / measureDuration) * measureDuration;
+    Math.floor(firstPosition / measureDuration) * measureDuration;
   const quantizedNotes = preparedNotes.map((note) => ({
     ...note,
     start: note.start - firstMeasureStart,
     end: note.end - firstMeasureStart,
   }));
+  const quantizedLocators = preparedLocators.map((locator) => ({
+    ...locator,
+    position: locator.position - firstMeasureStart,
+  }));
+  const quantizedKeySignatureEvents = keySignatureEvents.map((event) => ({
+    ...event,
+    position: event.position - firstMeasureStart,
+  }));
   const measureCount = Math.ceil(
     quantizedNotes[quantizedNotes.length - 1].end / measureDuration,
   );
   // Resolve the active key signature for every exported measure.
-  const { preparedLocators, keySignatureEvents } = prepareLocators({
-    locators,
-    measureDuration,
-  });
   const keySignaturesByMeasure = buildMeasureKeySignatures({
     initialKeySignature: keySignature,
-    events: keySignatureEvents,
-    firstMeasureStart,
+    events: quantizedKeySignatureEvents,
     measureCount,
     measureDuration,
   });
@@ -185,8 +196,7 @@ export function buildMusicXmlModel({
           measureDuration,
         }),
         locators: buildMeasureLocators({
-          locators: preparedLocators,
-          firstMeasureStart,
+          locators: quantizedLocators,
           measureStart,
           measureDuration,
         }),
@@ -245,13 +255,11 @@ function prepareLocators({
 function buildMeasureKeySignatures({
   initialKeySignature,
   events,
-  firstMeasureStart,
   measureCount,
   measureDuration,
 }: {
   initialKeySignature: KeySignature;
   events: KeySignatureEvent[];
-  firstMeasureStart: number;
   measureCount: number;
   measureDuration: number;
 }): MeasureKeySignature[] {
@@ -259,7 +267,7 @@ function buildMeasureKeySignatures({
   let eventIndex = 0;
   const result: MeasureKeySignature[] = [];
   for (let measureIndex = 0; measureIndex < measureCount; measureIndex++) {
-    const position = firstMeasureStart + measureIndex * measureDuration;
+    const position = measureIndex * measureDuration;
     let emit = false;
     while (events[eventIndex]?.position <= position) {
       const event = events[eventIndex];
@@ -276,12 +284,10 @@ function buildMeasureKeySignatures({
 
 function buildMeasureLocators({
   locators,
-  firstMeasureStart,
   measureStart,
   measureDuration,
 }: {
   locators: PreparedLocator[];
-  firstMeasureStart: number;
   measureStart: number;
   measureDuration: number;
 }): MusicXmlMeasure["locators"] {
@@ -289,7 +295,7 @@ function buildMeasureLocators({
     .filter((locator) => locator.label !== "")
     .map((locator) => ({
       label: locator.label,
-      offset: locator.position - firstMeasureStart - measureStart,
+      offset: locator.position - measureStart,
     }))
     .filter(({ offset }) => offset >= 0 && offset < measureDuration)
     .sort((a, b) => a.offset - b.offset);

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -193,6 +193,88 @@ export function buildMusicXmlModel({
   };
 }
 
+/** Quantizes notes, resolves TAB positions, orders them, and rejects polyphony. */
+function prepareNotes({
+  notes,
+  openStringPitches,
+}: {
+  notes: Note[];
+  openStringPitches: readonly number[];
+}): PreparedNote[] {
+  const result = notes
+    .map((note) => {
+      const start = toGridUnits(note.start, `start of note ${note.id}`);
+      const duration = toGridUnits(
+        note.duration,
+        `duration of note ${note.id}`,
+      );
+      if (start < 0) {
+        throw new Error(`Note ${note.id} starts before beat 0`);
+      }
+      if (duration <= 0) {
+        throw new Error(`Note ${note.id} must have a positive duration`);
+      }
+      const tabPosition = resolveTabPosition({
+        pitch: note.pitch,
+        openStringPitches,
+        tabString: note.tabString,
+      });
+      if (!tabPosition) {
+        throw new Error(
+          `MIDI note ${note.pitch} is not playable on a ${openStringPitches.length}-string bass`,
+        );
+      }
+      return { note, start, end: start + duration, tabPosition };
+    })
+    .sort((a, b) => a.start - b.start || a.note.pitch - b.note.pitch);
+
+  // TODO: Support strict chords first. Partial overlaps can be authored as split
+  // monophonic notes, but simultaneous notes cannot be represented without
+  // MusicXML <chord/>. Group identical start/end times, assign distinct TAB
+  // strings, and leave unequal-duration overlaps for future voice scheduling.
+  for (let index = 1; index < result.length; index++) {
+    if (result[index].start < result[index - 1].end) {
+      throw new Error(
+        `Polyphonic or overlapping notes ${result[index - 1].note.id} and ${result[index].note.id} are not supported`,
+      );
+    }
+  }
+  return result;
+}
+
+function buildNotesByMeasure({
+  notes,
+  keySignaturesByMeasure,
+  measureCount,
+  measureDuration,
+}: {
+  notes: PreparedNote[];
+  keySignaturesByMeasure: MeasureKeySignature[];
+  measureCount: number;
+  measureDuration: number;
+}): QuantizedNote[][] {
+  const result: QuantizedNote[][] = range(measureCount).map(() => []);
+  // Spell each note in the key where it begins, then assign it to every
+  // measure it spans so tied segments retain the original spelling.
+  for (const note of notes) {
+    const firstMeasure = Math.floor(note.start / measureDuration);
+    const lastMeasure = Math.ceil(note.end / measureDuration) - 1;
+    const quantizedNote: QuantizedNote = {
+      ...note,
+      pitch: toWrittenBassPitch(
+        spellMidiPitch({
+          pitch: note.note.pitch,
+          keySignature: keySignaturesByMeasure[firstMeasure].active,
+        }),
+      ),
+    };
+    for (let index = firstMeasure; index <= lastMeasure; index++) {
+      result[index].push(quantizedNote);
+    }
+  }
+  return result;
+}
+
 function prepareLocators({
   locators,
   measureDuration,
@@ -290,88 +372,6 @@ function buildLocatorsByMeasure({
       label: locator.label,
       offset: locator.position - measureIndex * measureDuration,
     });
-  }
-  return result;
-}
-
-function buildNotesByMeasure({
-  notes,
-  keySignaturesByMeasure,
-  measureCount,
-  measureDuration,
-}: {
-  notes: PreparedNote[];
-  keySignaturesByMeasure: MeasureKeySignature[];
-  measureCount: number;
-  measureDuration: number;
-}): QuantizedNote[][] {
-  const result: QuantizedNote[][] = range(measureCount).map(() => []);
-  // Spell each note in the key where it begins, then assign it to every
-  // measure it spans so tied segments retain the original spelling.
-  for (const note of notes) {
-    const firstMeasure = Math.floor(note.start / measureDuration);
-    const lastMeasure = Math.ceil(note.end / measureDuration) - 1;
-    const quantizedNote: QuantizedNote = {
-      ...note,
-      pitch: toWrittenBassPitch(
-        spellMidiPitch({
-          pitch: note.note.pitch,
-          keySignature: keySignaturesByMeasure[firstMeasure].active,
-        }),
-      ),
-    };
-    for (let index = firstMeasure; index <= lastMeasure; index++) {
-      result[index].push(quantizedNote);
-    }
-  }
-  return result;
-}
-
-/** Quantizes notes, resolves TAB positions, orders them, and rejects polyphony. */
-function prepareNotes({
-  notes,
-  openStringPitches,
-}: {
-  notes: Note[];
-  openStringPitches: readonly number[];
-}): PreparedNote[] {
-  const result = notes
-    .map((note) => {
-      const start = toGridUnits(note.start, `start of note ${note.id}`);
-      const duration = toGridUnits(
-        note.duration,
-        `duration of note ${note.id}`,
-      );
-      if (start < 0) {
-        throw new Error(`Note ${note.id} starts before beat 0`);
-      }
-      if (duration <= 0) {
-        throw new Error(`Note ${note.id} must have a positive duration`);
-      }
-      const tabPosition = resolveTabPosition({
-        pitch: note.pitch,
-        openStringPitches,
-        tabString: note.tabString,
-      });
-      if (!tabPosition) {
-        throw new Error(
-          `MIDI note ${note.pitch} is not playable on a ${openStringPitches.length}-string bass`,
-        );
-      }
-      return { note, start, end: start + duration, tabPosition };
-    })
-    .sort((a, b) => a.start - b.start || a.note.pitch - b.note.pitch);
-
-  // TODO: Support strict chords first. Partial overlaps can be authored as split
-  // monophonic notes, but simultaneous notes cannot be represented without
-  // MusicXML <chord/>. Group identical start/end times, assign distinct TAB
-  // strings, and leave unequal-duration overlaps for future voice scheduling.
-  for (let index = 1; index < result.length; index++) {
-    if (result[index].start < result[index - 1].end) {
-      throw new Error(
-        `Polyphonic or overlapping notes ${result[index - 1].note.id} and ${result[index].note.id} are not supported`,
-      );
-    }
   }
   return result;
 }

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -62,6 +62,11 @@ type KeySignatureEvent = {
   keySignature: KeySignature;
 };
 
+type MeasureKeySignature = {
+  active: KeySignature;
+  declaration?: KeySignature;
+};
+
 export type MusicXmlMeasureEvent =
   | { type: "rest"; duration: number; notation: DurationNotation }
   | {
@@ -139,21 +144,7 @@ export function buildMusicXmlModel({
       keySignature,
     }))
     .sort((a, b) => a.position - b.position);
-  const preparedNotes = prepareNotes({ notes, openStringPitches }).map(
-    (note): QuantizedNote => ({
-      ...note,
-      pitch: toWrittenBassPitch(
-        spellMidiPitch({
-          pitch: note.note.pitch,
-          keySignature: resolveKeySignature({
-            initialKeySignature: keySignature,
-            events: keySignatureEvents,
-            position: note.start,
-          }),
-        }),
-      ),
-    }),
-  );
+  const preparedNotes = prepareNotes({ notes, openStringPitches });
   const firstMeasureStart =
     Math.floor(preparedNotes[0].start / measureDuration) * measureDuration;
   const quantizedNotes = preparedNotes.map((note) => ({
@@ -164,6 +155,13 @@ export function buildMusicXmlModel({
   const measureCount = Math.ceil(
     quantizedNotes[quantizedNotes.length - 1].end / measureDuration,
   );
+  const keySignaturesByMeasure = buildMeasureKeySignatures({
+    initialKeySignature: keySignature,
+    events: keySignatureEvents,
+    firstMeasureStart,
+    measureCount,
+    measureDuration,
+  });
   const notesByMeasure = Array.from(
     { length: measureCount },
     () => [] as QuantizedNote[],
@@ -171,18 +169,23 @@ export function buildMusicXmlModel({
   for (const note of quantizedNotes) {
     const firstMeasure = Math.floor(note.start / measureDuration);
     const lastMeasure = Math.ceil(note.end / measureDuration) - 1;
+    const quantizedNote: QuantizedNote = {
+      ...note,
+      pitch: toWrittenBassPitch(
+        spellMidiPitch({
+          pitch: note.note.pitch,
+          keySignature: keySignaturesByMeasure[firstMeasure].active,
+        }),
+      ),
+    };
     for (let index = firstMeasure; index <= lastMeasure; index++) {
-      notesByMeasure[index].push(note);
+      notesByMeasure[index].push(quantizedNote);
     }
   }
   return {
     measureDuration,
     measures: notesByMeasure.map((notes, index) => {
       const measureStart = index * measureDuration;
-      const projectMeasureStart = firstMeasureStart + measureStart;
-      const keySignatureEvent = keySignatureEvents.find(
-        (event) => event.position === projectMeasureStart,
-      );
       return {
         events: buildMeasureEvents({
           notes,
@@ -195,17 +198,43 @@ export function buildMusicXmlModel({
           measureStart,
           measureDuration,
         }),
-        keySignature:
-          index === 0
-            ? resolveKeySignature({
-                initialKeySignature: keySignature,
-                events: keySignatureEvents,
-                position: projectMeasureStart,
-              })
-            : keySignatureEvent?.keySignature,
+        keySignature: keySignaturesByMeasure[index].declaration,
       };
     }),
   };
+}
+
+function buildMeasureKeySignatures({
+  initialKeySignature,
+  events,
+  firstMeasureStart,
+  measureCount,
+  measureDuration,
+}: {
+  initialKeySignature: KeySignature;
+  events: KeySignatureEvent[];
+  firstMeasureStart: number;
+  measureCount: number;
+  measureDuration: number;
+}): MeasureKeySignature[] {
+  let active = initialKeySignature;
+  let eventIndex = 0;
+  return Array.from({ length: measureCount }, (_, measureIndex) => {
+    const position = firstMeasureStart + measureIndex * measureDuration;
+    let declaration: KeySignature | undefined;
+    while (events[eventIndex]?.position <= position) {
+      const event = events[eventIndex];
+      active = event.keySignature;
+      if (event.position === position) {
+        declaration = active;
+      }
+      eventIndex++;
+    }
+    if (measureIndex === 0) {
+      return { active, declaration: active };
+    }
+    return declaration ? { active, declaration } : { active };
+  });
 }
 
 function prepareLocators({
@@ -303,22 +332,6 @@ function normalizeKeySignatureLabel(value: string): string {
     .replaceAll("♭", "b")
     .replace(/\s+/g, " ")
     .toLowerCase();
-}
-
-function resolveKeySignature({
-  initialKeySignature,
-  events,
-  position,
-}: {
-  initialKeySignature: KeySignature;
-  events: KeySignatureEvent[];
-  position: number;
-}): KeySignature {
-  return events.reduce(
-    (keySignature, event) =>
-      event.position <= position ? event.keySignature : keySignature,
-    initialKeySignature,
-  );
 }
 
 function buildMeasureLocators({

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -64,7 +64,7 @@ type KeySignatureEvent = {
 
 type MeasureKeySignature = {
   active: KeySignature;
-  declaration?: KeySignature;
+  emit: boolean;
 };
 
 export type MusicXmlMeasureEvent =
@@ -186,6 +186,7 @@ export function buildMusicXmlModel({
     measureDuration,
     measures: notesByMeasure.map((notes, index) => {
       const measureStart = index * measureDuration;
+      const measureKeySignature = keySignaturesByMeasure[index];
       return {
         events: buildMeasureEvents({
           notes,
@@ -198,7 +199,9 @@ export function buildMusicXmlModel({
           measureStart,
           measureDuration,
         }),
-        keySignature: keySignaturesByMeasure[index].declaration,
+        keySignature: measureKeySignature.emit
+          ? measureKeySignature.active
+          : undefined,
       };
     }),
   };
@@ -221,19 +224,16 @@ function buildMeasureKeySignatures({
   let eventIndex = 0;
   return Array.from({ length: measureCount }, (_, measureIndex) => {
     const position = firstMeasureStart + measureIndex * measureDuration;
-    let declaration: KeySignature | undefined;
+    let emit = false;
     while (events[eventIndex]?.position <= position) {
       const event = events[eventIndex];
       active = event.keySignature;
       if (event.position === position) {
-        declaration = active;
+        emit = true;
       }
       eventIndex++;
     }
-    if (measureIndex === 0) {
-      return { active, declaration: active };
-    }
-    return declaration ? { active, declaration } : { active };
+    return { active, emit: measureIndex === 0 || emit };
   });
 }
 

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -50,10 +50,7 @@ type QuantizedNote = PreparedNote & {
   pitch: SpelledPitch;
 };
 
-type PreparedLocator = {
-  id: string;
-  position: number;
-  label: string;
+type PreparedLocator = Locator & {
   keySignature?: KeySignature;
 };
 

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -156,34 +156,23 @@ export function buildMusicXmlModel({
     quantizedNotes[quantizedNotes.length - 1].end / measureDuration,
   );
   // Resolve the active key signature for every exported measure.
-  const keySignaturesByMeasure = buildMeasureKeySignatures({
+  const keySignaturesByMeasure = buildKeySignaturesByMeasure({
     initialKeySignature: keySignature,
     events: quantizedKeySignatureEvents,
     measureCount,
     measureDuration,
   });
-  // Spell each note in the key where it begins, then assign it to every
-  // measure it spans so tied segments retain the original spelling.
-  const notesByMeasure = Array.from(
-    { length: measureCount },
-    () => [] as QuantizedNote[],
-  );
-  for (const note of quantizedNotes) {
-    const firstMeasure = Math.floor(note.start / measureDuration);
-    const lastMeasure = Math.ceil(note.end / measureDuration) - 1;
-    const quantizedNote: QuantizedNote = {
-      ...note,
-      pitch: toWrittenBassPitch(
-        spellMidiPitch({
-          pitch: note.note.pitch,
-          keySignature: keySignaturesByMeasure[firstMeasure].active,
-        }),
-      ),
-    };
-    for (let index = firstMeasure; index <= lastMeasure; index++) {
-      notesByMeasure[index].push(quantizedNote);
-    }
-  }
+  const locatorsByMeasure = buildLocatorsByMeasure({
+    locators: quantizedLocators,
+    measureCount,
+    measureDuration,
+  });
+  const notesByMeasure = buildNotesByMeasure({
+    notes: quantizedNotes,
+    keySignaturesByMeasure,
+    measureCount,
+    measureDuration,
+  });
   return {
     measureDuration,
     measures: notesByMeasure.map((notes, index) => {
@@ -195,11 +184,7 @@ export function buildMusicXmlModel({
           measureStart,
           measureDuration,
         }),
-        locators: buildMeasureLocators({
-          locators: quantizedLocators,
-          measureStart,
-          measureDuration,
-        }),
+        locators: locatorsByMeasure[index],
         keySignature: measureKeySignature.emit
           ? measureKeySignature.active
           : undefined,
@@ -252,7 +237,7 @@ function prepareLocators({
   return { preparedLocators, keySignatureEvents };
 }
 
-function buildMeasureKeySignatures({
+function buildKeySignaturesByMeasure({
   initialKeySignature,
   events,
   measureCount,
@@ -282,23 +267,69 @@ function buildMeasureKeySignatures({
   return result;
 }
 
-function buildMeasureLocators({
+function buildLocatorsByMeasure({
   locators,
-  measureStart,
+  measureCount,
   measureDuration,
 }: {
   locators: PreparedLocator[];
-  measureStart: number;
+  measureCount: number;
   measureDuration: number;
-}): MusicXmlMeasure["locators"] {
-  return locators
-    .filter((locator) => locator.label !== "")
-    .map((locator) => ({
+}): MusicXmlMeasure["locators"][] {
+  const result = Array.from(
+    { length: measureCount },
+    () => [] as MusicXmlMeasure["locators"],
+  );
+  for (const locator of locators) {
+    if (locator.label === "") {
+      continue;
+    }
+    const measureIndex = Math.floor(locator.position / measureDuration);
+    if (measureIndex < 0 || measureIndex >= measureCount) {
+      continue;
+    }
+    result[measureIndex].push({
       label: locator.label,
-      offset: locator.position - measureStart,
-    }))
-    .filter(({ offset }) => offset >= 0 && offset < measureDuration)
-    .sort((a, b) => a.offset - b.offset);
+      offset: locator.position - measureIndex * measureDuration,
+    });
+  }
+  return result;
+}
+
+function buildNotesByMeasure({
+  notes,
+  keySignaturesByMeasure,
+  measureCount,
+  measureDuration,
+}: {
+  notes: PreparedNote[];
+  keySignaturesByMeasure: MeasureKeySignature[];
+  measureCount: number;
+  measureDuration: number;
+}): QuantizedNote[][] {
+  const result = Array.from(
+    { length: measureCount },
+    () => [] as QuantizedNote[],
+  );
+  // Spell each note in the key where it begins, then assign it to every
+  // measure it spans so tied segments retain the original spelling.
+  for (const note of notes) {
+    const firstMeasure = Math.floor(note.start / measureDuration);
+    const lastMeasure = Math.ceil(note.end / measureDuration) - 1;
+    const quantizedNote: QuantizedNote = {
+      ...note,
+      pitch: toWrittenBassPitch(
+        spellMidiPitch({
+          pitch: note.note.pitch,
+          keySignature: keySignaturesByMeasure[firstMeasure].active,
+        }),
+      ),
+    };
+    for (let index = firstMeasure; index <= lastMeasure; index++) {
+      result[index].push(quantizedNote);
+    }
+  }
+  return result;
 }
 
 /** Quantizes notes, resolves TAB positions, orders them, and rejects polyphony. */

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -131,6 +131,7 @@ export function buildMusicXmlModel({
     "time signature",
   );
   const preparedNotes = prepareNotes({ notes, openStringPitches });
+  // todo: comment
   const firstMeasureStart =
     Math.floor(preparedNotes[0].start / measureDuration) * measureDuration;
   const quantizedNotes = preparedNotes.map((note) => ({
@@ -141,6 +142,7 @@ export function buildMusicXmlModel({
   const measureCount = Math.ceil(
     quantizedNotes[quantizedNotes.length - 1].end / measureDuration,
   );
+  // todo comment
   const preparedLocators = prepareLocators({ locators, measureDuration });
   const keySignatureEvents = preparedLocators
     .filter(
@@ -162,6 +164,7 @@ export function buildMusicXmlModel({
     measureCount,
     measureDuration,
   });
+  // todo comment
   const notesByMeasure = Array.from(
     { length: measureCount },
     () => [] as QuantizedNote[],

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -248,21 +248,22 @@ function buildKeySignaturesByMeasure({
   measureCount: number;
   measureDuration: number;
 }): MeasureKeySignature[] {
-  let active = initialKeySignature;
-  let eventIndex = 0;
+  const eventsByMeasure = Array.from(
+    { length: measureCount },
+    (_, measureIndex) =>
+      events.find((event) => event.position / measureDuration === measureIndex),
+  );
   const result: MeasureKeySignature[] = [];
-  for (let measureIndex = 0; measureIndex < measureCount; measureIndex++) {
-    const position = measureIndex * measureDuration;
-    let emit = false;
-    while (events[eventIndex]?.position <= position) {
-      const event = events[eventIndex];
-      active = event.keySignature;
-      if (event.position === position) {
-        emit = true;
-      }
-      eventIndex++;
-    }
-    result.push({ active, emit: measureIndex === 0 || emit });
+  for (let index = 0; index < measureCount; index++) {
+    const previous = index > 0 ? result[index - 1].active : initialKeySignature;
+    const active = eventsByMeasure[index]?.keySignature ?? previous;
+    result[index] = {
+      active,
+      emit:
+        index === 0 ||
+        active.fifths !== previous!.fifths ||
+        active.mode !== previous!.mode,
+    };
   }
   return result;
 }

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -240,43 +240,38 @@ function prepareLocators({
   preparedLocators: PreparedLocator[];
   keySignatureEvents: KeySignatureEvent[];
 } {
-  const prepared = locators
-    .toSorted((a, b) => a.position - b.position)
-    .map((locator) => {
-      const position = toGridUnits(
-        locator.position,
-        `position of locator ${locator.id}`,
-      );
-      const parsed = parseLocatorLabel(locator);
-      if (parsed.keySignature && position <= 0) {
-        throw new Error(
-          `Key signature locator ${locator.id} must be after beat 0; use the project key signature for the initial key`,
-        );
-      }
-      if (parsed.keySignature && position % measureDuration !== 0) {
-        throw new Error(
-          `Key signature locator ${locator.id} must be at the start of a measure`,
-        );
-      }
-      return { id: locator.id, position, ...parsed };
-    });
-
+  const preparedLocators: PreparedLocator[] = [];
   const keySignatureEvents: KeySignatureEvent[] = [];
-  for (const locator of prepared) {
-    if (!locator.keySignature) {
-      continue;
-    }
-    if (keySignatureEvents.at(-1)?.position === locator.position) {
+  for (const locator of locators.toSorted((a, b) => a.position - b.position)) {
+    const position = toGridUnits(
+      locator.position,
+      `position of locator ${locator.id}`,
+    );
+    const parsed = parseLocatorLabel(locator);
+    if (parsed.keySignature && position <= 0) {
       throw new Error(
-        "Multiple key signature locators are at the same measure",
+        `Key signature locator ${locator.id} must be after beat 0; use the project key signature for the initial key`,
       );
     }
-    keySignatureEvents.push({
-      position: locator.position,
-      keySignature: locator.keySignature,
-    });
+    if (parsed.keySignature && position % measureDuration !== 0) {
+      throw new Error(
+        `Key signature locator ${locator.id} must be at the start of a measure`,
+      );
+    }
+    if (parsed.keySignature) {
+      if (keySignatureEvents.at(-1)?.position === position) {
+        throw new Error(
+          "Multiple key signature locators are at the same measure",
+        );
+      }
+      keySignatureEvents.push({
+        position,
+        keySignature: parsed.keySignature,
+      });
+    }
+    preparedLocators.push({ id: locator.id, position, ...parsed });
   }
-  return { preparedLocators: prepared, keySignatureEvents };
+  return { preparedLocators, keySignatureEvents };
 }
 
 function buildMeasureLocators({

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -1,6 +1,6 @@
 import type { Locator, Note, TimeSignature } from "../types";
+import { parseLocatorLabel } from "./locators";
 import {
-  KEY_SIGNATURE_OPTION_GROUPS,
   type KeySignature,
   type SpelledPitch,
   spellChromaticPitch,
@@ -277,61 +277,6 @@ function prepareLocators({
     positions.set(locator.position, locator.id);
   }
   return prepared;
-}
-
-function parseLocatorLabel(locator: Locator): {
-  label: string;
-  keySignature?: KeySignature;
-} {
-  let keySignature: KeySignature | undefined;
-  const labelWithoutDirectives = locator.label.replace(
-    /\[!([a-z][a-z0-9-]*):\s*([^\]]*)\]/gi,
-    (_directive, name: string, value: string) => {
-      if (name.toLowerCase() !== "key") {
-        throw new Error(
-          `Unknown score directive ${name} in locator ${locator.id}`,
-        );
-      }
-      if (keySignature) {
-        throw new Error(
-          `Locator ${locator.id} has multiple key signature directives`,
-        );
-      }
-      keySignature = parseKeySignature(value, locator.id);
-      return "";
-    },
-  );
-  if (labelWithoutDirectives.includes("[!")) {
-    throw new Error(`Malformed score directive in locator ${locator.id}`);
-  }
-  const label = keySignature
-    ? labelWithoutDirectives.replace(/\s+/g, " ").trim()
-    : locator.label;
-  return { label, keySignature };
-}
-
-function parseKeySignature(value: string, locatorId: string): KeySignature {
-  const normalized = normalizeKeySignatureLabel(value);
-  for (const group of KEY_SIGNATURE_OPTION_GROUPS) {
-    const option = group.options.find(
-      (candidate) => normalizeKeySignatureLabel(candidate.label) === normalized,
-    );
-    if (option) {
-      return { fifths: option.fifths, mode: group.mode };
-    }
-  }
-  throw new Error(
-    `Unsupported key signature "${value.trim()}" in locator ${locatorId}`,
-  );
-}
-
-function normalizeKeySignatureLabel(value: string): string {
-  return value
-    .trim()
-    .replaceAll("♯", "#")
-    .replaceAll("♭", "b")
-    .replace(/\s+/g, " ")
-    .toLowerCase();
 }
 
 function buildMeasureLocators({

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -261,19 +261,16 @@ function prepareLocators({
       return { id: locator.id, position, ...parsed };
     });
 
-  const positions = new Map<number, string>();
   const keySignatureEvents: KeySignatureEvent[] = [];
   for (const locator of prepared) {
     if (!locator.keySignature) {
       continue;
     }
-    const duplicate = positions.get(locator.position);
-    if (duplicate) {
+    if (keySignatureEvents.at(-1)?.position === locator.position) {
       throw new Error(
-        `Key signature locators ${duplicate} and ${locator.id} are at the same measure`,
+        "Multiple key signature locators are at the same measure",
       );
     }
-    positions.set(locator.position, locator.id);
     keySignatureEvents.push({
       position: locator.position,
       keySignature: locator.keySignature,

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -143,20 +143,10 @@ export function buildMusicXmlModel({
     quantizedNotes[quantizedNotes.length - 1].end / measureDuration,
   );
   // todo comment
-  const preparedLocators = prepareLocators({ locators, measureDuration });
-  const keySignatureEvents = preparedLocators
-    .filter(
-      (
-        locator,
-      ): locator is PreparedLocator & {
-        keySignature: KeySignature;
-      } => locator.keySignature !== undefined,
-    )
-    .map(({ position, keySignature }) => ({
-      position,
-      keySignature,
-    }))
-    .sort((a, b) => a.position - b.position);
+  const { preparedLocators, keySignatureEvents } = prepareLocators({
+    locators,
+    measureDuration,
+  });
   const keySignaturesByMeasure = buildMeasureKeySignatures({
     initialKeySignature: keySignature,
     events: keySignatureEvents,
@@ -246,27 +236,33 @@ function prepareLocators({
 }: {
   locators: Locator[];
   measureDuration: number;
-}): PreparedLocator[] {
-  const prepared = locators.map((locator) => {
-    const position = toGridUnits(
-      locator.position,
-      `position of locator ${locator.id}`,
-    );
-    const parsed = parseLocatorLabel(locator);
-    if (parsed.keySignature && position <= 0) {
-      throw new Error(
-        `Key signature locator ${locator.id} must be after beat 0; use the project key signature for the initial key`,
+}): {
+  preparedLocators: PreparedLocator[];
+  keySignatureEvents: KeySignatureEvent[];
+} {
+  const prepared = locators
+    .toSorted((a, b) => a.position - b.position)
+    .map((locator) => {
+      const position = toGridUnits(
+        locator.position,
+        `position of locator ${locator.id}`,
       );
-    }
-    if (parsed.keySignature && position % measureDuration !== 0) {
-      throw new Error(
-        `Key signature locator ${locator.id} must be at the start of a measure`,
-      );
-    }
-    return { id: locator.id, position, ...parsed };
-  });
+      const parsed = parseLocatorLabel(locator);
+      if (parsed.keySignature && position <= 0) {
+        throw new Error(
+          `Key signature locator ${locator.id} must be after beat 0; use the project key signature for the initial key`,
+        );
+      }
+      if (parsed.keySignature && position % measureDuration !== 0) {
+        throw new Error(
+          `Key signature locator ${locator.id} must be at the start of a measure`,
+        );
+      }
+      return { id: locator.id, position, ...parsed };
+    });
 
   const positions = new Map<number, string>();
+  const keySignatureEvents: KeySignatureEvent[] = [];
   for (const locator of prepared) {
     if (!locator.keySignature) {
       continue;
@@ -278,8 +274,12 @@ function prepareLocators({
       );
     }
     positions.set(locator.position, locator.id);
+    keySignatureEvents.push({
+      position: locator.position,
+      keySignature: locator.keySignature,
+    });
   }
-  return prepared;
+  return { preparedLocators: prepared, keySignatureEvents };
 }
 
 function buildMeasureLocators({

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -131,7 +131,7 @@ export function buildMusicXmlModel({
     "time signature",
   );
   const preparedNotes = prepareNotes({ notes, openStringPitches });
-  // todo: comment
+  // Trim empty leading measures and rebase notes to the exported score.
   const firstMeasureStart =
     Math.floor(preparedNotes[0].start / measureDuration) * measureDuration;
   const quantizedNotes = preparedNotes.map((note) => ({
@@ -142,7 +142,7 @@ export function buildMusicXmlModel({
   const measureCount = Math.ceil(
     quantizedNotes[quantizedNotes.length - 1].end / measureDuration,
   );
-  // todo comment
+  // Resolve the active key signature for every exported measure.
   const { preparedLocators, keySignatureEvents } = prepareLocators({
     locators,
     measureDuration,
@@ -154,7 +154,8 @@ export function buildMusicXmlModel({
     measureCount,
     measureDuration,
   });
-  // todo comment
+  // Spell each note in the key where it begins, then assign it to every
+  // measure it spans so tied segments retain the original spelling.
   const notesByMeasure = Array.from(
     { length: measureCount },
     () => [] as QuantizedNote[],

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -130,6 +130,17 @@ export function buildMusicXmlModel({
     timeSignature.numerator * (4 / timeSignature.denominator),
     "time signature",
   );
+  const preparedNotes = prepareNotes({ notes, openStringPitches });
+  const firstMeasureStart =
+    Math.floor(preparedNotes[0].start / measureDuration) * measureDuration;
+  const quantizedNotes = preparedNotes.map((note) => ({
+    ...note,
+    start: note.start - firstMeasureStart,
+    end: note.end - firstMeasureStart,
+  }));
+  const measureCount = Math.ceil(
+    quantizedNotes[quantizedNotes.length - 1].end / measureDuration,
+  );
   const preparedLocators = prepareLocators({ locators, measureDuration });
   const keySignatureEvents = preparedLocators
     .filter(
@@ -144,17 +155,6 @@ export function buildMusicXmlModel({
       keySignature,
     }))
     .sort((a, b) => a.position - b.position);
-  const preparedNotes = prepareNotes({ notes, openStringPitches });
-  const firstMeasureStart =
-    Math.floor(preparedNotes[0].start / measureDuration) * measureDuration;
-  const quantizedNotes = preparedNotes.map((note) => ({
-    ...note,
-    start: note.start - firstMeasureStart,
-    end: note.end - firstMeasureStart,
-  }));
-  const measureCount = Math.ceil(
-    quantizedNotes[quantizedNotes.length - 1].end / measureDuration,
-  );
   const keySignaturesByMeasure = buildMeasureKeySignatures({
     initialKeySignature: keySignature,
     events: keySignatureEvents,

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -156,14 +156,14 @@ export function buildMusicXmlModel({
     quantizedNotes[quantizedNotes.length - 1].end / measureDuration,
   );
   // Resolve the active key signature for every exported measure.
-  const keySignaturesByMeasure = buildKeySignaturesByMeasure({
-    initialKeySignature: keySignature,
-    events: quantizedKeySignatureEvents,
+  const locatorsByMeasure = buildLocatorsByMeasure({
+    locators: quantizedLocators,
     measureCount,
     measureDuration,
   });
-  const locatorsByMeasure = buildLocatorsByMeasure({
-    locators: quantizedLocators,
+  const keySignaturesByMeasure = buildKeySignaturesByMeasure({
+    initialKeySignature: keySignature,
+    events: quantizedKeySignatureEvents,
     measureCount,
     measureDuration,
   });

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -114,7 +114,6 @@ export function buildMusicXmlModel({
 }: MusicXmlModelOptions): {
   measureDuration: number;
   measures: MusicXmlMeasure[];
-  initialKeySignature: KeySignature;
 } {
   if (notes.length === 0) {
     throw new Error("Add at least one note before exporting MusicXML");
@@ -157,11 +156,6 @@ export function buildMusicXmlModel({
   );
   const firstMeasureStart =
     Math.floor(preparedNotes[0].start / measureDuration) * measureDuration;
-  const initialKeySignature = resolveKeySignature({
-    initialKeySignature: keySignature,
-    events: keySignatureEvents,
-    position: firstMeasureStart,
-  });
   const quantizedNotes = preparedNotes.map((note) => ({
     ...note,
     start: note.start - firstMeasureStart,
@@ -183,7 +177,6 @@ export function buildMusicXmlModel({
   }
   return {
     measureDuration,
-    initialKeySignature,
     measures: notesByMeasure.map((notes, index) => {
       const measureStart = index * measureDuration;
       const projectMeasureStart = firstMeasureStart + measureStart;
@@ -202,7 +195,14 @@ export function buildMusicXmlModel({
           measureStart,
           measureDuration,
         }),
-        keySignature: index > 0 ? keySignatureEvent?.keySignature : undefined,
+        keySignature:
+          index === 0
+            ? resolveKeySignature({
+                initialKeySignature: keySignature,
+                events: keySignatureEvents,
+                position: projectMeasureStart,
+              })
+            : keySignatureEvent?.keySignature,
       };
     }),
   };
@@ -530,21 +530,18 @@ export function exportMusicXml({
   openStringPitches,
   locators,
 }: MusicXmlExportOptions): string {
-  const { initialKeySignature, measureDuration, measures } = buildMusicXmlModel(
-    {
-      notes,
-      timeSignature,
-      keySignature,
-      openStringPitches,
-      locators,
-    },
-  );
+  const { measureDuration, measures } = buildMusicXmlModel({
+    notes,
+    timeSignature,
+    keySignature,
+    openStringPitches,
+    locators,
+  });
   // MusicXML places score-level configuration inside the first measure.
   const initialMeasureChildren = [
     hx(
       "attributes",
       hx("divisions", DIVISIONS),
-      renderKeySignature(initialKeySignature),
       hx(
         "time",
         hx("beats", timeSignature.numerator),

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -1,5 +1,6 @@
 import type { Locator, Note, TimeSignature } from "../types";
 import {
+  KEY_SIGNATURE_OPTION_GROUPS,
   type KeySignature,
   type SpelledPitch,
   spellChromaticPitch,
@@ -34,13 +35,30 @@ export type MusicXmlExportOptions = MusicXmlModelOptions & {
 export type MusicXmlMeasure = {
   events: MusicXmlMeasureEvent[];
   locators: { label: string; offset: number }[];
+  keySignature?: KeySignature;
 };
 
-type QuantizedNote = {
+type PreparedNote = {
   note: Note;
   start: number;
   end: number;
   tabPosition: TabPosition;
+};
+
+type QuantizedNote = PreparedNote & {
+  pitch: SpelledPitch;
+};
+
+type PreparedLocator = {
+  id: string;
+  position: number;
+  label?: string;
+  keySignature?: KeySignature;
+};
+
+type KeySignatureEvent = {
+  position: number;
+  keySignature: KeySignature;
 };
 
 export type MusicXmlMeasureEvent =
@@ -95,6 +113,7 @@ export function buildMusicXmlModel({
 }: MusicXmlModelOptions): {
   measureDuration: number;
   measures: MusicXmlMeasure[];
+  initialKeySignature: KeySignature;
 } {
   if (notes.length === 0) {
     throw new Error("Add at least one note before exporting MusicXML");
@@ -106,9 +125,42 @@ export function buildMusicXmlModel({
     timeSignature.numerator * (4 / timeSignature.denominator),
     "time signature",
   );
-  const preparedNotes = prepareNotes({ notes, openStringPitches });
+  const preparedLocators = prepareLocators({ locators, measureDuration });
+  const keySignatureEvents = preparedLocators
+    .filter(
+      (
+        locator,
+      ): locator is PreparedLocator & {
+        keySignature: KeySignature;
+      } => locator.keySignature !== undefined,
+    )
+    .map(({ position, keySignature }) => ({
+      position,
+      keySignature,
+    }))
+    .sort((a, b) => a.position - b.position);
+  const preparedNotes = prepareNotes({ notes, openStringPitches }).map(
+    (note): QuantizedNote => ({
+      ...note,
+      pitch: toWrittenBassPitch(
+        spellMidiPitch({
+          pitch: note.note.pitch,
+          keySignature: resolveKeySignature({
+            initialKeySignature: keySignature,
+            events: keySignatureEvents,
+            position: note.start,
+          }),
+        }),
+      ),
+    }),
+  );
   const firstMeasureStart =
     Math.floor(preparedNotes[0].start / measureDuration) * measureDuration;
+  const initialKeySignature = resolveKeySignature({
+    initialKeySignature: keySignature,
+    events: keySignatureEvents,
+    position: firstMeasureStart,
+  });
   const quantizedNotes = preparedNotes.map((note) => ({
     ...note,
     start: note.start - firstMeasureStart,
@@ -130,24 +182,142 @@ export function buildMusicXmlModel({
   }
   return {
     measureDuration,
+    initialKeySignature,
     measures: notesByMeasure.map((notes, index) => {
       const measureStart = index * measureDuration;
+      const projectMeasureStart = firstMeasureStart + measureStart;
+      const keySignatureEvent = keySignatureEvents.find(
+        (event) => event.position === projectMeasureStart,
+      );
       return {
         events: buildMeasureEvents({
           notes,
           measureStart,
           measureDuration,
-          keySignature,
         }),
         locators: buildMeasureLocators({
-          locators,
+          locators: preparedLocators,
           firstMeasureStart,
           measureStart,
           measureDuration,
         }),
+        keySignature: index > 0 ? keySignatureEvent?.keySignature : undefined,
       };
     }),
   };
+}
+
+function prepareLocators({
+  locators,
+  measureDuration,
+}: {
+  locators: Locator[];
+  measureDuration: number;
+}): PreparedLocator[] {
+  const prepared = locators.map((locator) => {
+    const position = toGridUnits(
+      locator.position,
+      `position of locator ${locator.id}`,
+    );
+    const parsed = parseLocatorLabel(locator);
+    if (parsed.keySignature && position <= 0) {
+      throw new Error(
+        `Key signature locator ${locator.id} must be after beat 0; use the project key signature for the initial key`,
+      );
+    }
+    if (parsed.keySignature && position % measureDuration !== 0) {
+      throw new Error(
+        `Key signature locator ${locator.id} must be at the start of a measure`,
+      );
+    }
+    return { id: locator.id, position, ...parsed };
+  });
+
+  const positions = new Map<number, string>();
+  for (const locator of prepared) {
+    if (!locator.keySignature) {
+      continue;
+    }
+    const duplicate = positions.get(locator.position);
+    if (duplicate) {
+      throw new Error(
+        `Key signature locators ${duplicate} and ${locator.id} are at the same measure`,
+      );
+    }
+    positions.set(locator.position, locator.id);
+  }
+  return prepared;
+}
+
+function parseLocatorLabel(locator: Locator): {
+  label?: string;
+  keySignature?: KeySignature;
+} {
+  let keySignature: KeySignature | undefined;
+  const labelWithoutDirectives = locator.label.replace(
+    /\[!([a-z][a-z0-9-]*):\s*([^\]]*)\]/gi,
+    (_directive, name: string, value: string) => {
+      if (name.toLowerCase() !== "key") {
+        throw new Error(
+          `Unknown score directive ${name} in locator ${locator.id}`,
+        );
+      }
+      if (keySignature) {
+        throw new Error(
+          `Locator ${locator.id} has multiple key signature directives`,
+        );
+      }
+      keySignature = parseKeySignature(value, locator.id);
+      return "";
+    },
+  );
+  if (labelWithoutDirectives.includes("[!")) {
+    throw new Error(`Malformed score directive in locator ${locator.id}`);
+  }
+  const label = keySignature
+    ? labelWithoutDirectives.replace(/\s+/g, " ").trim()
+    : locator.label;
+  return { label: label || undefined, keySignature };
+}
+
+function parseKeySignature(value: string, locatorId: string): KeySignature {
+  const normalized = normalizeKeySignatureLabel(value);
+  for (const group of KEY_SIGNATURE_OPTION_GROUPS) {
+    const option = group.options.find(
+      (candidate) => normalizeKeySignatureLabel(candidate.label) === normalized,
+    );
+    if (option) {
+      return { fifths: option.fifths, mode: group.mode };
+    }
+  }
+  throw new Error(
+    `Unsupported key signature "${value.trim()}" in locator ${locatorId}`,
+  );
+}
+
+function normalizeKeySignatureLabel(value: string): string {
+  return value
+    .trim()
+    .replaceAll("♯", "#")
+    .replaceAll("♭", "b")
+    .replace(/\s+/g, " ")
+    .toLowerCase();
+}
+
+function resolveKeySignature({
+  initialKeySignature,
+  events,
+  position,
+}: {
+  initialKeySignature: KeySignature;
+  events: KeySignatureEvent[];
+  position: number;
+}): KeySignature {
+  return events.reduce(
+    (keySignature, event) =>
+      event.position <= position ? event.keySignature : keySignature,
+    initialKeySignature,
+  );
 }
 
 function buildMeasureLocators({
@@ -156,18 +326,19 @@ function buildMeasureLocators({
   measureStart,
   measureDuration,
 }: {
-  locators: Locator[];
+  locators: PreparedLocator[];
   firstMeasureStart: number;
   measureStart: number;
   measureDuration: number;
 }): MusicXmlMeasure["locators"] {
   return locators
+    .filter(
+      (locator): locator is PreparedLocator & { label: string } =>
+        locator.label !== undefined,
+    )
     .map((locator) => ({
       label: locator.label,
-      offset:
-        toGridUnits(locator.position, `position of locator ${locator.id}`) -
-        firstMeasureStart -
-        measureStart,
+      offset: locator.position - firstMeasureStart - measureStart,
     }))
     .filter(({ offset }) => offset >= 0 && offset < measureDuration)
     .sort((a, b) => a.offset - b.offset);
@@ -180,7 +351,7 @@ function prepareNotes({
 }: {
   notes: Note[];
   openStringPitches: readonly number[];
-}): QuantizedNote[] {
+}): PreparedNote[] {
   const result = notes
     .map((note) => {
       const start = toGridUnits(note.start, `start of note ${note.id}`);
@@ -227,12 +398,10 @@ function buildMeasureEvents({
   notes,
   measureStart,
   measureDuration,
-  keySignature,
 }: {
   notes: QuantizedNote[];
   measureStart: number;
   measureDuration: number;
-  keySignature: KeySignature;
 }): MusicXmlMeasureEvent[] {
   const events: MusicXmlMeasureEvent[] = [];
   let cursor = 0;
@@ -267,9 +436,7 @@ function buildMeasureEvents({
       const pieceEnd = pieceStart + piece.duration;
       events.push({
         type: "note",
-        pitch: toWrittenBassPitch(
-          spellMidiPitch({ pitch: note.note.pitch, keySignature }),
-        ),
+        pitch: note.pitch,
         duration: piece.duration,
         notation: piece.notation,
         tabPosition: note.tabPosition,
@@ -361,23 +528,21 @@ export function exportMusicXml({
   openStringPitches,
   locators,
 }: MusicXmlExportOptions): string {
-  const { measureDuration, measures } = buildMusicXmlModel({
-    notes,
-    timeSignature,
-    keySignature,
-    openStringPitches,
-    locators,
-  });
+  const { initialKeySignature, measureDuration, measures } = buildMusicXmlModel(
+    {
+      notes,
+      timeSignature,
+      keySignature,
+      openStringPitches,
+      locators,
+    },
+  );
   // MusicXML places score-level configuration inside the first measure.
   const initialMeasureChildren = [
     hx(
       "attributes",
       hx("divisions", DIVISIONS),
-      hx(
-        "key",
-        hx("fifths", keySignature.fifths),
-        hx("mode", keySignature.mode),
-      ),
+      renderKeySignature(initialKeySignature),
       hx(
         "time",
         hx("beats", timeSignature.numerator),
@@ -476,10 +641,20 @@ function renderMeasure({
     "measure",
     { number: index + 1 },
     ...initialChildren,
+    measure.keySignature &&
+      hx("attributes", renderKeySignature(measure.keySignature)),
     ...measure.locators.map(renderRehearsalDirection),
     ...measure.events.map((event) => renderEvent(event, 1)),
     hx("backup", hx("duration", measureDuration)),
     ...measure.events.map((event) => renderEvent(event, 2)),
+  );
+}
+
+function renderKeySignature(keySignature: KeySignature): XmlElement {
+  return hx(
+    "key",
+    hx("fifths", keySignature.fifths),
+    hx("mode", keySignature.mode),
   );
 }
 

--- a/src/lib/score-viewer-samples.ts
+++ b/src/lib/score-viewer-samples.ts
@@ -143,6 +143,19 @@ export const SCORE_VIEWER_SAMPLES: ScoreViewerSample[] = [
       ],
     }),
   },
+  {
+    id: "key-changes",
+    name: "Key changes",
+    description: "C major to G-flat major at measure 3",
+    tempo: 120,
+    xml: exportSample({
+      tempo: 120,
+      notes: createSequentialNotes({ count: 32, duration: 0.5 }),
+      locators: [
+        createLocator({ position: 8, label: "G-flat major [!key: Gb major]" }),
+      ],
+    }),
+  },
 ];
 
 function createSequentialNotes({

--- a/src/lib/score-viewer-samples.ts
+++ b/src/lib/score-viewer-samples.ts
@@ -111,11 +111,25 @@ export const SCORE_VIEWER_SAMPLES: ScoreViewerSample[] = [
   }),
   createSample({
     name: "Key changes",
-    description: "C major to G-flat major at measure 3",
+    description:
+      "Tied accidentals and diatonic notes across flat and sharp keys",
     tempo: 120,
-    notes: createSequentialNotes({ count: 32, duration: 0.5 }),
+    notes: [
+      // A# crosses into G-flat major, where the following pitch is spelled Bb.
+      createNote({ pitch: 34, start: 3.5, duration: 1 }),
+      createNote({ pitch: 34, start: 5, duration: 1 }),
+      // Gb, Bb, and Db are diatonic in G-flat major.
+      createNote({ pitch: 42, start: 6, duration: 0.5 }),
+      createNote({ pitch: 46, start: 6.5, duration: 0.5 }),
+      createNote({ pitch: 49, start: 7, duration: 1 }),
+      // F#, A#, and C# are diatonic in F-sharp major.
+      createNote({ pitch: 42, start: 8, duration: 1 }),
+      createNote({ pitch: 46, start: 9, duration: 1 }),
+      createNote({ pitch: 49, start: 10, duration: 1 }),
+    ],
     locators: [
-      createLocator({ position: 8, label: "G-flat major [!key: Gb major]" }),
+      createLocator({ position: 4, label: "G-flat major [!key: Gb major]" }),
+      createLocator({ position: 8, label: "F-sharp major [!key: F# major]" }),
     ],
   }),
 ];


### PR DESCRIPTION
- part of https://github.com/hi-ogawa/toy-midi/issues/224

This PR lets locators influence score export through `[!key: F# major]` directives. A directive can stand alone or be combined with rehearsal text such as `Last chorus [!key: F# major]`, which keeps the visible rehearsal mark while applying the key change.
