### PR TITLE
fix: render grouped eighth-note triplets

### DIFF
--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -345,20 +345,6 @@ describe("MusicXML export", () => {
     ]);
   });
 
-  it("exports matching tuplet groups on standard and TAB staves", () => {
-    const xml = exportNotes([
-      makeNote({ id: "first", start: 0, duration: 1 / 3 }),
-      makeNote({ id: "last", start: 2 / 3, duration: 1 / 3 }),
-    ]);
-
-    expect(xml.match(/<tuplet type="start" number="1"\/>/g)).toHaveLength(2);
-    expect(xml.match(/<tuplet type="stop" number="1"\/>/g)).toHaveLength(2);
-    expect(xml.match(/<time-modification>/g)).toHaveLength(6);
-    expect(xml).toContain(
-      '<notations>\n          <technical>\n            <string>3</string>\n            <fret>0</fret>\n          </technical>\n          <tuplet type="start" number="1"/>',
-    );
-  });
-
   it("fills gaps and remaining measure time with rests", () => {
     const model = buildModel([
       makeNote({

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -464,6 +464,44 @@ describe("MusicXML export", () => {
     ]);
   });
 
+  it("groups a note followed by two triplet rests", () => {
+    const model = buildModel([
+      makeNote({ id: "first", start: 0, duration: 1 / 3 }),
+    ]);
+
+    expect(model.measures[0].events).toMatchObject([
+      {
+        type: "note",
+        duration: 4,
+        notation: {
+          type: "eighth",
+          triplet: true,
+          tuplet: { boundary: "start" },
+        },
+      },
+      {
+        type: "rest",
+        duration: 4,
+        notation: { type: "eighth", triplet: true },
+      },
+      {
+        type: "rest",
+        duration: 8,
+        notation: { type: "quarter", triplet: true },
+      },
+      { type: "rest", duration: 16, notation: { type: "half", triplet: true } },
+      {
+        type: "rest",
+        duration: 16,
+        notation: {
+          type: "half",
+          triplet: true,
+          tuplet: { boundary: "stop" },
+        },
+      },
+    ]);
+  });
+
   it("fills gaps and remaining measure time with rests", () => {
     const model = buildModel([
       makeNote({

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -199,12 +199,164 @@ describe("MusicXML export", () => {
         type: "note",
         pitch: { step: "A", alter: 0, octave: 2 },
         duration: QUARTER_NOTE_DURATION / 3,
-        notation: { type: "eighth", triplet: true },
+        notation: {
+          type: "eighth",
+          triplet: true,
+          tuplet: {
+            actualNotes: 3,
+            normalNotes: 2,
+            number: 1,
+            boundary: "start",
+          },
+        },
         tabPosition: { tabString: 3, fret: 0 },
         tieStart: false,
         tieStop: false,
       },
     ]);
+  });
+
+  it("groups beat-aligned eighth-note triplet partitions", () => {
+    const model = buildModel([
+      makeNote({ id: "one-a", start: 0, duration: 1 / 3 }),
+      makeNote({ id: "one-b", start: 1 / 3, duration: 1 / 3 }),
+      makeNote({ id: "one-c", start: 2 / 3, duration: 1 / 3 }),
+      makeNote({ id: "one-two-a", start: 1, duration: 1 / 3 }),
+      makeNote({ id: "one-two-b", start: 4 / 3, duration: 2 / 3 }),
+      makeNote({ id: "two-one-a", start: 2, duration: 2 / 3 }),
+      makeNote({ id: "two-one-b", start: 8 / 3, duration: 1 / 3 }),
+    ]);
+
+    expect(
+      model.measures[0].events.slice(0, 7).map((event) => ({
+        type: event.type,
+        duration: event.duration,
+        notation: event.notation,
+      })),
+    ).toEqual([
+      {
+        type: "note",
+        duration: 4,
+        notation: {
+          type: "eighth",
+          triplet: true,
+          tuplet: {
+            actualNotes: 3,
+            normalNotes: 2,
+            number: 1,
+            boundary: "start",
+          },
+        },
+      },
+      {
+        type: "note",
+        duration: 4,
+        notation: { type: "eighth", triplet: true },
+      },
+      {
+        type: "note",
+        duration: 4,
+        notation: {
+          type: "eighth",
+          triplet: true,
+          tuplet: {
+            actualNotes: 3,
+            normalNotes: 2,
+            number: 1,
+            boundary: "stop",
+          },
+        },
+      },
+      {
+        type: "note",
+        duration: 4,
+        notation: {
+          type: "eighth",
+          triplet: true,
+          tuplet: {
+            actualNotes: 3,
+            normalNotes: 2,
+            number: 1,
+            boundary: "start",
+          },
+        },
+      },
+      {
+        type: "note",
+        duration: 8,
+        notation: {
+          type: "quarter",
+          triplet: true,
+          tuplet: {
+            actualNotes: 3,
+            normalNotes: 2,
+            number: 1,
+            boundary: "stop",
+          },
+        },
+      },
+      {
+        type: "note",
+        duration: 8,
+        notation: {
+          type: "quarter",
+          triplet: true,
+          tuplet: {
+            actualNotes: 3,
+            normalNotes: 2,
+            number: 1,
+            boundary: "start",
+          },
+        },
+      },
+      {
+        type: "note",
+        duration: 4,
+        notation: {
+          type: "eighth",
+          triplet: true,
+          tuplet: {
+            actualNotes: 3,
+            normalNotes: 2,
+            number: 1,
+            boundary: "stop",
+          },
+        },
+      },
+    ]);
+  });
+
+  it("groups generated rests within triplets", () => {
+    const model = buildModel([
+      makeNote({ id: "first", start: 0, duration: 1 / 3 }),
+      makeNote({ id: "last", start: 2 / 3, duration: 1 / 3 }),
+    ]);
+
+    expect(model.measures[0].events.slice(0, 3)).toMatchObject([
+      {
+        type: "note",
+        notation: { triplet: true, tuplet: { boundary: "start" } },
+      },
+      { type: "rest", notation: { triplet: true } },
+      {
+        type: "note",
+        notation: { triplet: true, tuplet: { boundary: "stop" } },
+      },
+    ]);
+  });
+
+  it("exports matching tuplet groups on standard and TAB staves", () => {
+    const xml = exportNotes([
+      makeNote({ id: "first", start: 0, duration: 1 / 3 }),
+      makeNote({ id: "last", start: 2 / 3, duration: 1 / 3 }),
+    ]);
+
+    expect(xml.match(/<tuplet type="start" number="1"\/>/g)).toHaveLength(2);
+    expect(xml.match(/<tuplet type="stop" number="1"\/>/g)).toHaveLength(2);
+    expect(xml.match(/<time-modification>/g)).toHaveLength(6);
+    expect(xml).toContain(
+      '<notations>\n          <technical>\n            <string>3</string>\n            <fret>0</fret>\n          </technical>\n          <tuplet type="start" number="1"/>',
+    );
   });
 
   it("fills gaps and remaining measure time with rests", () => {

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -332,7 +332,7 @@ describe("MusicXML export", () => {
       makeNote({ id: "last", start: 2 / 3, duration: 1 / 3 }),
     ]);
 
-    expect(model.measures[0].events.slice(0, 3)).toMatchObject([
+    expect(model.measures[0].events).toMatchObject([
       {
         type: "note",
         notation: { triplet: true, tuplet: { boundary: "start" } },
@@ -342,6 +342,10 @@ describe("MusicXML export", () => {
         type: "note",
         notation: { triplet: true, tuplet: { boundary: "stop" } },
       },
+      { type: "rest", duration: 18, notation: { type: "quarter", dots: 1 } },
+      { type: "rest", duration: 9, notation: { type: "eighth", dots: 1 } },
+      { type: "rest", duration: 3, notation: { type: "16th" } },
+      { type: "rest", duration: 6, notation: { type: "eighth" } },
     ]);
   });
 

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -60,6 +60,12 @@ type DurationNotation = {
   type: string;
   dots?: number;
   triplet?: boolean;
+  tuplet?: {
+    actualNotes: 3;
+    normalNotes: 2;
+    number: 1;
+    boundary: "start" | "stop";
+  };
 };
 
 type DurationCandidate = DurationNotation & {
@@ -134,12 +140,14 @@ export function buildMusicXmlModel({
     measures: notesByMeasure.map((notes, index) => {
       const measureStart = index * measureDuration;
       return {
-        events: buildMeasureEvents({
-          notes,
-          measureStart,
-          measureDuration,
-          keySignature,
-        }),
+        events: annotateTuplets(
+          buildMeasureEvents({
+            notes,
+            measureStart,
+            measureDuration,
+            keySignature,
+          }),
+        ),
         locators: buildMeasureLocators({
           locators,
           firstMeasureStart,
@@ -300,6 +308,63 @@ function buildMeasureEvents({
   return events;
 }
 
+/** Marks complete beat-aligned eighth-note triplet groups for engraving. */
+function annotateTuplets(
+  events: MusicXmlMeasureEvent[],
+): MusicXmlMeasureEvent[] {
+  const result = events.map((event) => ({
+    ...event,
+    notation: event.notation,
+  }));
+  let offset = 0;
+  let groupStartIndex: number | undefined;
+
+  for (let index = 0; index < result.length; index++) {
+    const event = result[index];
+    const eventEnd = offset + event.duration;
+
+    if (offset % DIVISIONS === 0) {
+      groupStartIndex = event.notation.triplet ? index : undefined;
+    } else if (!event.notation.triplet) {
+      groupStartIndex = undefined;
+    }
+
+    if (eventEnd % DIVISIONS === 0) {
+      if (groupStartIndex !== undefined && index > groupStartIndex) {
+        result[groupStartIndex] = {
+          ...result[groupStartIndex],
+          notation: {
+            ...result[groupStartIndex].notation,
+            tuplet: {
+              actualNotes: 3,
+              normalNotes: 2,
+              number: 1,
+              boundary: "start",
+            },
+          },
+        };
+        result[index] = {
+          ...event,
+          notation: {
+            ...event.notation,
+            tuplet: {
+              actualNotes: 3,
+              normalNotes: 2,
+              number: 1,
+              boundary: "stop",
+            },
+          },
+        };
+      }
+      groupStartIndex = undefined;
+    }
+
+    offset = eventEnd;
+  }
+
+  return result;
+}
+
 /** Decomposes a grid duration into the longest notation values valid at each offset. */
 function splitDuration({
   start,
@@ -320,8 +385,8 @@ function splitDuration({
       duration: candidate.duration,
       notation: {
         type: candidate.type,
-        dots: candidate.dots,
-        triplet: candidate.triplet,
+        ...(candidate.dots && { dots: candidate.dots }),
+        ...(candidate.triplet && { triplet: true }),
       },
     });
     cursor += candidate.duration;
@@ -525,6 +590,7 @@ function renderEvent(event: MusicXmlMeasureEvent, staff: 1 | 2): XmlElement {
   // MuseScore allocates four voice IDs per staff, so the first voices of staff 1
   // and staff 2 are 1 and 5 respectively.
   const voice = staff === 1 ? 1 : 5;
+  const tupletNotation = renderTupletNotation(event.notation);
   if (event.type === "rest") {
     return hx(
       "note",
@@ -533,6 +599,7 @@ function renderEvent(event: MusicXmlMeasureEvent, staff: 1 | 2): XmlElement {
       hx("voice", voice),
       ...renderDurationNotation(event.notation),
       hx("staff", staff),
+      tupletNotation && hx("notations", tupletNotation),
     );
   }
 
@@ -564,8 +631,18 @@ function renderEvent(event: MusicXmlMeasureEvent, staff: 1 | 2): XmlElement {
     hx("voice", voice),
     ...renderDurationNotation(event.notation),
     hx("staff", staff),
-    (tiedNotations.some(Boolean) || technical) &&
-      hx("notations", ...tiedNotations, technical),
+    (tiedNotations.some(Boolean) || technical || tupletNotation) &&
+      hx("notations", ...tiedNotations, technical, tupletNotation),
+  );
+}
+
+function renderTupletNotation(notation: DurationNotation): XmlNode {
+  return (
+    notation.tuplet &&
+    h("tuplet", {
+      type: notation.tuplet.boundary,
+      number: notation.tuplet.number,
+    })
   );
 }
 

--- a/src/lib/score-viewer-samples.ts
+++ b/src/lib/score-viewer-samples.ts
@@ -42,6 +42,12 @@ export const SCORE_VIEWER_SAMPLES: ScoreViewerSample[] = [
     ],
   }),
   createSample({
+    name: "Eighth-note triplets",
+    description: "All note and rest combinations for eighth-note triplets",
+    tempo: 120,
+    notes: createTripletNotes(),
+  }),
+  createSample({
     name: "Ties and barlines",
     description: "Durations split within and across measures",
     tempo: 120,
@@ -125,6 +131,50 @@ function createSequentialNotes({
       duration,
     }),
   );
+}
+
+function createTripletNotes() {
+  const patterns = [
+    [tripletNote(1), tripletNote(1), tripletNote(1)],
+    [tripletNote(1), tripletNote(1), tripletRest(1)],
+    [tripletNote(1), tripletRest(1), tripletNote(1)],
+    [tripletNote(1), tripletRest(1), tripletRest(1)],
+    [tripletRest(1), tripletNote(1), tripletNote(1)],
+    [tripletRest(1), tripletNote(1), tripletRest(1)],
+    [tripletRest(1), tripletRest(1), tripletNote(1)],
+    [tripletRest(1), tripletRest(1), tripletRest(1)],
+    [tripletNote(1), tripletNote(2)],
+    [tripletNote(1), tripletRest(2)],
+    [tripletRest(1), tripletNote(2)],
+    [tripletRest(1), tripletRest(2)],
+    [tripletNote(2), tripletNote(1)],
+    [tripletNote(2), tripletRest(1)],
+    [tripletRest(2), tripletNote(1)],
+    [tripletRest(2), tripletRest(1)],
+  ];
+
+  return patterns.flatMap((pattern, beat) => {
+    let unit = 0;
+    return pattern.flatMap((segment, index) => {
+      const note = segment.note
+        ? createNote({
+            pitch: SAMPLE_PITCHES[(beat + index) % SAMPLE_PITCHES.length],
+            start: beat + unit / 3,
+            duration: segment.units / 3,
+          })
+        : [];
+      unit += segment.units;
+      return note;
+    });
+  });
+}
+
+function tripletNote(units: 1 | 2) {
+  return { units, note: true } as const;
+}
+
+function tripletRest(units: 1 | 2) {
+  return { units, note: false } as const;
 }
 
 function createPrintNotes() {


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/toy-midi/issues/264
- part of https://github.com/hi-ogawa/toy-midi/issues/224

The MusicXML exporter currently emits triplet time modification per event without identifying complete tuplet groups, so OSMD can space standard notation and TAB independently.

This PR annotates complete beat-aligned 3:2 eighth-note triplets after measure notes and rests are built, then emits matching start and stop notation on both staves. It supports 1+1+1, 1+2, and 2+1 note/rest combinations and adds an exhaustive score-viewer sample for manual inspection.