### PR TITLE
refactor: add metric-aware score durations

### DIFF
--- a/src/lib/__snapshots__/five-string-tab.musicxml
+++ b/src/lib/__snapshots__/five-string-tab.musicxml
@@ -89,32 +89,16 @@
       </note>
       <note>
         <rest/>
-        <duration>18</duration>
+        <duration>12</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <dot/>
         <staff>1</staff>
       </note>
       <note>
         <rest/>
-        <duration>9</duration>
+        <duration>24</duration>
         <voice>1</voice>
-        <type>eighth</type>
-        <dot/>
-        <staff>1</staff>
-      </note>
-      <note>
-        <rest/>
-        <duration>3</duration>
-        <voice>1</voice>
-        <type>16th</type>
-        <staff>1</staff>
-      </note>
-      <note>
-        <rest/>
-        <duration>6</duration>
-        <voice>1</voice>
-        <type>eighth</type>
+        <type>half</type>
         <staff>1</staff>
       </note>
       <backup>
@@ -138,32 +122,16 @@
       </note>
       <note>
         <rest/>
-        <duration>18</duration>
+        <duration>12</duration>
         <voice>5</voice>
         <type>quarter</type>
-        <dot/>
         <staff>2</staff>
       </note>
       <note>
         <rest/>
-        <duration>9</duration>
+        <duration>24</duration>
         <voice>5</voice>
-        <type>eighth</type>
-        <dot/>
-        <staff>2</staff>
-      </note>
-      <note>
-        <rest/>
-        <duration>3</duration>
-        <voice>5</voice>
-        <type>16th</type>
-        <staff>2</staff>
-      </note>
-      <note>
-        <rest/>
-        <duration>6</duration>
-        <voice>5</voice>
-        <type>eighth</type>
+        <type>half</type>
         <staff>2</staff>
       </note>
     </measure>

