### PR TITLE
feat: add score settings panel

### DIFF
--- a/e2e/score-viewer-debug-capture.spec.ts
+++ b/e2e/score-viewer-debug-capture.spec.ts
@@ -20,7 +20,7 @@ test("capture paged score PDF", async ({ page }) => {
   await page.goto("/score-viewer");
   await page.getByRole("button", { name: "Samples" }).click();
   await page.getByRole("menuitem", { name: /^Long score/ }).click();
-  await page.getByRole("button", { name: "Score appearance" }).click();
+  await page.getByRole("button", { name: "Score settings" }).click();
   await page.getByLabel("Layout").selectOption("paged");
 
   const pages = page.getByTestId("score-viewer-renderer").locator("svg");

--- a/e2e/score-viewer-debug-capture.spec.ts
+++ b/e2e/score-viewer-debug-capture.spec.ts
@@ -20,6 +20,7 @@ test("capture paged score PDF", async ({ page }) => {
   await page.goto("/score-viewer");
   await page.getByRole("button", { name: "Samples" }).click();
   await page.getByRole("menuitem", { name: /^Long score/ }).click();
+  await page.getByRole("button", { name: "Score appearance" }).click();
   await page.getByLabel("Layout").selectOption("paged");
 
   const pages = page.getByTestId("score-viewer-renderer").locator("svg");

--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -277,6 +277,14 @@ test("adjusts title spacing", async ({ page }) => {
   await expect
     .poll(async () => (await firstMeasure.boundingBox())!.y)
     .toBeGreaterThan(normalTop);
+
+  const relaxedTop = (await firstMeasure.boundingBox())!.y;
+  await page.getByLabel("Title spacing").fill("-1");
+  await page.getByLabel("Title spacing").press("Enter");
+  await expect(page.getByLabel("Title spacing")).toHaveValue("-1");
+  await expect
+    .poll(async () => (await firstMeasure.boundingBox())!.y)
+    .toBeLessThan(relaxedTop);
 });
 
 async function loadSample(page: Page, name: string) {

--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -50,7 +50,7 @@ test("opens the latest project state as a score in a new tab", async ({
   await expect(scorePage.getByLabel("BPM")).toHaveValue("137");
   const renderer = scorePage.getByTestId("score-viewer-renderer");
   await expect(renderer.getByText("Untitled", { exact: true })).toBeVisible();
-  await openAppearance(scorePage);
+  await openScoreSettings(scorePage);
   await scorePage.getByLabel("Title", { exact: true }).uncheck();
   await expect(renderer.getByText("Untitled", { exact: true })).toHaveCount(0);
   await expect(scorePage.getByLabel("Title spacing")).toBeDisabled();
@@ -180,7 +180,7 @@ test("toggles rehearsal marks", async ({ page }) => {
   const renderer = page.getByTestId("score-viewer-renderer");
   await expect(renderer.getByText("A", { exact: true })).toBeVisible();
 
-  await openAppearance(page);
+  await openScoreSettings(page);
   await page.getByLabel("Section labels").uncheck();
   await expect(renderer.getByText("A", { exact: true })).toHaveCount(0);
 
@@ -209,7 +209,7 @@ test("switches score layout", async ({ page }) => {
   await loadSample(page, "Long score");
 
   const renderer = page.getByTestId("score-viewer-renderer");
-  await openAppearance(page);
+  await openScoreSettings(page);
   await page.getByLabel("Layout").selectOption("paged");
   await expect(page.getByLabel("Layout")).toHaveValue("paged");
   await expect.poll(() => renderer.locator("svg").count()).toBeGreaterThan(1);
@@ -265,7 +265,7 @@ test("switches score layout", async ({ page }) => {
 test("adjusts title spacing", async ({ page }) => {
   await page.goto("/score-viewer");
   await loadSample(page, "Long score");
-  await openAppearance(page);
+  await openScoreSettings(page);
 
   const firstMeasure = page.locator(
     '[data-testid="score-viewer-measure"][data-measure-index="0"]',
@@ -283,7 +283,7 @@ async function loadSample(page: Page, name: string) {
   await page.getByRole("menuitem", { name: new RegExp(`^${name}`) }).click();
 }
 
-async function openAppearance(page: Page) {
-  await page.getByRole("button", { name: "Score appearance" }).click();
-  await expect(page.getByTestId("score-appearance-panel")).toBeVisible();
+async function openScoreSettings(page: Page) {
+  await page.getByRole("button", { name: "Score settings" }).click();
+  await expect(page.getByTestId("score-settings-panel")).toBeVisible();
 }

--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -50,9 +50,11 @@ test("opens the latest project state as a score in a new tab", async ({
   await expect(scorePage.getByLabel("BPM")).toHaveValue("137");
   const renderer = scorePage.getByTestId("score-viewer-renderer");
   await expect(renderer.getByText("Untitled", { exact: true })).toBeVisible();
-  await scorePage.getByLabel("Title").selectOption("hide");
+  await openAppearance(scorePage);
+  await scorePage.getByLabel("Title", { exact: true }).uncheck();
   await expect(renderer.getByText("Untitled", { exact: true })).toHaveCount(0);
-  await scorePage.getByLabel("Title").selectOption("show");
+  await expect(scorePage.getByLabel("Title spacing")).toBeDisabled();
+  await scorePage.getByLabel("Title", { exact: true }).check();
   await expect(renderer.getByText("Untitled", { exact: true })).toBeVisible();
   await expect(scorePage.getByRole("button", { name: "Samples" })).toHaveCount(
     0,
@@ -178,10 +180,11 @@ test("toggles rehearsal marks", async ({ page }) => {
   const renderer = page.getByTestId("score-viewer-renderer");
   await expect(renderer.getByText("A", { exact: true })).toBeVisible();
 
-  await page.getByLabel("Section labels").selectOption("hide");
+  await openAppearance(page);
+  await page.getByLabel("Section labels").uncheck();
   await expect(renderer.getByText("A", { exact: true })).toHaveCount(0);
 
-  await page.getByLabel("Section labels").selectOption("show");
+  await page.getByLabel("Section labels").check();
   await expect(renderer.getByText("A", { exact: true })).toBeVisible();
 });
 
@@ -206,6 +209,7 @@ test("switches score layout", async ({ page }) => {
   await loadSample(page, "Long score");
 
   const renderer = page.getByTestId("score-viewer-renderer");
+  await openAppearance(page);
   await page.getByLabel("Layout").selectOption("paged");
   await expect(page.getByLabel("Layout")).toHaveValue("paged");
   await expect.poll(() => renderer.locator("svg").count()).toBeGreaterThan(1);
@@ -258,7 +262,28 @@ test("switches score layout", async ({ page }) => {
   await expect(page.getByLabel("Layout")).toHaveValue("continuous");
 });
 
+test("adjusts title spacing", async ({ page }) => {
+  await page.goto("/score-viewer");
+  await loadSample(page, "Long score");
+  await openAppearance(page);
+
+  const firstMeasure = page.locator(
+    '[data-testid="score-viewer-measure"][data-measure-index="0"]',
+  );
+  const normalTop = (await firstMeasure.boundingBox())!.y;
+  await page.getByLabel("Title spacing").selectOption("relaxed");
+  await expect(page.getByLabel("Title spacing")).toHaveValue("relaxed");
+  await expect
+    .poll(async () => (await firstMeasure.boundingBox())!.y)
+    .toBeGreaterThan(normalTop);
+});
+
 async function loadSample(page: Page, name: string) {
   await page.getByRole("button", { name: "Samples" }).click();
   await page.getByRole("menuitem", { name: new RegExp(`^${name}`) }).click();
+}
+
+async function openAppearance(page: Page) {
+  await page.getByRole("button", { name: "Score appearance" }).click();
+  await expect(page.getByTestId("score-appearance-panel")).toBeVisible();
 }

--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -271,8 +271,9 @@ test("adjusts title spacing", async ({ page }) => {
     '[data-testid="score-viewer-measure"][data-measure-index="0"]',
   );
   const normalTop = (await firstMeasure.boundingBox())!.y;
-  await page.getByLabel("Title spacing").selectOption("relaxed");
-  await expect(page.getByLabel("Title spacing")).toHaveValue("relaxed");
+  await page.getByLabel("Title spacing").fill("3.5");
+  await page.getByLabel("Title spacing").press("Enter");
+  await expect(page.getByLabel("Title spacing")).toHaveValue("3.5");
   await expect
     .poll(async () => (await firstMeasure.boundingBox())!.y)
     .toBeGreaterThan(normalTop);

--- a/src/components/score-appearance.tsx
+++ b/src/components/score-appearance.tsx
@@ -1,0 +1,71 @@
+import type {
+  ScoreLayout,
+  ScoreTitleSpacing,
+  ScoreViewerSettings,
+} from "./score-viewer-runtime";
+
+type ScoreAppearanceProps = {
+  settings: ScoreViewerSettings;
+  onChange: (update: Partial<ScoreViewerSettings>) => void;
+};
+
+const selectClassName =
+  "h-8 w-32 rounded border border-neutral-600 bg-neutral-900 px-2 text-sm text-neutral-100 focus:border-neutral-500 focus:outline-none";
+
+export function ScoreAppearance({ settings, onChange }: ScoreAppearanceProps) {
+  return (
+    <div className="grid min-w-72 grid-cols-[1fr_auto] items-center gap-x-6 gap-y-3 text-sm text-neutral-300">
+      <label htmlFor="score-layout">Layout</label>
+      <select
+        id="score-layout"
+        value={settings.layout}
+        onChange={(event) =>
+          onChange({ layout: event.currentTarget.value as ScoreLayout })
+        }
+        className={selectClassName}
+      >
+        <option value="continuous">Continuous</option>
+        <option value="paged">Pages</option>
+      </select>
+
+      <label htmlFor="score-title">Title</label>
+      <input
+        id="score-title"
+        type="checkbox"
+        checked={settings.showTitle}
+        onChange={(event) =>
+          onChange({ showTitle: event.currentTarget.checked })
+        }
+        className="justify-self-end size-4 rounded border-neutral-600 bg-neutral-900 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-0"
+      />
+
+      <label htmlFor="score-title-spacing">Title spacing</label>
+      <select
+        id="score-title-spacing"
+        disabled={!settings.showTitle}
+        value={settings.titleSpacing}
+        onChange={(event) =>
+          onChange({
+            titleSpacing: event.currentTarget.value as ScoreTitleSpacing,
+          })
+        }
+        className={selectClassName}
+      >
+        <option value="compact">Compact</option>
+        <option value="normal">Normal</option>
+        <option value="relaxed">Relaxed</option>
+      </select>
+
+      <label htmlFor="score-section-labels">Section labels</label>
+      <input
+        id="score-section-labels"
+        type="checkbox"
+        checked={settings.showSectionLabels}
+        onChange={(event) =>
+          onChange({ showSectionLabels: event.currentTarget.checked })
+        }
+        className="justify-self-end size-4 rounded border-neutral-600 bg-neutral-900 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-0"
+      />
+    </div>
+  );
+}

--- a/src/components/score-settings.tsx
+++ b/src/components/score-settings.tsx
@@ -4,7 +4,7 @@ import type {
   ScoreViewerSettings,
 } from "./score-viewer-runtime";
 
-type ScoreAppearanceProps = {
+type ScoreSettingsProps = {
   settings: ScoreViewerSettings;
   onChange: (update: Partial<ScoreViewerSettings>) => void;
 };
@@ -12,7 +12,7 @@ type ScoreAppearanceProps = {
 const selectClassName =
   "h-8 w-32 rounded border border-neutral-600 bg-neutral-900 px-2 text-sm text-neutral-100 focus:border-neutral-500 focus:outline-none";
 
-export function ScoreAppearance({ settings, onChange }: ScoreAppearanceProps) {
+export function ScoreSettings({ settings, onChange }: ScoreSettingsProps) {
   return (
     <div className="grid min-w-72 grid-cols-[1fr_auto] items-center gap-x-6 gap-y-3 text-sm text-neutral-300">
       <label htmlFor="score-layout">Layout</label>

--- a/src/components/score-settings.tsx
+++ b/src/components/score-settings.tsx
@@ -1,9 +1,6 @@
 import type { ComponentProps } from "react";
-import type {
-  ScoreLayout,
-  ScoreTitleSpacing,
-  ScoreViewerSettings,
-} from "./score-viewer-runtime";
+import { useDraftInput } from "../hooks/use-draft-input";
+import type { ScoreLayout, ScoreViewerSettings } from "./score-viewer-runtime";
 
 type ScoreSettingsProps = {
   settings: ScoreViewerSettings;
@@ -11,6 +8,14 @@ type ScoreSettingsProps = {
 };
 
 export function ScoreSettings({ settings, onChange }: ScoreSettingsProps) {
+  const titleSpacingInput = useDraftInput({
+    value: settings.titleSpacing,
+    onCommit: (titleSpacing) => onChange({ titleSpacing }),
+    min: 0,
+    step: 0.5,
+    parse: "float",
+  });
+
   return (
     <div className="grid min-w-72 grid-cols-[1fr_auto] items-center gap-x-6 gap-y-3 text-sm text-neutral-300">
       <label htmlFor="score-layout">Layout</label>
@@ -37,20 +42,13 @@ export function ScoreSettings({ settings, onChange }: ScoreSettingsProps) {
       />
 
       <label htmlFor="score-title-spacing">Title spacing</label>
-      <SettingsSelect
+      <input
         id="score-title-spacing"
+        type="number"
         disabled={!settings.showTitle}
-        value={settings.titleSpacing}
-        onChange={(event) =>
-          onChange({
-            titleSpacing: event.currentTarget.value as ScoreTitleSpacing,
-          })
-        }
-      >
-        <option value="compact">Compact</option>
-        <option value="normal">Normal</option>
-        <option value="relaxed">Relaxed</option>
-      </SettingsSelect>
+        {...titleSpacingInput.props}
+        className="h-8 w-32 rounded border border-neutral-600 bg-neutral-900 px-2 text-sm text-neutral-100 focus:border-neutral-500 focus:outline-none"
+      />
 
       <label htmlFor="score-section-labels">Section labels</label>
       <input

--- a/src/components/score-settings.tsx
+++ b/src/components/score-settings.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from "react";
 import type {
   ScoreLayout,
   ScoreTitleSpacing,
@@ -9,24 +10,20 @@ type ScoreSettingsProps = {
   onChange: (update: Partial<ScoreViewerSettings>) => void;
 };
 
-const selectClassName =
-  "h-8 w-32 rounded border border-neutral-600 bg-neutral-900 px-2 text-sm text-neutral-100 focus:border-neutral-500 focus:outline-none";
-
 export function ScoreSettings({ settings, onChange }: ScoreSettingsProps) {
   return (
     <div className="grid min-w-72 grid-cols-[1fr_auto] items-center gap-x-6 gap-y-3 text-sm text-neutral-300">
       <label htmlFor="score-layout">Layout</label>
-      <select
+      <SettingsSelect
         id="score-layout"
         value={settings.layout}
         onChange={(event) =>
           onChange({ layout: event.currentTarget.value as ScoreLayout })
         }
-        className={selectClassName}
       >
         <option value="continuous">Continuous</option>
         <option value="paged">Pages</option>
-      </select>
+      </SettingsSelect>
 
       <label htmlFor="score-title">Title</label>
       <input
@@ -40,7 +37,7 @@ export function ScoreSettings({ settings, onChange }: ScoreSettingsProps) {
       />
 
       <label htmlFor="score-title-spacing">Title spacing</label>
-      <select
+      <SettingsSelect
         id="score-title-spacing"
         disabled={!settings.showTitle}
         value={settings.titleSpacing}
@@ -49,12 +46,11 @@ export function ScoreSettings({ settings, onChange }: ScoreSettingsProps) {
             titleSpacing: event.currentTarget.value as ScoreTitleSpacing,
           })
         }
-        className={selectClassName}
       >
         <option value="compact">Compact</option>
         <option value="normal">Normal</option>
         <option value="relaxed">Relaxed</option>
-      </select>
+      </SettingsSelect>
 
       <label htmlFor="score-section-labels">Section labels</label>
       <input
@@ -67,5 +63,14 @@ export function ScoreSettings({ settings, onChange }: ScoreSettingsProps) {
         className="justify-self-end size-4 rounded border-neutral-600 bg-neutral-900 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-0"
       />
     </div>
+  );
+}
+
+function SettingsSelect(props: ComponentProps<"select">) {
+  return (
+    <select
+      className="h-8 w-32 rounded border border-neutral-600 bg-neutral-900 px-2 text-sm text-neutral-100 focus:border-neutral-500 focus:outline-none"
+      {...props}
+    />
   );
 }

--- a/src/components/score-settings.tsx
+++ b/src/components/score-settings.tsx
@@ -11,7 +11,6 @@ export function ScoreSettings({ settings, onChange }: ScoreSettingsProps) {
   const titleSpacingInput = useDraftInput({
     value: settings.titleSpacing,
     onCommit: (titleSpacing) => onChange({ titleSpacing }),
-    min: 0,
     step: 0.5,
     parse: "float",
   });

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -19,6 +19,15 @@ const INITIAL_RUNTIME_STATE: ScoreViewerRuntimeState = {
 
 export type ScoreLayout = "continuous" | "paged";
 
+export type ScoreTitleSpacing = "compact" | "normal" | "relaxed";
+
+export type ScoreViewerSettings = {
+  layout: ScoreLayout;
+  showSectionLabels: boolean;
+  showTitle: boolean;
+  titleSpacing: ScoreTitleSpacing;
+};
+
 export type ScoreSource = {
   name: string;
   xml: string;
@@ -49,6 +58,11 @@ type CursorPosition = {
 // which is an application-specific scale rather than a physical CSS pixel size.
 // TODO: Expose this as a layout density control without coupling it to view zoom.
 const SCORE_LAYOUT_WIDTH = 1110;
+const TITLE_BOTTOM_DISTANCE: Record<ScoreTitleSpacing, number> = {
+  compact: 1,
+  normal: 2,
+  relaxed: 3,
+};
 
 export class ScoreViewerRuntime {
   // attach() initializes the runtime-owned DOM:
@@ -144,28 +158,22 @@ export class ScoreViewerRuntime {
 
   async load({
     score,
-    layout,
-    showTitle,
-    showRehearsalMarks,
+    settings,
   }: {
     score: ScoreSource;
-    layout: ScoreLayout;
-    showTitle: boolean;
-    showRehearsalMarks: boolean;
+    settings: ScoreViewerSettings;
   }) {
     this.#clock.stop();
     this.#setState({ isReady: false });
 
     this.#osmd.clear();
-    this.#osmd.setPageFormat(layout === "paged" ? "A4_P" : "Endless");
-    this.#osmd.setOptions({ drawTitle: showTitle });
-    this.#osmd.EngravingRules.RenderRehearsalMarks = showRehearsalMarks;
+    applyEngravingSettings(this.#osmd, settings);
     await this.#osmd.load(score.xml);
     this.#sheet.hidden = false;
     this.#osmd.render();
 
     this.#sheet.className =
-      layout === "continuous"
+      settings.layout === "continuous"
         ? "relative mx-auto bg-white px-4 shadow-xl"
         : "relative mx-auto";
     this.#positions = buildCursorPositions(this.#osmd, this.#container);
@@ -280,6 +288,17 @@ export class ScoreViewerRuntime {
       listener();
     }
   }
+}
+
+function applyEngravingSettings(
+  osmd: OpenSheetMusicDisplay,
+  settings: ScoreViewerSettings,
+) {
+  osmd.setPageFormat(settings.layout === "paged" ? "A4_P" : "Endless");
+  osmd.setOptions({ drawTitle: settings.showTitle });
+  osmd.EngravingRules.RenderRehearsalMarks = settings.showSectionLabels;
+  osmd.EngravingRules.TitleBottomDistance =
+    TITLE_BOTTOM_DISTANCE[settings.titleSpacing];
 }
 
 function secondsToScoreTime(seconds: number, tempo: number) {

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -19,20 +19,18 @@ const INITIAL_RUNTIME_STATE: ScoreViewerRuntimeState = {
 
 export type ScoreLayout = "continuous" | "paged";
 
-export type ScoreTitleSpacing = "compact" | "normal" | "relaxed";
-
 export type ScoreViewerSettings = {
   layout: ScoreLayout;
   showSectionLabels: boolean;
   showTitle: boolean;
-  titleSpacing: ScoreTitleSpacing;
+  titleSpacing: number;
 };
 
 export const INITIAL_SCORE_VIEWER_SETTINGS: ScoreViewerSettings = {
   layout: "continuous",
   showSectionLabels: true,
   showTitle: true,
-  titleSpacing: "normal",
+  titleSpacing: 2,
 };
 
 export type ScoreSource = {
@@ -65,11 +63,6 @@ type CursorPosition = {
 // which is an application-specific scale rather than a physical CSS pixel size.
 // TODO: Expose this as a layout density control without coupling it to view zoom.
 const SCORE_LAYOUT_WIDTH = 1110;
-const TITLE_BOTTOM_DISTANCE: Record<ScoreTitleSpacing, number> = {
-  compact: 1,
-  normal: 2,
-  relaxed: 3,
-};
 
 export class ScoreViewerRuntime {
   // attach() initializes the runtime-owned DOM:
@@ -304,8 +297,7 @@ function applyEngravingSettings(
   osmd.setPageFormat(settings.layout === "paged" ? "A4_P" : "Endless");
   osmd.setOptions({ drawTitle: settings.showTitle });
   osmd.EngravingRules.RenderRehearsalMarks = settings.showSectionLabels;
-  osmd.EngravingRules.TitleBottomDistance =
-    TITLE_BOTTOM_DISTANCE[settings.titleSpacing];
+  osmd.EngravingRules.TitleBottomDistance = settings.titleSpacing;
 }
 
 function secondsToScoreTime(seconds: number, tempo: number) {

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -28,6 +28,13 @@ export type ScoreViewerSettings = {
   titleSpacing: ScoreTitleSpacing;
 };
 
+export const INITIAL_SCORE_VIEWER_SETTINGS: ScoreViewerSettings = {
+  layout: "continuous",
+  showSectionLabels: true,
+  showTitle: true,
+  titleSpacing: "normal",
+};
+
 export type ScoreSource = {
   name: string;
   xml: string;

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -30,7 +30,7 @@ export const INITIAL_SCORE_VIEWER_SETTINGS: ScoreViewerSettings = {
   layout: "continuous",
   showSectionLabels: true,
   showTitle: true,
-  titleSpacing: 2,
+  titleSpacing: 0,
 };
 
 export type ScoreSource = {

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -7,6 +7,7 @@ import {
   PauseIcon,
   PlayIcon,
   RotateCcwIcon,
+  SlidersHorizontalIcon,
   UploadIcon,
 } from "lucide-react";
 import { useEffect, useRef, useState, useSyncExternalStore } from "react";
@@ -16,9 +17,10 @@ import { isShortcutTextInputTarget, matchKeyboardEvent } from "../lib/keyboard";
 import { routes } from "../lib/routes";
 import { SCORE_VIEWER_SAMPLES } from "../lib/score-viewer-samples";
 import { FileDropInput } from "./file-drop-input";
+import { ScoreAppearance } from "./score-appearance";
 import {
-  type ScoreLayout,
   type ScoreSource,
+  type ScoreViewerSettings,
   ScoreViewerRuntime,
 } from "./score-viewer-runtime";
 import { Button } from "./ui/button";
@@ -28,7 +30,15 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
+import { FloatingPanel } from "./ui/floating-panel";
 import { cn } from "./ui/utils";
+
+const INITIAL_SETTINGS: ScoreViewerSettings = {
+  layout: "continuous",
+  showSectionLabels: true,
+  showTitle: true,
+  titleSpacing: "normal",
+};
 
 export function ScoreViewer({
   initialSource,
@@ -38,9 +48,8 @@ export function ScoreViewer({
   const runtimeRootRef = useRef<HTMLDivElement>(null);
 
   const [score, setScore] = useState<ScoreSource | undefined>(initialSource);
-  const [layout, setLayout] = useState<ScoreLayout>("continuous");
-  const [showTitle, setShowTitle] = useState(true);
-  const [showRehearsalMarks, setShowRehearsalMarks] = useState(true);
+  const [settings, setSettings] = useState(INITIAL_SETTINGS);
+  const [isAppearanceOpen, setIsAppearanceOpen] = useState(false);
   const [isRuntimeAttached, setIsRuntimeAttached] = useState(false);
 
   useEffect(() => {
@@ -83,14 +92,10 @@ export function ScoreViewer({
 
   const loadMutation = useMutation({
     mutationFn: async ({
-      layout,
-      showTitle,
-      showRehearsalMarks,
+      settings,
       source,
     }: {
-      layout: ScoreLayout;
-      showTitle: boolean;
-      showRehearsalMarks: boolean;
+      settings: ScoreViewerSettings;
       source: File | ScoreSource;
     }) => {
       const nextScore =
@@ -99,9 +104,7 @@ export function ScoreViewer({
           : source;
       await runtime.load({
         score: nextScore,
-        layout,
-        showTitle,
-        showRehearsalMarks,
+        settings,
       });
       setScore(nextScore);
     },
@@ -114,55 +117,19 @@ export function ScoreViewer({
     staleTime: Infinity,
     queryFn: async () => {
       loadMutation.mutate({
-        layout,
-        showTitle,
-        showRehearsalMarks,
+        settings,
         source: initialSource!,
       });
       return true;
     },
   });
 
-  function changeLayout(nextLayout: ScoreLayout) {
-    if (nextLayout === layout) {
-      return;
-    }
-    setLayout(nextLayout);
+  function changeSettings(update: Partial<ScoreViewerSettings>) {
+    const nextSettings = { ...settings, ...update };
+    setSettings(nextSettings);
     if (score) {
       loadMutation.mutate({
-        layout: nextLayout,
-        showTitle,
-        showRehearsalMarks,
-        source: score,
-      });
-    }
-  }
-
-  function changeTitleVisible(visible: boolean) {
-    if (visible === showTitle) {
-      return;
-    }
-    setShowTitle(visible);
-    if (score) {
-      loadMutation.mutate({
-        layout,
-        showTitle: visible,
-        showRehearsalMarks,
-        source: score,
-      });
-    }
-  }
-
-  function changeRehearsalMarksVisible(visible: boolean) {
-    if (visible === showRehearsalMarks) {
-      return;
-    }
-    setShowRehearsalMarks(visible);
-    if (score) {
-      loadMutation.mutate({
-        layout,
-        showTitle,
-        showRehearsalMarks: visible,
+        settings: nextSettings,
         source: score,
       });
     }
@@ -172,7 +139,7 @@ export function ScoreViewer({
     <main
       className={cn(
         "flex h-screen flex-col overflow-hidden bg-neutral-300 text-neutral-950",
-        layout === "paged" && "score-viewer-root-paged",
+        settings.layout === "paged" && "score-viewer-root-paged",
       )}
     >
       <header className="flex items-center gap-2 border-b border-neutral-700 bg-neutral-800 px-3 py-2 text-neutral-100">
@@ -223,53 +190,6 @@ export function ScoreViewer({
               className="h-8 w-14 rounded border border-border bg-input px-1 text-center font-mono text-sm text-foreground"
             />
           </label>
-
-          <label className="flex items-center gap-1.5 text-sm">
-            <span className="text-muted-foreground">Layout</span>
-            <select
-              aria-label="Layout"
-              value={layout}
-              onChange={(event) =>
-                changeLayout(event.currentTarget.value as ScoreLayout)
-              }
-              className="h-8 rounded border border-border bg-input px-2 text-sm text-foreground"
-            >
-              <option value="continuous">Continuous</option>
-              <option value="paged">Paged</option>
-            </select>
-          </label>
-
-          <label className="flex items-center gap-1.5 text-sm">
-            <span className="text-muted-foreground">Title</span>
-            <select
-              aria-label="Title"
-              value={showTitle ? "show" : "hide"}
-              onChange={(event) =>
-                changeTitleVisible(event.currentTarget.value === "show")
-              }
-              className="h-8 rounded border border-border bg-input px-2 text-sm text-foreground"
-            >
-              <option value="show">Show</option>
-              <option value="hide">Hide</option>
-            </select>
-          </label>
-
-          <label className="flex items-center gap-1.5 text-sm">
-            <span className="text-muted-foreground">Section labels</span>
-            <select
-              aria-label="Section labels"
-              value={showRehearsalMarks ? "show" : "hide"}
-              onChange={(event) =>
-                changeRehearsalMarksVisible(
-                  event.currentTarget.value === "show",
-                )
-              }
-              className="h-8 rounded border border-border bg-input px-2 text-sm text-foreground"
-            >
-              <option value="show">Show</option>
-              <option value="hide">Hide</option>
-            </select>
-          </label>
         </div>
 
         <div className="flex-1" />
@@ -282,6 +202,21 @@ export function ScoreViewer({
           {score?.name ?? "No score loaded"}
         </span>
 
+        <Button
+          data-testid="score-appearance-button"
+          onClick={() => setIsAppearanceOpen((open) => !open)}
+          aria-pressed={isAppearanceOpen}
+          title="Score appearance"
+          aria-label="Score appearance"
+          className={cn(
+            "size-8 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+            isAppearanceOpen &&
+              "bg-primary text-primary-foreground hover:bg-primary/90",
+          )}
+        >
+          <SlidersHorizontalIcon className="size-5" />
+        </Button>
+
         {!initialSource && (
           <>
             <div className="h-5 w-px bg-border" />
@@ -292,9 +227,7 @@ export function ScoreViewer({
               inputProps={{ "aria-label": "Open MusicXML" }}
               onFile={(file) =>
                 loadMutation.mutate({
-                  layout,
-                  showTitle,
-                  showRehearsalMarks,
+                  settings,
                   source: file,
                 })
               }
@@ -316,9 +249,7 @@ export function ScoreViewer({
                     key={sample.name}
                     onSelect={() =>
                       loadMutation.mutate({
-                        layout,
-                        showTitle,
-                        showRehearsalMarks,
+                        settings,
                         source: { name: sample.name, xml: sample.xml },
                       })
                     }
@@ -365,9 +296,7 @@ export function ScoreViewer({
               inputProps={{ "aria-label": "Upload MusicXML" }}
               onFile={(file) =>
                 loadMutation.mutate({
-                  layout,
-                  showTitle,
-                  showRehearsalMarks,
+                  settings,
                   source: file,
                 })
               }
@@ -394,6 +323,16 @@ export function ScoreViewer({
         data-testid="score-viewer-runtime-root"
         className="min-h-0 flex-1"
       />
+      {isAppearanceOpen && (
+        <FloatingPanel
+          closeLabel="Close Score Appearance"
+          onClose={() => setIsAppearanceOpen(false)}
+          title="Score appearance"
+          testId="score-appearance-panel"
+        >
+          <ScoreAppearance settings={settings} onChange={changeSettings} />
+        </FloatingPanel>
+      )}
     </main>
   );
 }

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -19,6 +19,7 @@ import { SCORE_VIEWER_SAMPLES } from "../lib/score-viewer-samples";
 import { FileDropInput } from "./file-drop-input";
 import { ScoreSettings } from "./score-settings";
 import {
+  INITIAL_SCORE_VIEWER_SETTINGS,
   type ScoreSource,
   type ScoreViewerSettings,
   ScoreViewerRuntime,
@@ -33,13 +34,6 @@ import {
 import { FloatingPanel } from "./ui/floating-panel";
 import { cn } from "./ui/utils";
 
-const INITIAL_SETTINGS: ScoreViewerSettings = {
-  layout: "continuous",
-  showSectionLabels: true,
-  showTitle: true,
-  titleSpacing: "normal",
-};
-
 export function ScoreViewer({
   initialSource,
 }: {
@@ -48,7 +42,7 @@ export function ScoreViewer({
   const runtimeRootRef = useRef<HTMLDivElement>(null);
 
   const [score, setScore] = useState<ScoreSource | undefined>(initialSource);
-  const [settings, setSettings] = useState(INITIAL_SETTINGS);
+  const [settings, setSettings] = useState(INITIAL_SCORE_VIEWER_SETTINGS);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isRuntimeAttached, setIsRuntimeAttached] = useState(false);
 

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -185,20 +185,22 @@ export function ScoreViewer({
             />
           </label>
         </div>
-        <Button
-          data-testid="score-settings-button"
-          onClick={() => setIsSettingsOpen((open) => !open)}
-          aria-pressed={isSettingsOpen}
-          title="Score settings"
-          aria-label="Score settings"
-          className={cn(
-            "size-8 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-            isSettingsOpen &&
-              "bg-primary text-primary-foreground hover:bg-primary/90",
-          )}
-        >
-          <SlidersHorizontalIcon className="size-5" />
-        </Button>
+        <div className="ml-2">
+          <Button
+            data-testid="score-settings-button"
+            onClick={() => setIsSettingsOpen((open) => !open)}
+            aria-pressed={isSettingsOpen}
+            title="Score settings"
+            aria-label="Score settings"
+            className={cn(
+              "size-8 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+              isSettingsOpen &&
+                "bg-primary text-primary-foreground hover:bg-primary/90",
+            )}
+          >
+            <SlidersHorizontalIcon className="size-5" />
+          </Button>
+        </div>
 
         <div className="flex-1" />
 

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -17,7 +17,7 @@ import { isShortcutTextInputTarget, matchKeyboardEvent } from "../lib/keyboard";
 import { routes } from "../lib/routes";
 import { SCORE_VIEWER_SAMPLES } from "../lib/score-viewer-samples";
 import { FileDropInput } from "./file-drop-input";
-import { ScoreAppearance } from "./score-appearance";
+import { ScoreSettings } from "./score-settings";
 import {
   type ScoreSource,
   type ScoreViewerSettings,
@@ -49,7 +49,7 @@ export function ScoreViewer({
 
   const [score, setScore] = useState<ScoreSource | undefined>(initialSource);
   const [settings, setSettings] = useState(INITIAL_SETTINGS);
-  const [isAppearanceOpen, setIsAppearanceOpen] = useState(false);
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isRuntimeAttached, setIsRuntimeAttached] = useState(false);
 
   useEffect(() => {
@@ -203,14 +203,14 @@ export function ScoreViewer({
         </span>
 
         <Button
-          data-testid="score-appearance-button"
-          onClick={() => setIsAppearanceOpen((open) => !open)}
-          aria-pressed={isAppearanceOpen}
-          title="Score appearance"
-          aria-label="Score appearance"
+          data-testid="score-settings-button"
+          onClick={() => setIsSettingsOpen((open) => !open)}
+          aria-pressed={isSettingsOpen}
+          title="Score settings"
+          aria-label="Score settings"
           className={cn(
             "size-8 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-            isAppearanceOpen &&
+            isSettingsOpen &&
               "bg-primary text-primary-foreground hover:bg-primary/90",
           )}
         >
@@ -323,14 +323,14 @@ export function ScoreViewer({
         data-testid="score-viewer-runtime-root"
         className="min-h-0 flex-1"
       />
-      {isAppearanceOpen && (
+      {isSettingsOpen && (
         <FloatingPanel
-          closeLabel="Close Score Appearance"
-          onClose={() => setIsAppearanceOpen(false)}
-          title="Score appearance"
-          testId="score-appearance-panel"
+          closeLabel="Close Score Settings"
+          onClose={() => setIsSettingsOpen(false)}
+          title="Score settings"
+          testId="score-settings-panel"
         >
-          <ScoreAppearance settings={settings} onChange={changeSettings} />
+          <ScoreSettings settings={settings} onChange={changeSettings} />
         </FloatingPanel>
       )}
     </main>

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -185,22 +185,22 @@ export function ScoreViewer({
             />
           </label>
         </div>
-        <div className="ml-2">
-          <Button
-            data-testid="score-settings-button"
-            onClick={() => setIsSettingsOpen((open) => !open)}
-            aria-pressed={isSettingsOpen}
-            title="Score settings"
-            aria-label="Score settings"
-            className={cn(
-              "size-8 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-              isSettingsOpen &&
-                "bg-primary text-primary-foreground hover:bg-primary/90",
-            )}
-          >
-            <SlidersHorizontalIcon className="size-5" />
-          </Button>
-        </div>
+        <div className="h-5 w-px bg-border" />
+
+        <Button
+          data-testid="score-settings-button"
+          onClick={() => setIsSettingsOpen((open) => !open)}
+          aria-pressed={isSettingsOpen}
+          title="Score settings"
+          aria-label="Score settings"
+          className={cn(
+            "size-8 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+            isSettingsOpen &&
+              "bg-primary text-primary-foreground hover:bg-primary/90",
+          )}
+        >
+          <SlidersHorizontalIcon className="size-5" />
+        </Button>
 
         <div className="flex-1" />
 

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -185,17 +185,6 @@ export function ScoreViewer({
             />
           </label>
         </div>
-
-        <div className="flex-1" />
-
-        <span
-          data-testid="score-name"
-          title={score?.name}
-          className="max-w-[220px] truncate text-sm text-neutral-300"
-        >
-          {score?.name ?? "No score loaded"}
-        </span>
-
         <Button
           data-testid="score-settings-button"
           onClick={() => setIsSettingsOpen((open) => !open)}
@@ -210,6 +199,16 @@ export function ScoreViewer({
         >
           <SlidersHorizontalIcon className="size-5" />
         </Button>
+
+        <div className="flex-1" />
+
+        <span
+          data-testid="score-name"
+          title={score?.name}
+          className="max-w-[220px] truncate text-sm text-neutral-300"
+        >
+          {score?.name ?? "No score loaded"}
+        </span>
 
         {!initialSource && (
           <>


### PR DESCRIPTION
Score presentation controls were crowding the playback header, while the related OSMD engraving options were passed and applied independently.

This PR moves layout, title, numeric title spacing, and section-label controls into the existing bottom-right floating-panel pattern. It also consolidates viewer settings into one runtime contract and applies the corresponding OSMD engraving rules in one place.