### PR TITLE
fix: preserve triplet beat boundaries in score export

### DIFF
--- a/src/lib/__snapshots__/five-string-tab.musicxml
+++ b/src/lib/__snapshots__/five-string-tab.musicxml
@@ -89,16 +89,32 @@
       </note>
       <note>
         <rest/>
-        <duration>12</duration>
+        <duration>18</duration>
         <voice>1</voice>
         <type>quarter</type>
+        <dot/>
         <staff>1</staff>
       </note>
       <note>
         <rest/>
-        <duration>24</duration>
+        <duration>9</duration>
         <voice>1</voice>
-        <type>half</type>
+        <type>eighth</type>
+        <dot/>
+        <staff>1</staff>
+      </note>
+      <note>
+        <rest/>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <staff>1</staff>
+      </note>
+      <note>
+        <rest/>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>eighth</type>
         <staff>1</staff>
       </note>
       <backup>
@@ -122,16 +138,32 @@
       </note>
       <note>
         <rest/>
-        <duration>12</duration>
+        <duration>18</duration>
         <voice>5</voice>
         <type>quarter</type>
+        <dot/>
         <staff>2</staff>
       </note>
       <note>
         <rest/>
-        <duration>24</duration>
+        <duration>9</duration>
         <voice>5</voice>
-        <type>half</type>
+        <type>eighth</type>
+        <dot/>
+        <staff>2</staff>
+      </note>
+      <note>
+        <rest/>
+        <duration>3</duration>
+        <voice>5</voice>
+        <type>16th</type>
+        <staff>2</staff>
+      </note>
+      <note>
+        <rest/>
+        <duration>6</duration>
+        <voice>5</voice>
+        <type>eighth</type>
         <staff>2</staff>
       </note>
     </measure>

--- a/src/lib/__snapshots__/five-string-tab.musicxml
+++ b/src/lib/__snapshots__/five-string-tab.musicxml
@@ -89,32 +89,16 @@
       </note>
       <note>
         <rest/>
-        <duration>18</duration>
+        <duration>12</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <dot/>
         <staff>1</staff>
       </note>
       <note>
         <rest/>
-        <duration>9</duration>
+        <duration>24</duration>
         <voice>1</voice>
-        <type>eighth</type>
-        <dot/>
-        <staff>1</staff>
-      </note>
-      <note>
-        <rest/>
-        <duration>3</duration>
-        <voice>1</voice>
-        <type>16th</type>
-        <staff>1</staff>
-      </note>
-      <note>
-        <rest/>
-        <duration>6</duration>
-        <voice>1</voice>
-        <type>eighth</type>
+        <type>half</type>
         <staff>1</staff>
       </note>
       <backup>
@@ -138,32 +122,16 @@
       </note>
       <note>
         <rest/>
-        <duration>18</duration>
+        <duration>12</duration>
         <voice>5</voice>
         <type>quarter</type>
-        <dot/>
         <staff>2</staff>
       </note>
       <note>
         <rest/>
-        <duration>9</duration>
+        <duration>24</duration>
         <voice>5</voice>
