### PR TITLE
feat: show score titles by default

### DIFF
--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -47,11 +47,11 @@ test("opens the latest project state as a score in a new tab", async ({
   ).toBeVisible();
   await expect(scorePage.getByLabel("BPM")).toHaveValue("137");
   const renderer = scorePage.getByTestId("score-viewer-renderer");
-  await expect(renderer.getByText("Untitled", { exact: true })).toHaveCount(0);
-  await scorePage.getByLabel("Title").selectOption("show");
   await expect(renderer.getByText("Untitled", { exact: true })).toBeVisible();
   await scorePage.getByLabel("Title").selectOption("hide");
   await expect(renderer.getByText("Untitled", { exact: true })).toHaveCount(0);
+  await scorePage.getByLabel("Title").selectOption("show");
+  await expect(renderer.getByText("Untitled", { exact: true })).toBeVisible();
   await expect(scorePage.getByRole("button", { name: "Samples" })).toHaveCount(
     0,
   );

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -39,7 +39,7 @@ export function ScoreViewer({
 
   const [score, setScore] = useState<ScoreSource | undefined>(initialSource);
   const [layout, setLayout] = useState<ScoreLayout>("continuous");
-  const [showTitle, setShowTitle] = useState(false);
+  const [showTitle, setShowTitle] = useState(true);
   const [showRehearsalMarks, setShowRehearsalMarks] = useState(true);
   const [isRuntimeAttached, setIsRuntimeAttached] = useState(false);
 


### PR DESCRIPTION
Score titles provide useful context when opening project-backed and uploaded scores, but the viewer currently hides that metadata on every fresh visit. Users can already hide titles explicitly when they want a more compact rendering.

This PR shows titles by default and updates the score-viewer coverage to verify the default plus both toggle directions.