### PR TITLE
feat: show absolute score playback time

### DIFF
--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -123,6 +123,9 @@ test("loads and advances the cursor sample", async ({ page }) => {
   await page.getByRole("button", { name: "Pause" }).click();
   await page.locator('[data-measure-index="1"]').click();
   await expect(page.getByText("02|01")).toBeVisible();
+  await expect(page.getByTestId("score-time-display")).toHaveText(
+    "02|01 - 00:02:00",
+  );
   const seekTransform = await cursor.evaluate(
     (element) => element.style.transform,
   );

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -4,6 +4,7 @@ import { SCORE_VIEWER_SAMPLES } from "../lib/score-viewer-samples";
 type ScoreViewerRuntimeState = {
   bar: number;
   beat: number;
+  currentTime: number;
   isPlaying: boolean;
   isReady: boolean;
   tempo: number;
@@ -12,6 +13,7 @@ type ScoreViewerRuntimeState = {
 const INITIAL_RUNTIME_STATE: ScoreViewerRuntimeState = {
   bar: 1,
   beat: 1,
+  currentTime: 0,
   isPlaying: false,
   isReady: false,
   tempo: SCORE_VIEWER_SAMPLES[0].tempo,
@@ -95,8 +97,12 @@ export class ScoreViewerRuntime {
       const { currentTime, paused } = this.#clock.getSnapshot();
       const scoreTime = secondsToScoreTime(currentTime, this.#state.tempo);
       const { bar, beat } = scoreTimeToBarBeat(scoreTime);
-      if (bar !== this.#state.bar || beat !== this.#state.beat) {
-        this.#setState({ bar, beat });
+      if (
+        bar !== this.#state.bar ||
+        beat !== this.#state.beat ||
+        currentTime !== this.#state.currentTime
+      ) {
+        this.#setState({ bar, beat, currentTime });
       }
       this.#updateCursor(scoreTime);
       const isPlaying = !paused;
@@ -182,6 +188,7 @@ export class ScoreViewerRuntime {
     this.#setState({
       bar: 1,
       beat: 1,
+      currentTime: 0,
       isReady: true,
       tempo: parseTempo(score.xml),
     });

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -16,6 +16,7 @@ import { useWindowEvent } from "../hooks/use-window-event";
 import { isShortcutTextInputTarget, matchKeyboardEvent } from "../lib/keyboard";
 import { routes } from "../lib/routes";
 import { SCORE_VIEWER_SAMPLES } from "../lib/score-viewer-samples";
+import { formatTimeCompact } from "../lib/time-format";
 import { FileDropInput } from "./file-drop-input";
 import { ScoreSettings } from "./score-settings";
 import {
@@ -167,8 +168,12 @@ export function ScoreViewer({
 
         <div className="h-5 w-px bg-border" />
 
-        <span className="whitespace-nowrap font-mono text-sm text-neutral-300">
-          {formatBarBeat(runtimeState.bar, runtimeState.beat)}
+        <span
+          data-testid="score-time-display"
+          className="whitespace-nowrap font-mono text-sm text-neutral-300 tabular-nums"
+        >
+          {formatBarBeat(runtimeState.bar, runtimeState.beat)} -{" "}
+          {formatTimeCompact(runtimeState.currentTime)}
         </span>
 
         <div className="h-5 w-px bg-border" />

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -55,6 +55,8 @@ export function ScoreViewer({
 
   // initialize runtime
   const [runtime] = useState(() => new ScoreViewerRuntime());
+  // TODO: Isolate the clock subscription if whole-view RAF rerenders become
+  // expensive; the current component tree is small enough.
   const runtimeState = useSyncExternalStore(
     runtime.subscribe,
     runtime.getSnapshot,

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -13,6 +13,7 @@ import { GM_PROGRAMS } from "../lib/general-midi";
 import { isShortcutTextInputTarget, matchKeyboardEvent } from "../lib/keyboard";
 import { projectStorage } from "../lib/project-storage";
 import { useProjectStore } from "../lib/project-store";
+import { formatTimeCompact } from "../lib/time-format";
 import { COMMON_TIME_SIGNATURES, type GridSnap } from "../types";
 import { MetronomeIcon } from "./icons";
 import { Button } from "./ui/button";
@@ -325,13 +326,6 @@ function formatBarBeat(seconds: number, tempo: number): string {
   const bar = Math.floor(totalBeats / 4) + 1; // 4/4 time signature
   const beatInBar = Math.floor(totalBeats % 4) + 1;
   return `${String(bar).padStart(2, "0")}|${String(beatInBar).padStart(2, "0")}`;
-}
-
-function formatTimeCompact(seconds: number): string {
-  const mins = Math.floor(seconds / 60);
-  const secs = Math.floor(seconds % 60);
-  const hundredths = Math.floor((seconds % 1) * 100);
-  return `${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}:${String(hundredths).padStart(2, "0")}`;
 }
 
 // GM instrument groups for organized display

--- a/src/lib/time-format.ts
+++ b/src/lib/time-format.ts
@@ -1,0 +1,6 @@
+export function formatTimeCompact(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  const hundredths = Math.floor((seconds % 1) * 100);
+  return `${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}:${String(hundredths).padStart(2, "0")}`;
+}


### PR DESCRIPTION
The score viewer only shows bar and beat, which makes it difficult to correlate a notation position with playback time or verify measure seeks independently of transport playback.

This PR adds the current absolute time to the score viewer header using the same `MM:SS:CC` format as the main editor. The runtime publishes clock time alongside bar and beat, and both displays now share one formatter.