### PR TITLE
fix: align long dotted score durations

### DIFF
--- a/src/lib/__snapshots__/five-string-tab.musicxml
+++ b/src/lib/__snapshots__/five-string-tab.musicxml
@@ -89,32 +89,16 @@
       </note>
       <note>
         <rest/>
-        <duration>18</duration>
+        <duration>12</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <dot/>
         <staff>1</staff>
       </note>
       <note>
         <rest/>
-        <duration>9</duration>
+        <duration>24</duration>
         <voice>1</voice>
-        <type>eighth</type>
-        <dot/>
-        <staff>1</staff>
-      </note>
-      <note>
-        <rest/>
-        <duration>3</duration>
-        <voice>1</voice>
-        <type>16th</type>
-        <staff>1</staff>
-      </note>
-      <note>
-        <rest/>
-        <duration>6</duration>
-        <voice>1</voice>
-        <type>eighth</type>
+        <type>half</type>
         <staff>1</staff>
       </note>
       <backup>
@@ -138,32 +122,16 @@
       </note>
       <note>
         <rest/>
-        <duration>18</duration>
+        <duration>12</duration>
         <voice>5</voice>
         <type>quarter</type>
-        <dot/>
         <staff>2</staff>
       </note>
       <note>
         <rest/>
-        <duration>9</duration>
+        <duration>24</duration>
         <voice>5</voice>
-        <type>eighth</type>
-        <dot/>
-        <staff>2</staff>
-      </note>
-      <note>
-        <rest/>
-        <duration>3</duration>
-        <voice>5</voice>
-        <type>16th</type>
-        <staff>2</staff>
-      </note>
-      <note>
-        <rest/>
-        <duration>6</duration>
-        <voice>5</voice>
-        <type>eighth</type>
+        <type>half</type>
         <staff>2</staff>
       </note>
     </measure>

--- a/src/lib/musicxml-export.test.ts
+++ b/src/lib/musicxml-export.test.ts
@@ -322,6 +322,42 @@ describe("MusicXML export", () => {
     ]);
   });
 
+  it.each([
+    // TODO: Preserve the quarter note as [12].
+    { start: 0.5, duration: 1, actual: [9, 3] },
+    // TODO: Preserve the eighth note as [6].
+    { start: 0.25, duration: 0.5, actual: [3, 3] },
+    { start: 1, duration: 2, actual: [12, 12] },
+  ])(
+    "decomposes a $duration-beat note after a rest at beat $start",
+    ({ start, duration, actual }) => {
+      const model = buildModel([makeNote({ start, duration })]);
+      const noteEvents = model.measures[0].events
+        .filter((event) => event.type === "note")
+        .map((event) => event.duration);
+
+      expect(noteEvents).toEqual(actual);
+    },
+  );
+
+  it("decomposes trailing silence after a quarter note", () => {
+    const model = buildModel([makeNote({ start: 0, duration: 1 })]);
+
+    expect(model.measures[0].events).toMatchObject([
+      {
+        type: "note",
+        duration: 12,
+        notation: { type: "quarter" },
+      },
+      {
+        type: "rest",
+        duration: 12,
+        notation: { type: "quarter" },
+      },
+      { type: "rest", duration: 24, notation: { type: "half" } },
+    ]);
+  });
+
   it("fills gaps and remaining measure time with rests", () => {
     const model = buildModel([
       makeNote({

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -459,7 +459,8 @@ function splitDuration({
   while (remaining > 0) {
     // Prefer the longest notation value that starts on its valid beat boundary.
     const candidate = DURATION_CANDIDATES.find(
-      (item) => item.duration <= remaining && cursor % item.alignment === 0,
+      (item) =>
+        item.duration <= remaining && isCandidateAligned({ item, cursor }),
     )!;
     result.push({
       duration: candidate.duration,
@@ -473,6 +474,19 @@ function splitDuration({
     remaining -= candidate.duration;
   }
   return result;
+}
+
+function isCandidateAligned({
+  item,
+  cursor,
+}: {
+  item: DurationCandidate;
+  cursor: number;
+}): boolean {
+  if (item.dots && item.duration > DIVISIONS) {
+    return cursor % item.duration === 0;
+  }
+  return cursor % item.alignment === 0;
 }
 
 /** Converts quarter-note beats to integer MusicXML divisions and rejects off-grid values. */


### PR DESCRIPTION
Long dotted values currently use their base note alignment, so a dotted quarter can start on beat 2 and cross the next strong beat. This fragments otherwise simple trailing silence into dotted eighth and 16th rests.

This PR makes dotted values longer than one beat require full-duration alignment while leaving short dotted, ordinary, and triplet candidates unchanged. A quarter note followed by three beats of silence now exports as a quarter rest and half rest.