### PR TITLE
refactor: add range helper

### DIFF
--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,5 +1,6 @@
 import * as SliderPrimitive from "@radix-ui/react-slider";
 import * as React from "react";
+import { range } from "../../utils/array";
 import { cn } from "./utils";
 
 export function Slider({
@@ -66,7 +67,7 @@ export function Slider({
           )}
         />
       </SliderPrimitive.Track>
-      {Array.from({ length: _values.length }, (_, index) => (
+      {range(_values.length).map((index) => (
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}

--- a/src/lib/audio-view.test.ts
+++ b/src/lib/audio-view.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { range } from "../utils/array";
 import {
   type AudioView,
   type AudioViewSlice,
@@ -95,7 +96,7 @@ describe("createAudioView", () => {
 describe("queryAudioView", () => {
   // Create test view: 100 points at 10 points/sec = 10 seconds of audio
   const createTestView = (count: number): AudioView => ({
-    data: Array.from({ length: count }, (_, i) => (i + 1) / count),
+    data: range(count).map((i) => (i + 1) / count),
     samplesPerPoint: 100, // 1000 Hz / 10 points/sec
     sampleRate: 1000,
   });
@@ -242,10 +243,7 @@ describe("queryAudioView", () => {
 
     // Create view with distinct values so we can detect changes
     const view: AudioView = {
-      data: Array.from(
-        { length: duration * pointsPerSec },
-        (_, i) => (i % 100) / 100,
-      ),
+      data: range(duration * pointsPerSec).map((i) => (i % 100) / 100),
       samplesPerPoint: 60, // 48000 / 800
       sampleRate: 48000,
     };

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -4,6 +4,7 @@ import oxisynthWasmUrl from "../assets/oxisynth/oxisynth.wasm?url";
 import oxisynthWorkletUrl from "../assets/oxisynth/worklet.js?url";
 import soundfontUrl from "../assets/soundfonts/A320U.sf2?url";
 import type { Note } from "../types";
+import { range } from "../utils/array";
 import { type AudioView, createAudioView } from "./audio-view";
 import { Metronome } from "./metronome";
 import { clampGain } from "./music";
@@ -321,9 +322,7 @@ class AudioManager {
   setMetronomeSequence(beatsPerBar: number): void {
     // Create new sequence with updated beats per bar
     this.metronomeSeq.clear();
-    this.metronomeSeq.events = Array.from({ length: beatsPerBar }, (_, i) =>
-      i === 0 ? 1 : 0,
-    );
+    this.metronomeSeq.events = range(beatsPerBar).map((i) => (i === 0 ? 1 : 0));
   }
 
   setProgram(programNumber: number): void {

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -119,7 +119,7 @@ export function buildMusicXmlModel({
   const measureCount = Math.ceil(
     quantizedNotes[quantizedNotes.length - 1].end / measureDuration,
   );
-  const notesByMeasure = range(measureCount).map((): QuantizedNote[] => []);
+  const notesByMeasure: QuantizedNote[][] = range(measureCount).map(() => []);
   for (const note of quantizedNotes) {
     const firstMeasure = Math.floor(note.start / measureDuration);
     const lastMeasure = Math.ceil(note.end / measureDuration) - 1;

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -1,4 +1,5 @@
 import type { Locator, Note, TimeSignature } from "../types";
+import { range } from "../utils/array";
 import {
   type KeySignature,
   type SpelledPitch,
@@ -118,10 +119,7 @@ export function buildMusicXmlModel({
   const measureCount = Math.ceil(
     quantizedNotes[quantizedNotes.length - 1].end / measureDuration,
   );
-  const notesByMeasure = Array.from(
-    { length: measureCount },
-    () => [] as QuantizedNote[],
-  );
+  const notesByMeasure = range(measureCount).map((): QuantizedNote[] => []);
   for (const note of quantizedNotes) {
     const firstMeasure = Math.floor(note.start / measureDuration);
     const lastMeasure = Math.ceil(note.end / measureDuration) - 1;
@@ -572,7 +570,7 @@ function renderEvent(event: MusicXmlMeasureEvent, staff: 1 | 2): XmlElement {
 function renderDurationNotation(notation: DurationNotation): XmlNode[] {
   return [
     hx("type", notation.type),
-    ...Array.from({ length: notation.dots ?? 0 }, () => hx("dot")),
+    ...range(notation.dots ?? 0).map(() => hx("dot")),
     notation.triplet &&
       hx("time-modification", hx("actual-notes", 3), hx("normal-notes", 2)),
   ];

--- a/src/lib/score-viewer-samples.ts
+++ b/src/lib/score-viewer-samples.ts
@@ -1,4 +1,5 @@
 import type { Locator, Note } from "../types";
+import { range } from "../utils/array";
 import { exportMusicXml } from "./musicxml-export";
 import type { KeySignature } from "./pitch-spelling";
 import { TAB_STRING_PRESETS } from "./tab-annotation";
@@ -118,7 +119,7 @@ function createSequentialNotes({
   count: number;
   duration: number;
 }) {
-  return Array.from({ length: count }, (_, index) =>
+  return range(count).map((index) =>
     createNote({
       pitch: SAMPLE_PITCHES[index % SAMPLE_PITCHES.length],
       start: index * duration,
@@ -128,7 +129,7 @@ function createSequentialNotes({
 }
 
 function createPrintNotes() {
-  return Array.from({ length: 64 }, (_, measure) => {
+  return range(64).flatMap((measure) => {
     const durations =
       measure % 2 === 0 ? [0.5, 0.5, 1, 0.5, 0.5, 1] : Array(16).fill(0.25);
     let start = measure * 4;
@@ -141,7 +142,7 @@ function createPrintNotes() {
       start += duration;
       return note;
     });
-  }).flat();
+  });
 }
 
 function createSample({

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,0 +1,3 @@
+export function range(length: number): number[] {
+  return Array.from({ length }, (_, index) => index);
+}


### PR DESCRIPTION
Repeated `Array.from({ length }, ...)` expressions are harder to skim than the indexed mapping they represent.

This PR adds a small `range(length)` helper under `src/utils/array.ts` and uses it for array generation. Collection conversion such as `Array.from(selectedNoteIds)` remains unchanged.