--- a/src/lib/musicxml-export.ts
+++ b/src/lib/musicxml-export.ts
@@ -2,6 +2,12 @@ import type { Locator, Note, TimeSignature } from "../types";
 import { range } from "../utils/array";
 import { parseLocatorLabel } from "./locators";
 import {
+  buildMeasureEvents,
+  type DurationNotation,
+  MUSICXML_DIVISIONS,
+  type MusicXmlMeasureEvent,
+} from "./musicxml-measure-events";
+import {
   type KeySignature,
   type SpelledPitch,
   spellChromaticPitch,
@@ -18,7 +24,7 @@ import { resolveTabPosition, type TabPosition } from "./tab-annotation";
 // MusicXML durations are integer multiples of divisions per quarter note.
 // Twelve is divisible by 2, 3, and 4, so eighth, triplet, and 16th-note
 // subdivisions are represented without rounding.
-const DIVISIONS = 12;
+const DIVISIONS = MUSICXML_DIVISIONS;
 const EPSILON = 1e-6;
 
 export type MusicXmlModelOptions = {
@@ -64,48 +70,6 @@ type MeasureKeySignature = {
   active: KeySignature;
   emit: boolean;
 };
-
-export type MusicXmlMeasureEvent =
-  | { type: "rest"; duration: number; notation: DurationNotation }
-  | {
-      type: "note";
-      pitch: SpelledPitch;
-      duration: number;
-      notation: DurationNotation;
-      tabPosition: TabPosition;
-      tieStart: boolean;
-      tieStop: boolean;
-    };
-
-type DurationNotation = {
-  type: string;
-  dots?: number;
-  triplet?: boolean;
-};
-
-type DurationCandidate = DurationNotation & {
-  duration: number;
-  alignment: number;
-};
-
-const DURATION_CANDIDATES: DurationCandidate[] = [
-  { duration: 48, alignment: 48, type: "whole" },
-  { duration: 36, alignment: 24, type: "half", dots: 1 },
-  { duration: 32, alignment: 32, type: "whole", triplet: true },
-  { duration: 24, alignment: 24, type: "half" },
-  { duration: 18, alignment: 12, type: "quarter", dots: 1 },
-  { duration: 16, alignment: 16, type: "half", triplet: true },
-  { duration: 12, alignment: 12, type: "quarter" },
-  { duration: 9, alignment: 6, type: "eighth", dots: 1 },
-  { duration: 8, alignment: 8, type: "quarter", triplet: true },
-  { duration: 6, alignment: 6, type: "eighth" },
-  { duration: 4, alignment: 4, type: "eighth", triplet: true },
-  { duration: 3, alignment: 3, type: "16th" },
-  { duration: 2, alignment: 2, type: "16th", triplet: true },
-  // This one-unit fallback makes every positive integer grid duration
-  // decomposable after toGridUnits has validated its inputs.
-  { duration: 1, alignment: 1, type: "32nd", triplet: true },
-];
 
 // Model preprocessing
 export function buildMusicXmlModel({
@@ -184,6 +148,7 @@ export function buildMusicXmlModel({
           notes,
           measureStart,
           measureDuration,
+          timeSignature,
         }),
         locators: locatorsByMeasure[index],
         keySignature: measureKeySignature.emit
@@ -370,109 +335,6 @@ function buildLocatorsByMeasure({
         offset: locator.position - measureIndex * measureDuration,
       })),
   );
-}
-
-/** Clips notes to one measure and fills its timeline with notated notes and rests. */
-function buildMeasureEvents({
-  notes,
-  measureStart,
-  measureDuration,
-}: {
-  notes: QuantizedNote[];
-  measureStart: number;
-  measureDuration: number;
-}): MusicXmlMeasureEvent[] {
-  const events: MusicXmlMeasureEvent[] = [];
-  let cursor = 0;
-
-  for (const note of notes) {
-    // Convert the assigned note to measure-local bounds.
-    const originalNoteStart = note.start - measureStart;
-    const originalNoteEnd = note.end - measureStart;
-    const noteStart = Math.max(originalNoteStart, 0);
-    const noteEnd = Math.min(originalNoteEnd, measureDuration);
-
-    // Fill silence before this note, including any gap after the previous note.
-    if (noteStart > cursor) {
-      for (const piece of splitDuration({
-        start: cursor,
-        duration: noteStart - cursor,
-      })) {
-        events.push({
-          type: "rest" as const,
-          duration: piece.duration,
-          notation: piece.notation,
-        });
-      }
-    }
-
-    // Split the clipped note into notatable tied pieces.
-    let pieceStart = noteStart;
-    for (const piece of splitDuration({
-      start: noteStart,
-      duration: noteEnd - noteStart,
-    })) {
-      const pieceEnd = pieceStart + piece.duration;
-      events.push({
-        type: "note",
-        pitch: note.pitch,
-        duration: piece.duration,
-        notation: piece.notation,
-        tabPosition: note.tabPosition,
-        // Splits within or across measures become one tied chain, which is then
-        // rendered identically on both notation staves.
-        tieStart: pieceEnd < originalNoteEnd,
-        tieStop: pieceStart > originalNoteStart,
-      });
-      pieceStart = pieceEnd;
-    }
-    cursor = noteEnd;
-  }
-
-  // Fill silence from the final note to the end of the measure.
-  if (cursor < measureDuration) {
-    for (const piece of splitDuration({
-      start: cursor,
-      duration: measureDuration - cursor,
-    })) {
-      events.push({
-        type: "rest" as const,
-        duration: piece.duration,
-        notation: piece.notation,
-      });
-    }
-  }
-  return events;
-}
-
-/** Decomposes a grid duration into the longest notation values valid at each offset. */
-function splitDuration({
-  start,
-  duration,
-}: {
-  start: number;
-  duration: number;
-}): { duration: number; notation: DurationNotation }[] {
-  const result: { duration: number; notation: DurationNotation }[] = [];
-  let cursor = start;
-  let remaining = duration;
-  while (remaining > 0) {
-    // Prefer the longest notation value that starts on its valid beat boundary.
-    const candidate = DURATION_CANDIDATES.find(
-      (item) => item.duration <= remaining && cursor % item.alignment === 0,
-    )!;
-    result.push({
-      duration: candidate.duration,
-      notation: {
-        type: candidate.type,
-        dots: candidate.dots,
-        triplet: candidate.triplet,
-      },
-    });
-    cursor += candidate.duration;
-    remaining -= candidate.duration;
-  }
-  return result;
 }
 
 /** Converts quarter-note beats to integer MusicXML divisions and rejects off-grid values. */

--- a/src/lib/musicxml-measure-events.test.ts
+++ b/src/lib/musicxml-measure-events.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { TimeSignature } from "../types";
+import {
+  buildMeasureEvents,
+  type MeasureNote,
+  MUSICXML_DIVISIONS,
+} from "./musicxml-measure-events";
+
+const FOUR_FOUR: TimeSignature = { numerator: 4, denominator: 4 };
+
+function makeNote(options: Partial<MeasureNote> = {}): MeasureNote {
+  return {
+    start: 0,
+    end: MUSICXML_DIVISIONS,
+    pitch: { step: "A", alter: 0, octave: 2 },
+    tabPosition: { tabString: 3, fret: 0 },
+    ...options,
+  };
+}
+
+describe("MusicXML measure events", () => {
+  it("uses metric rest values after a quarter note", () => {
+    const events = buildMeasureEvents({
+      notes: [makeNote()],
+      measureStart: 0,
+      measureDuration: 4 * MUSICXML_DIVISIONS,
+      timeSignature: FOUR_FOUR,
+    });
+
+    expect(
+      events.map(({ type, duration, notation }) => ({
+        type,
+        duration,
+        notation,
+      })),
+    ).toEqual([
+      { type: "note", duration: 12, notation: { type: "quarter" } },
+      { type: "rest", duration: 12, notation: { type: "quarter" } },
+      { type: "rest", duration: 24, notation: { type: "half" } },
+    ]);
+  });
+
+  it("splits a two-beat note at the midpoint of 4/4", () => {
+    const events = buildMeasureEvents({
+      notes: [makeNote({ start: 12, end: 36 })],
+      measureStart: 0,
+      measureDuration: 4 * MUSICXML_DIVISIONS,
+      timeSignature: FOUR_FOUR,
+    });
+
+    expect(
+      events.map(({ type, duration, notation }) => ({
+        type,
+        duration,
+        notation,
+      })),
+    ).toEqual([
+      { type: "rest", duration: 12, notation: { type: "quarter" } },
+      { type: "note", duration: 12, notation: { type: "quarter" } },
+      { type: "note", duration: 12, notation: { type: "quarter" } },
+      { type: "rest", duration: 12, notation: { type: "quarter" } },
+    ]);
+    expect(events.slice(1, 3)).toMatchObject([
+      { tieStart: true, tieStop: false },
+      { tieStart: false, tieStop: true },
+    ]);
+  });
+
+  it("keeps a dotted note within one side of the midpoint", () => {
+    const events = buildMeasureEvents({
+      notes: [makeNote({ end: 18 })],
+      measureStart: 0,
+      measureDuration: 4 * MUSICXML_DIVISIONS,
+      timeSignature: FOUR_FOUR,
+    });
+
+    expect(events[0]).toMatchObject({
+      type: "note",
+      duration: 18,
+      notation: { type: "quarter", dots: 1 },
+    });
+  });
+});

--- a/src/lib/musicxml-measure-events.test.ts
+++ b/src/lib/musicxml-measure-events.test.ts
@@ -80,4 +80,109 @@ describe("MusicXML measure events", () => {
       notation: { type: "quarter", dots: 1 },
     });
   });