-        <type>eighth</type>
-        <dot/>
-        <staff>2</staff>
-      </note>
-      <note>
-        <rest/>
-        <duration>3</duration>
-        <voice>5</voice>
-        <type>16th</type>
-        <staff>2</staff>
-      </note>
-      <note>
-        <rest/>
-        <duration>6</duration>
-        <voice>5</voice>
-        <type>eighth</type>
+        <type>half</type>
         <staff>2</staff>
       </note>
     </measure>

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -404,6 +404,37 @@ describe("MusicXML export", () => {
   );
 
   it.each([
+    // TODO: Preserve the quarter note as [12].
+    {
+      start: 0.5,
+      duration: 1,
+      actual: [9, 3],
+    },
+    // TODO: Preserve the eighth note as [6].
+    {
+      start: 0.25,
+      duration: 0.5,
+      actual: [3, 3],
+    },
+    // TODO: Preserve the half note as [24].
+    {
+      start: 1,
+      duration: 2,
+      actual: [12, 12],
+    },
+  ])(
+    "decomposes a $duration-beat note after a rest at beat $start",
+    ({ start, duration, actual }) => {
+      const model = buildModel([makeNote({ start, duration })]);
+      const noteEvents = model.measures[0].events
+        .filter((event) => event.type === "note")
+        .map((event) => event.duration);
+
+      expect(noteEvents).toEqual(actual);
+    },
+  );
+
+  it.each([
     // TODO: Preserve as [8, 8, 8].
     { start: 0, durations: [8, 8, 8], actual: [8, 4, 4, 8] },
     // TODO: Preserve as [8, 16].

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -322,6 +322,123 @@ describe("MusicXML export", () => {
     ]);
   });
 
+  it.each([
+    {
+      start: 0,
+      actual: [
+        {
+          type: "note",
+          duration: 4,
+          notation: { type: "eighth", triplet: true },
+        },
+        {
+          type: "rest",
+          duration: 8,
+          notation: { type: "quarter", triplet: true },
+        },
+        { type: "rest", duration: 12, notation: { type: "quarter" } },
+        { type: "rest", duration: 24, notation: { type: "half" } },
+      ],
+    },
+    {
+      start: 1,
+      actual: [
+        { type: "rest", duration: 12, notation: { type: "quarter" } },
+        {
+          type: "note",
+          duration: 4,
+          notation: { type: "eighth", triplet: true },
+        },
+        {
+          type: "rest",
+          duration: 8,
+          notation: { type: "quarter", triplet: true },
+        },
+        { type: "rest", duration: 24, notation: { type: "half" } },
+      ],
+    },
+    {
+      start: 2,
+      actual: [
+        { type: "rest", duration: 24, notation: { type: "half" } },
+        {
+          type: "note",
+          duration: 4,
+          notation: { type: "eighth", triplet: true },
+        },
+        {
+          type: "rest",
+          duration: 8,
+          notation: { type: "quarter", triplet: true },
+        },
+        { type: "rest", duration: 12, notation: { type: "quarter" } },
+      ],
+    },
+    {
+      start: 3,
+      actual: [
+        {
+          type: "rest",
+          duration: 36,
+          notation: { type: "half", dots: 1 },
+        },
+        {
+          type: "note",
+          duration: 4,
+          notation: { type: "eighth", triplet: true },
+        },
+        {
+          type: "rest",
+          duration: 8,
+          notation: { type: "quarter", triplet: true },
+        },
+      ],
+    },
+  ])(
+    "decomposes an eighth-note triplet at beat $start",
+    ({ start, actual }) => {
+      const model = buildModel([makeNote({ start, duration: 1 / 3 })]);
+
+      expect(model.measures[0].events).toMatchObject(actual);
+    },
+  );
+
+  it.each([
+    // TODO: Preserve as [8, 8, 8].
+    { start: 0, durations: [8, 8, 8], actual: [8, 4, 4, 8] },
+    // TODO: Preserve as [8, 16].
+    { start: 0, durations: [8, 16], actual: [8, 4, 12] },
+    { start: 0, durations: [16, 8], actual: [16, 8] },
+    // TODO: Preserve as [8, 8, 8].
+    { start: 2, durations: [8, 8, 8], actual: [8, 4, 4, 8] },
+    // TODO: Preserve as [8, 16].
+    { start: 2, durations: [8, 16], actual: [8, 4, 12] },
+    // TODO: Preserve as [16, 8].
+    { start: 2, durations: [16, 8], actual: [12, 4, 8] },
+  ])(
+    "decomposes quarter-note triplet $durations at beat $start",
+    ({ start, durations, actual }) => {
+      let position = start;
+      const model = buildModel(
+        durations.map((duration, index) => {
+          const note = makeNote({
+            id: `triplet-${index}`,
+            start: position,
+            duration: duration / QUARTER_NOTE_DURATION,
+          });
+          position += duration / QUARTER_NOTE_DURATION;
+          return note;
+        }),
+      );
+
+      const noteEvents = model.measures[0].events
+        .filter((event) => event.type === "note")
+        .map(({ duration }) => duration);
+
+      expect(noteEvents).toEqual(actual);
+    },
+  );
+
   it("fills gaps and remaining measure time with rests", () => {
     const model = buildModel([
       makeNote({

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -415,20 +415,21 @@ describe("MusicXML export", () => {
     },
   );
 
+  // TODO: discuss what's the expectation
   it.each([
-    // TODO: Preserve the quarter note as [12].
+    // TODO: Preserve the quarter note as [12]?
     {
       start: 0.5,
       duration: 1,
       actual: [9, 3],
     },
-    // TODO: Preserve the eighth note as [6].
+    // TODO: Preserve the eighth note as [6]?
     {
       start: 0.25,
       duration: 0.5,
       actual: [3, 3],
     },
-    // TODO: Preserve the half note as [24].
+    // TODO: Preserve the half note as [24]?
     {
       start: 1,
       duration: 2,
@@ -446,14 +447,15 @@ describe("MusicXML export", () => {
     },
   );
 
+  // TODO: discuss what's the expectation
   it.each([
     { start: 0, durations: [8, 8, 8], actual: [8, 8, 8] },
-    // TODO: Preserve as [8, 16].
+    // TODO: Preserve as [8, 16]?
     { start: 0, durations: [8, 16], actual: [8, 8, 8] },
     { start: 0, durations: [16, 8], actual: [16, 8] },
     { start: 2, durations: [8, 8, 8], actual: [8, 8, 8] },
     { start: 2, durations: [8, 16], actual: [8, 16] },
-    // TODO: Preserve as [16, 8].
+    // TODO: Preserve as [16, 8]?
     { start: 2, durations: [16, 8], actual: [12, 4, 8] },
   ])(
     "decomposes quarter-note triplet $durations at beat $start",

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -325,6 +325,7 @@ describe("MusicXML export", () => {
   it.each([
     {
       start: 0,
+      // TODO: Preserve the ordinary trailing rests as [12, 24].
       actual: [
         {
           type: "note",
@@ -336,12 +337,23 @@ describe("MusicXML export", () => {
           duration: 8,
           notation: { type: "quarter", triplet: true },
         },
-        { type: "rest", duration: 12, notation: { type: "quarter" } },
-        { type: "rest", duration: 24, notation: { type: "half" } },
+        {
+          type: "rest",
+          duration: 18,
+          notation: { type: "quarter", dots: 1 },
+        },
+        {
+          type: "rest",
+          duration: 9,
+          notation: { type: "eighth", dots: 1 },
+        },
+        { type: "rest", duration: 3, notation: { type: "16th" } },
+        { type: "rest", duration: 6, notation: { type: "eighth" } },
       ],
     },
     {
       start: 1,
+      // TODO: Complete the triplet beat with [8], then preserve the rest as [24].
       actual: [
         { type: "rest", duration: 12, notation: { type: "quarter" } },
         {
@@ -351,10 +363,10 @@ describe("MusicXML export", () => {
         },
         {
           type: "rest",
-          duration: 8,
-          notation: { type: "quarter", triplet: true },
+          duration: 16,
+          notation: { type: "half", triplet: true },
         },
-        { type: "rest", duration: 24, notation: { type: "half" } },
+        { type: "rest", duration: 16, notation: { type: "half" } },
       ],
     },
     {
@@ -420,7 +432,7 @@ describe("MusicXML export", () => {
     {
       start: 1,
       duration: 2,
-      actual: [12, 12],
+      actual: [18, 6],
     },
   ])(
     "decomposes a $duration-beat note after a rest at beat $start",
@@ -435,15 +447,12 @@ describe("MusicXML export", () => {
   );
 
   it.each([
-    // TODO: Preserve as [8, 8, 8].
-    { start: 0, durations: [8, 8, 8], actual: [8, 4, 4, 8] },
+    { start: 0, durations: [8, 8, 8], actual: [8, 8, 8] },
     // TODO: Preserve as [8, 16].
-    { start: 0, durations: [8, 16], actual: [8, 4, 12] },
+    { start: 0, durations: [8, 16], actual: [8, 8, 8] },
     { start: 0, durations: [16, 8], actual: [16, 8] },
-    // TODO: Preserve as [8, 8, 8].
-    { start: 2, durations: [8, 8, 8], actual: [8, 4, 4, 8] },
-    // TODO: Preserve as [8, 16].
-    { start: 2, durations: [8, 16], actual: [8, 4, 12] },
+    { start: 2, durations: [8, 8, 8], actual: [8, 8, 8] },
+    { start: 2, durations: [8, 16], actual: [8, 16] },
     // TODO: Preserve as [16, 8].
     { start: 2, durations: [16, 8], actual: [12, 4, 8] },
   ])(

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -457,10 +457,25 @@ function splitDuration({
   let cursor = start;
   let remaining = duration;
   while (remaining > 0) {
+    const offsetInBeat = cursor % DIVISIONS;
+    const tripletCompletion =
+      offsetInBeat !== 0 && offsetInBeat % (DIVISIONS / 3) === 0
+        ? DURATION_CANDIDATES.find(
+            (item) =>
+              item.triplet && item.duration === DIVISIONS - offsetInBeat,
+          )
+        : undefined;
     // Prefer the longest notation value that starts on its valid beat boundary.
-    const candidate = DURATION_CANDIDATES.find(
-      (item) => item.duration <= remaining && cursor % item.alignment === 0,
-    )!;
+    const candidate =
+      (tripletCompletion && tripletCompletion.duration <= remaining
+        ? tripletCompletion
+        : undefined) ??
+      DURATION_CANDIDATES.find(
+        (item) =>
+          item.duration <= remaining &&
+          cursor % item.alignment === 0 &&
+          (item.duration <= DIVISIONS || cursor % item.duration === 0),
+      )!;
     result.push({
       duration: candidate.duration,
       notation: {

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -458,6 +458,8 @@ function splitDuration({
   let remaining = duration;
   while (remaining > 0) {
     const offsetInBeat = cursor % DIVISIONS;
+    // A triplet value inside a beat must complete that beat before ordinary
+    // notation resumes, for example an eighth-triplet followed by a quarter-triplet.
     const tripletCompletion =
       offsetInBeat !== 0 && offsetInBeat % (DIVISIONS / 3) === 0
         ? DURATION_CANDIDATES.find(
@@ -465,11 +467,12 @@ function splitDuration({
               item.triplet && item.duration === DIVISIONS - offsetInBeat,
           )
         : undefined;
-    // Prefer the longest notation value that starts on its valid beat boundary.
     const candidate =
       (tripletCompletion && tripletCompletion.duration <= remaining
         ? tripletCompletion
         : undefined) ??
+      // Longer values must start on their own natural boundary so they do not
+      // cross strong beats; shorter values retain their subdivision alignment.
       DURATION_CANDIDATES.find(
         (item) =>
           item.duration <= remaining &&

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -457,28 +457,12 @@ function splitDuration({
   let cursor = start;
   let remaining = duration;
   while (remaining > 0) {
-    const offsetInBeat = cursor % DIVISIONS;
-    // A triplet value inside a beat must complete that beat before ordinary
-    // notation resumes, for example an eighth-triplet followed by a quarter-triplet.
-    const tripletCompletion =
-      offsetInBeat !== 0 && offsetInBeat % (DIVISIONS / 3) === 0
-        ? DURATION_CANDIDATES.find(
-            (item) =>
-              item.triplet && item.duration === DIVISIONS - offsetInBeat,
-          )
-        : undefined;
-    const candidate =
-      (tripletCompletion && tripletCompletion.duration <= remaining
-        ? tripletCompletion
-        : undefined) ??
-      // Longer values must start on their own natural boundary so they do not
-      // cross strong beats; shorter values retain their subdivision alignment.
-      DURATION_CANDIDATES.find(
-        (item) =>
-          item.duration <= remaining &&
-          cursor % item.alignment === 0 &&
-          (item.duration <= DIVISIONS || cursor % item.duration === 0),
-      )!;
+    // Prefer the longest value aligned to its own grid. Triplets may also start
+    // where they complete a supported one- or two-beat tuplet span.
+    const candidate = DURATION_CANDIDATES.find(
+      (item) =>
+        item.duration <= remaining && isCandidateAligned({ item, cursor }),
+    )!;
     result.push({
       duration: candidate.duration,
       notation: {
@@ -491,6 +475,23 @@ function splitDuration({
     remaining -= candidate.duration;
   }
   return result;
+}
+
+function isCandidateAligned({
+  item,
+  cursor,
+}: {
+  item: DurationCandidate;
+  cursor: number;
+}): boolean {
+  if (cursor % item.alignment === 0) {
+    return true;
+  }
+  // Allow written quarter-triplet values or shorter to complete the beat.
+  if (item.triplet && item.duration <= DIVISIONS) {
+    return (cursor + item.duration) % DIVISIONS === 0;
+  }
+  return false;
 }
 
 /** Converts quarter-note beats to integer MusicXML divisions and rejects off-grid values. */


### PR DESCRIPTION
Score export currently decomposes silence after an eighth-note triplet into locally aligned triplet durations that leak across later beats. For example, a triplet eighth at the start of a measure produces fragmented triplet-valued rests throughout the bar instead of completing the first beat and returning to ordinary rests.

This PR makes duration decomposition complete the active triplet beat first, then chooses longer values only on their natural boundaries. It adds model coverage for eighth-triplet placement across all four beats and records the remaining quarter-triplet decomposition limitations as focused TODO cases.