+
+  it.each([
+    {
+      start: 0,
+      expected: [
+        {
+          type: "note",
+          duration: 4,
+          notation: { type: "eighth", triplet: true },
+        },
+        {
+          type: "rest",
+          duration: 9,
+          notation: { type: "eighth", dots: 1 },
+        },
+        {
+          type: "rest",
+          duration: 9,
+          notation: { type: "eighth", dots: 1 },
+        },
+        {
+          type: "rest",
+          duration: 2,
+          notation: { type: "16th", triplet: true },
+        },
+        { type: "rest", duration: 24, notation: { type: "half" } },
+      ],
+    },
+    {
+      start: 12,
+      expected: [
+        { type: "rest", duration: 12, notation: { type: "quarter" } },
+        {
+          type: "note",
+          duration: 4,
+          notation: { type: "eighth", triplet: true },
+        },
+        {
+          type: "rest",
+          duration: 16,
+          notation: { type: "half", triplet: true },
+        },
+        {
+          type: "rest",
+          duration: 16,
+          notation: { type: "half", triplet: true },
+        },
+      ],
+    },
+    {
+      start: 24,
+      expected: [
+        { type: "rest", duration: 24, notation: { type: "half" } },
+        {
+          type: "note",
+          duration: 4,
+          notation: { type: "eighth", triplet: true },
+        },
+        {
+          type: "rest",
+          duration: 4,
+          notation: { type: "eighth", triplet: true },
+        },
+        {
+          type: "rest",
+          duration: 16,
+          notation: { type: "half", triplet: true },
+        },
+      ],
+    },
+    {
+      start: 36,
+      expected: [
+        { type: "rest", duration: 36, notation: { type: "half", dots: 1 } },
+        {
+          type: "note",
+          duration: 4,
+          notation: { type: "eighth", triplet: true },
+        },
+        {
+          type: "rest",
+          duration: 8,
+          notation: { type: "quarter", triplet: true },
+        },
+      ],
+    },
+  ])(
+    "decomposes a triplet eighth at grid offset $start",
+    ({ start, expected }) => {
+      const events = buildMeasureEvents({
+        notes: [makeNote({ start, end: start + 4 })],
+        measureStart: 0,
+        measureDuration: 4 * MUSICXML_DIVISIONS,
+        timeSignature: FOUR_FOUR,
+      });
+
+      expect(
+        events.map(({ type, duration, notation }) => ({
+          type,
+          duration,
+          notation,
+        })),
+      ).toEqual(expected);
+    },
+  );
 });

--- a/src/lib/musicxml-measure-events.test.ts
+++ b/src/lib/musicxml-measure-events.test.ts
@@ -92,19 +92,10 @@ describe("MusicXML measure events", () => {
         },
         {
           type: "rest",
-          duration: 9,
-          notation: { type: "eighth", dots: 1 },
+          duration: 8,
+          notation: { type: "quarter", triplet: true },
         },
-        {
-          type: "rest",
-          duration: 9,
-          notation: { type: "eighth", dots: 1 },
-        },
-        {
-          type: "rest",
-          duration: 2,
-          notation: { type: "16th", triplet: true },
-        },
+        { type: "rest", duration: 12, notation: { type: "quarter" } },
         { type: "rest", duration: 24, notation: { type: "half" } },
       ],
     },
@@ -119,14 +110,10 @@ describe("MusicXML measure events", () => {
         },
         {
           type: "rest",
-          duration: 16,
-          notation: { type: "half", triplet: true },
+          duration: 8,
+          notation: { type: "quarter", triplet: true },
         },
-        {
-          type: "rest",
-          duration: 16,
-          notation: { type: "half", triplet: true },
-        },
+        { type: "rest", duration: 24, notation: { type: "half" } },
       ],
     },
     {
@@ -140,14 +127,10 @@ describe("MusicXML measure events", () => {
         },
         {
           type: "rest",
-          duration: 4,
-          notation: { type: "eighth", triplet: true },
+          duration: 8,
+          notation: { type: "quarter", triplet: true },
         },
-        {
-          type: "rest",
-          duration: 16,
-          notation: { type: "half", triplet: true },
-        },
+        { type: "rest", duration: 12, notation: { type: "quarter" } },
       ],
     },
     {

--- a/src/lib/musicxml-measure-events.ts
+++ b/src/lib/musicxml-measure-events.ts
@@ -4,6 +4,8 @@ import type { TabPosition } from "./tab-annotation";
 
 export const MUSICXML_DIVISIONS = 12;
 
+// DurationNotation describes the written value. DurationPiece.duration remains
+// the performed MusicXML duration, which differs for tuplets.
 export type DurationNotation = {
   type: string;
   dots?: number;
@@ -29,6 +31,9 @@ export type MeasureNote = {
   tabPosition: TabPosition;
 };
 
+// Raw events preserve authored note boundaries and make every implicit silence
+// explicit before notation values are chosen. Decomposition must never merge
+// across one of these note/rest boundaries.
 type RawMeasureEvent =
   | { type: "rest"; start: number; end: number }
   | {
@@ -51,6 +56,9 @@ type MetricContext = {
   beatDuration: number;
 };
 
+// Ordered longest-first so equal-symbol paths prefer longer values. Placement
+// belongs to the metric heuristic below rather than to absolute alignments in
+// this vocabulary.
 const DURATION_CANDIDATES: DurationPiece[] = [
   { duration: 48, notation: { type: "whole" } },
   { duration: 36, notation: { type: "half", dots: 1 } },
@@ -79,6 +87,8 @@ export function buildMeasureEvents({
   measureDuration: number;
   timeSignature: TimeSignature;
 }): MusicXmlMeasureEvent[] {
+  // Build the complete measure first so future tuplet detection can inspect
+  // neighboring notes and rests before either side is decomposed.
   const timeline = buildRawTimeline({ notes, measureStart, measureDuration });
   const metric = buildMetricContext({ timeSignature });
 
@@ -98,6 +108,9 @@ function buildRawTimeline({
   let cursor = 0;
 
   for (const note of notes) {
+    // Notes may be assigned to every measure they overlap. Keep both clipped
+    // and original bounds so notation is measure-local while ties remain aware
+    // of continuations across barlines.
     const originalStart = note.start - measureStart;
     const originalEnd = note.end - measureStart;
     const start = Math.max(originalStart, 0);
@@ -131,6 +144,8 @@ function decomposeEvent({
   event: RawMeasureEvent;
   metric: MetricContext;
 }): MusicXmlMeasureEvent[] {
+  // Raw boundaries are fixed, but notation splits inside one raw event are
+  // chosen as a complete path instead of making irreversible greedy choices.
   const pieces = findFewestPieces({
     start: event.start,
     end: event.end,
@@ -151,6 +166,8 @@ function decomposeEvent({
       duration: piece.duration,
       notation: piece.notation,
       tabPosition: event.tabPosition,
+      // Every internal split and clipped barline segment belongs to one tied
+      // chain. A single unsplit note has neither marker.
       tieStart: pieceEnd < event.originalEnd,
       tieStop: cursor > event.originalStart,
     };
@@ -169,6 +186,8 @@ function buildMetricContext({
     (4 / timeSignature.denominator) *
     MUSICXML_DIVISIONS;
   const beatDuration =
+    // Compound x/8 meters group three eighth notes into one dotted-quarter
+    // beat. Other supported meters use the denominator as the beat unit.
     timeSignature.denominator === 8 && timeSignature.numerator % 3 === 0
       ? 1.5 * MUSICXML_DIVISIONS
       : (4 / timeSignature.denominator) * MUSICXML_DIVISIONS;
@@ -186,6 +205,8 @@ function findFewestPieces({
   durationType: "note" | "rest";
   metric: MetricContext;
 }): DurationPiece[] {
+  // The search space is tiny, but memoization makes the complete-path search
+  // linear in reachable grid offsets rather than repeatedly exploring suffixes.
   const memo = new Map<number, DurationPiece[]>();
 
   function visit(cursor: number): DurationPiece[] {
@@ -203,6 +224,8 @@ function findFewestPieces({
         isValidPlacement({ candidate, cursor, durationType, metric }),
     )
       .map((candidate) => [candidate, ...visit(cursor + candidate.duration)])
+      // Candidate order breaks equal-length ties, preserving the longest-first
+      // vocabulary preference without sacrificing global symbol minimization.
       .toSorted((left, right) => left.length - right.length)[0];
     memo.set(cursor, result);
     return result;
@@ -223,16 +246,25 @@ function isValidPlacement({
   metric: MetricContext;
 }): boolean {
   if (candidate.notation.triplet) {
+    // This retains the exporter's existing triplet placement behavior for now.
+    // Measure-wide tuplet regions will replace this absolute phase check so an
+    // equivalent triplet decomposes identically on every beat.
     return cursor % candidate.duration === 0;
   }
 
   const end = cursor + candidate.duration;
+  // Ordinary beat-sized and longer values start on their own metric raster.
+  // This prevents a dotted value from winning merely because it fits the
+  // remaining arithmetic duration while crossing stronger beat structure.
   if (
     candidate.duration >= metric.beatDuration &&
     cursor % candidate.duration !== 0
   ) {
     return false;
   }
+  // In 4/4, preserve the central accent for notes. This is the first concrete
+  // boundary-strength rule; a later metric hierarchy can generalize it across
+  // time signatures and apply stricter tolerances to rests.
   if (durationType === "note" && metric.measureDuration === 48) {
     const midpoint = metric.measureDuration / 2;
     if (cursor < midpoint && end > midpoint) {

--- a/src/lib/musicxml-measure-events.ts
+++ b/src/lib/musicxml-measure-events.ts
@@ -1,0 +1,243 @@
+import type { TimeSignature } from "../types";
+import type { SpelledPitch } from "./pitch-spelling";
+import type { TabPosition } from "./tab-annotation";
+
+export const MUSICXML_DIVISIONS = 12;
+
+export type DurationNotation = {
+  type: string;
+  dots?: number;
+  triplet?: boolean;
+};
+
+export type MusicXmlMeasureEvent =
+  | { type: "rest"; duration: number; notation: DurationNotation }
+  | {
+      type: "note";
+      pitch: SpelledPitch;
+      duration: number;
+      notation: DurationNotation;
+      tabPosition: TabPosition;
+      tieStart: boolean;
+      tieStop: boolean;
+    };
+
+export type MeasureNote = {
+  start: number;
+  end: number;
+  pitch: SpelledPitch;
+  tabPosition: TabPosition;
+};
+
+type RawMeasureEvent =
+  | { type: "rest"; start: number; end: number }
+  | {
+      type: "note";
+      start: number;
+      end: number;
+      originalStart: number;
+      originalEnd: number;
+      pitch: SpelledPitch;
+      tabPosition: TabPosition;
+    };
+
+type DurationPiece = {
+  duration: number;
+  notation: DurationNotation;
+};
+
+type MetricContext = {
+  measureDuration: number;
+  beatDuration: number;
+};
+
+const DURATION_CANDIDATES: DurationPiece[] = [
+  { duration: 48, notation: { type: "whole" } },
+  { duration: 36, notation: { type: "half", dots: 1 } },
+  { duration: 32, notation: { type: "whole", triplet: true } },
+  { duration: 24, notation: { type: "half" } },
+  { duration: 18, notation: { type: "quarter", dots: 1 } },
+  { duration: 16, notation: { type: "half", triplet: true } },
+  { duration: 12, notation: { type: "quarter" } },
+  { duration: 9, notation: { type: "eighth", dots: 1 } },
+  { duration: 8, notation: { type: "quarter", triplet: true } },
+  { duration: 6, notation: { type: "eighth" } },
+  { duration: 4, notation: { type: "eighth", triplet: true } },
+  { duration: 3, notation: { type: "16th" } },
+  { duration: 2, notation: { type: "16th", triplet: true } },
+  { duration: 1, notation: { type: "32nd", triplet: true } },
+];
+
+export function buildMeasureEvents({
+  notes,
+  measureStart,
+  measureDuration,
+  timeSignature,
+}: {
+  notes: MeasureNote[];
+  measureStart: number;
+  measureDuration: number;
+  timeSignature: TimeSignature;
+}): MusicXmlMeasureEvent[] {
+  const timeline = buildRawTimeline({ notes, measureStart, measureDuration });
+  const metric = buildMetricContext({ timeSignature });
+
+  return timeline.flatMap((event) => decomposeEvent({ event, metric }));
+}
+
+function buildRawTimeline({
+  notes,
+  measureStart,
+  measureDuration,
+}: {
+  notes: MeasureNote[];
+  measureStart: number;
+  measureDuration: number;
+}): RawMeasureEvent[] {
+  const events: RawMeasureEvent[] = [];
+  let cursor = 0;
+
+  for (const note of notes) {
+    const originalStart = note.start - measureStart;
+    const originalEnd = note.end - measureStart;
+    const start = Math.max(originalStart, 0);
+    const end = Math.min(originalEnd, measureDuration);
+
+    if (start > cursor) {
+      events.push({ type: "rest", start: cursor, end: start });
+    }
+    events.push({
+      type: "note",
+      start,
+      end,
+      originalStart,
+      originalEnd,
+      pitch: note.pitch,
+      tabPosition: note.tabPosition,
+    });
+    cursor = end;
+  }
+
+  if (cursor < measureDuration) {
+    events.push({ type: "rest", start: cursor, end: measureDuration });
+  }
+  return events;
+}
+
+function decomposeEvent({
+  event,
+  metric,
+}: {
+  event: RawMeasureEvent;
+  metric: MetricContext;
+}): MusicXmlMeasureEvent[] {
+  const pieces = findFewestPieces({
+    start: event.start,
+    end: event.end,
+    durationType: event.type,
+    metric,
+  });
+
+  if (event.type === "rest") {
+    return pieces.map((piece) => ({ type: "rest", ...piece }));
+  }
+
+  let cursor = event.start;
+  return pieces.map((piece) => {
+    const pieceEnd = cursor + piece.duration;
+    const result: MusicXmlMeasureEvent = {
+      type: "note",
+      pitch: event.pitch,
+      duration: piece.duration,
+      notation: piece.notation,
+      tabPosition: event.tabPosition,
+      tieStart: pieceEnd < event.originalEnd,
+      tieStop: cursor > event.originalStart,
+    };
+    cursor = pieceEnd;
+    return result;
+  });
+}
+
+function buildMetricContext({
+  timeSignature,
+}: {
+  timeSignature: TimeSignature;
+}): MetricContext {
+  const measureDuration =
+    timeSignature.numerator *
+    (4 / timeSignature.denominator) *
+    MUSICXML_DIVISIONS;
+  const beatDuration =
+    timeSignature.denominator === 8 && timeSignature.numerator % 3 === 0
+      ? 1.5 * MUSICXML_DIVISIONS
+      : (4 / timeSignature.denominator) * MUSICXML_DIVISIONS;
+  return { measureDuration, beatDuration };
+}
+
+function findFewestPieces({
+  start,
+  end,
+  durationType,
+  metric,
+}: {
+  start: number;
+  end: number;
+  durationType: "note" | "rest";
+  metric: MetricContext;
+}): DurationPiece[] {
+  const memo = new Map<number, DurationPiece[]>();
+
+  function visit(cursor: number): DurationPiece[] {
+    if (cursor === end) {
+      return [];
+    }
+    const cached = memo.get(cursor);
+    if (cached) {
+      return cached;
+    }
+
+    const result = DURATION_CANDIDATES.filter(
+      (candidate) =>
+        cursor + candidate.duration <= end &&
+        isValidPlacement({ candidate, cursor, durationType, metric }),
+    )
+      .map((candidate) => [candidate, ...visit(cursor + candidate.duration)])
+      .toSorted((left, right) => left.length - right.length)[0];
+    memo.set(cursor, result);
+    return result;
+  }
+
+  return visit(start);
+}
+
+function isValidPlacement({
+  candidate,
+  cursor,
+  durationType,
+  metric,
+}: {
+  candidate: DurationPiece;
+  cursor: number;
+  durationType: "note" | "rest";
+  metric: MetricContext;
+}): boolean {
+  if (candidate.notation.triplet) {
+    return cursor % candidate.duration === 0;
+  }
+
+  const end = cursor + candidate.duration;
+  if (
+    candidate.duration >= metric.beatDuration &&
+    cursor % candidate.duration !== 0
+  ) {
+    return false;
+  }
+  if (durationType === "note" && metric.measureDuration === 48) {
+    const midpoint = metric.measureDuration / 2;
+    if (cursor < midpoint && end > midpoint) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/lib/musicxml-measure-events.ts
+++ b/src/lib/musicxml-measure-events.ts
@@ -4,8 +4,6 @@ import type { TabPosition } from "./tab-annotation";
 
 export const MUSICXML_DIVISIONS = 12;
 
-// DurationNotation describes the written value. DurationPiece.duration remains
-// the performed MusicXML duration, which differs for tuplets.
 export type DurationNotation = {
   type: string;
   dots?: number;
@@ -32,8 +30,7 @@ export type MeasureNote = {
 };
 
 // Raw events preserve authored note boundaries and make every implicit silence
-// explicit before notation values are chosen. Decomposition must never merge
-// across one of these note/rest boundaries.
+// explicit. Notation decomposition may split them, but never merge across them.
 type RawMeasureEvent =
   | { type: "rest"; start: number; end: number }
   | {
@@ -51,14 +48,21 @@ type DurationPiece = {
   notation: DurationNotation;
 };
 
-type MetricContext = {
-  measureDuration: number;
-  beatDuration: number;
+type MetricBoundary = {
+  position: number;
+  strength: number;
 };
 
-// Ordered longest-first so equal-symbol paths prefer longer values. Placement
-// belongs to the metric heuristic below rather than to absolute alignments in
-// this vocabulary.
+type TripletRegion = {
+  start: number;
+  end: number;
+};
+
+type MeasureContext = {
+  boundaries: MetricBoundary[];
+  triplets: TripletRegion[];
+};
+
 const DURATION_CANDIDATES: DurationPiece[] = [
   { duration: 48, notation: { type: "whole" } },
   { duration: 36, notation: { type: "half", dots: 1 } },
@@ -73,7 +77,7 @@ const DURATION_CANDIDATES: DurationPiece[] = [
   { duration: 4, notation: { type: "eighth", triplet: true } },
   { duration: 3, notation: { type: "16th" } },
   { duration: 2, notation: { type: "16th", triplet: true } },
-  { duration: 1, notation: { type: "32nd", triplet: true } },
+  { duration: 1, notation: { type: "32nd" } },
 ];
 
 export function buildMeasureEvents({
@@ -87,12 +91,15 @@ export function buildMeasureEvents({
   measureDuration: number;
   timeSignature: TimeSignature;
 }): MusicXmlMeasureEvent[] {
-  // Build the complete measure first so future tuplet detection can inspect
-  // neighboring notes and rests before either side is decomposed.
   const timeline = buildRawTimeline({ notes, measureStart, measureDuration });
-  const metric = buildMetricContext({ timeSignature });
-
-  return timeline.flatMap((event) => decomposeEvent({ event, metric }));
+  // The complete timeline determines local tuplets before either neighboring
+  // note or rest is decomposed. Every event then shares this measure context.
+  const context = buildMeasureContext({
+    timeline,
+    measureDuration,
+    timeSignature,
+  });
+  return timeline.flatMap((event) => decomposeEvent({ event, context }));
 }
 
 function buildRawTimeline({
@@ -108,9 +115,8 @@ function buildRawTimeline({
   let cursor = 0;
 
   for (const note of notes) {
-    // Notes may be assigned to every measure they overlap. Keep both clipped
-    // and original bounds so notation is measure-local while ties remain aware
-    // of continuations across barlines.
+    // A note may be assigned to every measure it overlaps. Keep original bounds
+    // for ties while clipping the rhythmic event to this measure.
     const originalStart = note.start - measureStart;
     const originalEnd = note.end - measureStart;
     const start = Math.max(originalStart, 0);
@@ -130,33 +136,115 @@ function buildRawTimeline({
     });
     cursor = end;
   }
-
   if (cursor < measureDuration) {
     events.push({ type: "rest", start: cursor, end: measureDuration });
   }
   return events;
 }
 
+function buildMeasureContext({
+  timeline,
+  measureDuration,
+  timeSignature,
+}: {
+  timeline: RawMeasureEvent[];
+  measureDuration: number;
+  timeSignature: TimeSignature;
+}): MeasureContext {
+  const beatDuration = getBeatDuration(timeSignature);
+  const boundaries: MetricBoundary[] = [
+    { position: 0, strength: 3 },
+    { position: measureDuration, strength: 3 },
+  ];
+  for (
+    let position = beatDuration;
+    position < measureDuration;
+    position += beatDuration
+  ) {
+    boundaries.push({
+      position,
+      strength: position * 2 === measureDuration ? 2 : 1,
+    });
+  }
+  return {
+    boundaries,
+    triplets: detectTripletRegions({ timeline, beatDuration, measureDuration }),
+  };
+}
+
+function getBeatDuration(timeSignature: TimeSignature): number {
+  // Compound x/8 meters group three eighth notes into one dotted-quarter beat.
+  if (timeSignature.denominator === 8 && timeSignature.numerator % 3 === 0) {
+    return 1.5 * MUSICXML_DIVISIONS;
+  }
+  return (4 / timeSignature.denominator) * MUSICXML_DIVISIONS;
+}
+
+function detectTripletRegions({
+  timeline,
+  beatDuration,
+  measureDuration,
+}: {
+  timeline: RawMeasureEvent[];
+  beatDuration: number;
+  measureDuration: number;
+}): TripletRegion[] {
+  // Initial support is deliberately limited to 3:2 eighth-note tuplets in one
+  // quarter-note beat. A region needs an authored note boundary on the triplet
+  // grid so ordinary all-silent or binary beats are never inferred as tuplets.
+  if (beatDuration !== MUSICXML_DIVISIONS) {
+    return [];
+  }
+  const noteBoundaries = timeline
+    .filter((event) => event.type === "note")
+    .flatMap((event) => [event.start, event.end]);
+  const regions: TripletRegion[] = [];
+  for (let start = 0; start < measureDuration; start += beatDuration) {
+    const end = start + beatDuration;
+    const hasTripletBoundary = noteBoundaries.some((position) => {
+      const offset = position - start;
+      return (
+        offset === MUSICXML_DIVISIONS / 3 ||
+        offset === (2 * MUSICXML_DIVISIONS) / 3
+      );
+    });
+    if (hasTripletBoundary) {
+      regions.push({ start, end });
+    }
+  }
+  return regions;
+}
+
 function decomposeEvent({
   event,
-  metric,
+  context,
 }: {
   event: RawMeasureEvent;
-  metric: MetricContext;
+  context: MeasureContext;
 }): MusicXmlMeasureEvent[] {
-  // Raw boundaries are fixed, but notation splits inside one raw event are
-  // chosen as a complete path instead of making irreversible greedy choices.
-  const pieces = findFewestPieces({
-    start: event.start,
-    end: event.end,
-    durationType: event.type,
-    metric,
-  });
+  // Split first at tuplet boundaries because no written value can cross into or
+  // out of a tuplet. Metric boundaries remain weighted choices in the search.
+  const regionEdges = context.triplets.flatMap(({ start, end }) => [
+    start,
+    end,
+  ]);
+  const points = [
+    event.start,
+    ...regionEdges.filter((point) => point > event.start && point < event.end),
+    event.end,
+  ].toSorted((left, right) => left - right);
+  const pieces = points.slice(0, -1).flatMap((start, index) =>
+    findBestPieces({
+      start,
+      end: points[index + 1],
+      durationType: event.type,
+      context,
+    }),
+  );
 
   if (event.type === "rest") {
     return pieces.map((piece) => ({ type: "rest", ...piece }));
   }
-
   let cursor = event.start;
   return pieces.map((piece) => {
     const pieceEnd = cursor + piece.duration;
@@ -166,8 +254,6 @@ function decomposeEvent({
       duration: piece.duration,
       notation: piece.notation,
       tabPosition: event.tabPosition,
-      // Every internal split and clipped barline segment belongs to one tied
-      // chain. A single unsplit note has neither marker.
       tieStart: pieceEnd < event.originalEnd,
       tieStop: cursor > event.originalStart,
     };
@@ -176,100 +262,112 @@ function decomposeEvent({
   });
 }
 
-function buildMetricContext({
-  timeSignature,
-}: {
-  timeSignature: TimeSignature;
-}): MetricContext {
-  const measureDuration =
-    timeSignature.numerator *
-    (4 / timeSignature.denominator) *
-    MUSICXML_DIVISIONS;
-  const beatDuration =
-    // Compound x/8 meters group three eighth notes into one dotted-quarter
-    // beat. Other supported meters use the denominator as the beat unit.
-    timeSignature.denominator === 8 && timeSignature.numerator % 3 === 0
-      ? 1.5 * MUSICXML_DIVISIONS
-      : (4 / timeSignature.denominator) * MUSICXML_DIVISIONS;
-  return { measureDuration, beatDuration };
-}
-
-function findFewestPieces({
+function findBestPieces({
   start,
   end,
   durationType,
-  metric,
+  context,
 }: {
   start: number;
   end: number;
   durationType: "note" | "rest";
-  metric: MetricContext;
+  context: MeasureContext;
 }): DurationPiece[] {
-  // The search space is tiny, but memoization makes the complete-path search
-  // linear in reachable grid offsets rather than repeatedly exploring suffixes.
-  const memo = new Map<number, DurationPiece[]>();
+  const memo = new Map<number, DurationPiece[] | undefined>();
+  const triplet = context.triplets.find(
+    (region) => start >= region.start && end <= region.end,
+  );
 
-  function visit(cursor: number): DurationPiece[] {
+  function visit(cursor: number): DurationPiece[] | undefined {
     if (cursor === end) {
       return [];
     }
-    const cached = memo.get(cursor);
-    if (cached) {
-      return cached;
+    if (memo.has(cursor)) {
+      return memo.get(cursor);
     }
-
-    const result = DURATION_CANDIDATES.filter(
-      (candidate) =>
-        cursor + candidate.duration <= end &&
-        isValidPlacement({ candidate, cursor, durationType, metric }),
-    )
-      .map((candidate) => [candidate, ...visit(cursor + candidate.duration)])
-      // Candidate order breaks equal-length ties, preserving the longest-first
-      // vocabulary preference without sacrificing global symbol minimization.
-      .toSorted((left, right) => left.length - right.length)[0];
+    const paths: DurationPiece[][] = [];
+    for (const candidate of DURATION_CANDIDATES) {
+      if (
+        cursor + candidate.duration > end ||
+        Boolean(candidate.notation.triplet) !== Boolean(triplet)
+      ) {
+        continue;
+      }
+      const suffix = visit(cursor + candidate.duration);
+      if (suffix !== undefined) {
+        paths.push([candidate, ...suffix]);
+      }
+    }
+    const result = paths.toSorted((left, right) =>
+      comparePaths({
+        left,
+        right,
+        start: cursor,
+        durationType,
+        context,
+      }),
+    )[0];
     memo.set(cursor, result);
     return result;
   }
-
-  return visit(start);
+  const result = visit(start);
+  if (!result) {
+    throw new Error(
+      `Cannot decompose ${durationType} from ${start} to ${end}${triplet ? " inside triplet" : ""}`,
+    );
+  }
+  return result;
 }
 
-function isValidPlacement({
-  candidate,
-  cursor,
+function comparePaths({
+  left,
+  right,
+  start,
   durationType,
-  metric,
+  context,
 }: {
-  candidate: DurationPiece;
-  cursor: number;
+  left: DurationPiece[];
+  right: DurationPiece[];
+  start: number;
   durationType: "note" | "rest";
-  metric: MetricContext;
-}): boolean {
-  if (candidate.notation.triplet) {
-    // This retains the exporter's existing triplet placement behavior for now.
-    // Measure-wide tuplet regions will replace this absolute phase check so an
-    // equivalent triplet decomposes identically on every beat.
-    return cursor % candidate.duration === 0;
-  }
+  context: MeasureContext;
+}): number {
+  const leftCost = pathCost({ pieces: left, start, durationType, context });
+  const rightCost = pathCost({ pieces: right, start, durationType, context });
+  return leftCost - rightCost || left.length - right.length;
+}
 
-  const end = cursor + candidate.duration;
-  // Ordinary beat-sized and longer values start on their own metric raster.
-  // This prevents a dotted value from winning merely because it fits the
-  // remaining arithmetic duration while crossing stronger beat structure.
-  if (
-    candidate.duration >= metric.beatDuration &&
-    cursor % candidate.duration !== 0
-  ) {
-    return false;
-  }
-  // In 4/4, preserve the central accent for notes. This is the first concrete
-  // boundary-strength rule; a later metric hierarchy can generalize it across
-  // time signatures and apply stricter tolerances to rests.
-  if (durationType === "note" && metric.measureDuration === 48) {
-    const midpoint = metric.measureDuration / 2;
-    if (cursor < midpoint && end > midpoint) {
-      return false;
+function pathCost({
+  pieces,
+  start,
+  durationType,
+  context,
+}: {
+  pieces: DurationPiece[];
+  start: number;
+  durationType: "note" | "rest";
+  context: MeasureContext;
+}): number {
+  let cursor = start;
+  let cost = 0;
+  for (const piece of pieces) {
+    const end = cursor + piece.duration;
+    for (const boundary of context.boundaries) {
+      if (boundary.position > cursor && boundary.position < end) {
+        if (
+          durationType === "rest" &&
+          cursor % piece.duration === 0 &&
+          end % piece.duration === 0
+        ) {
+          continue;
+        }
+        // Rests preserve every beat boundary. Notes may cross weak beat
+        // boundaries, but not the stronger midpoint or measure boundaries.
+        const tolerance = durationType === "note" ? 1 : 0;
+        cost += Math.max(0, boundary.strength - tolerance) * 100;
+      }
     }
+    cursor = end;
   }
-  return true;
+  return cost;
 }


### PR DESCRIPTION
The score exporter currently chooses durations greedily from absolute alignment values. That can cross stronger metric boundaries, fragment simple rests, and make equivalent triplets decompose differently depending on their beat.

This PR moves complete measure-event construction into a focused module. It builds the full note/rest timeline first, derives shared metric boundaries and beat-local triplet regions, then searches complete duration paths against that measure context while preserving authored event boundaries. The basic 4/4 example now emits a quarter rest followed by a half rest, midpoint-crossing notes remain split, and a triplet eighth followed by silence consistently becomes a triplet quarter rest on every beat.