### PR TITLE
fix: pause score following during interaction

### DIFF
--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -66,6 +66,7 @@ type CursorPosition = {
 // which is an application-specific scale rather than a physical CSS pixel size.
 // TODO: Expose this as a layout density control without coupling it to view zoom.
 const SCORE_LAYOUT_WIDTH = 1110;
+const MANUAL_SCROLL_IDLE_MS = 2000;
 
 export class ScoreViewerRuntime {
   // attach() initializes the runtime-owned DOM:
@@ -91,6 +92,7 @@ export class ScoreViewerRuntime {
   #state = INITIAL_RUNTIME_STATE;
   #timeSignature: TimeSignature = DEFAULT_TIME_SIGNATURE;
   readonly #listeners = new Set<() => void>();
+  #manualScrollTimer?: ReturnType<typeof setTimeout>;
 
   readonly #clock = new PlayheadClock();
 
@@ -128,6 +130,8 @@ export class ScoreViewerRuntime {
     this.#scroller = document.createElement("section");
     this.#scroller.dataset.testid = "score-viewer-scroll";
     this.#scroller.className = "h-full overflow-y-auto p-6";
+    this.#scroller.addEventListener("wheel", this.#handleManualScroll);
+    this.#scroller.addEventListener("pointerdown", this.#handleManualScroll);
 
     this.#sheet = document.createElement("div");
     this.#sheet.dataset.testid = "score-viewer-sheet";
@@ -171,6 +175,7 @@ export class ScoreViewerRuntime {
     score: ScoreSource;
     settings: ScoreViewerSettings;
   }) {
+    this.#resumeAutoScroll();
     this.#clock.stop();
     this.#setState({ isReady: false });
 
@@ -210,6 +215,7 @@ export class ScoreViewerRuntime {
   }
 
   restart() {
+    this.#resumeAutoScroll();
     this.#clock.stop();
     this.#scroller.scrollTo({ top: 0 });
   }
@@ -223,11 +229,15 @@ export class ScoreViewerRuntime {
   }
 
   seek(scoreTime: number) {
+    this.#resumeAutoScroll();
     this.#clock.seek(scoreTimeToSeconds(scoreTime, this.#state.tempo));
   }
 
   dispose() {
     this.#clock.stop();
+    this.#resumeAutoScroll();
+    this.#scroller.removeEventListener("wheel", this.#handleManualScroll);
+    this.#scroller.removeEventListener("pointerdown", this.#handleManualScroll);
     this.#measureLayers.removeEventListener("click", this.#handleMeasureClick);
     if (this.#root.hasChildNodes()) {
       this.#osmd.clear();
@@ -244,6 +254,18 @@ export class ScoreViewerRuntime {
     }
     this.seek(Number(target.dataset.scoreTime));
   };
+
+  #handleManualScroll = () => {
+    clearTimeout(this.#manualScrollTimer);
+    this.#manualScrollTimer = setTimeout(() => {
+      this.#manualScrollTimer = undefined;
+    }, MANUAL_SCROLL_IDLE_MS);
+  };
+
+  #resumeAutoScroll() {
+    clearTimeout(this.#manualScrollTimer);
+    this.#manualScrollTimer = undefined;
+  }
 
   #updateCursor(scoreTime: number) {
     if (this.#positions.length < 2) {
@@ -287,7 +309,10 @@ export class ScoreViewerRuntime {
     const cursorBottom = cursorTop + currentAnchor.height;
     const viewportTop = this.#scroller.scrollTop;
     const viewportBottom = viewportTop + this.#scroller.clientHeight;
-    if (cursorTop < viewportTop || viewportBottom < cursorBottom) {
+    if (
+      this.#manualScrollTimer === undefined &&
+      (cursorTop < viewportTop || viewportBottom < cursorBottom)
+    ) {
       this.#scroller.scrollTo({ top: Math.max(cursorTop - 24, 0) });
     }
   }


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/toy-midi/issues/279

Playback cursor updates currently pull the score viewport back as soon as someone manually inspects another section.

This PR temporarily suppresses playback-driven scrolling after wheel or pointer interaction, resets the two-second idle timer on repeated interaction, and resumes following immediately for explicit measure seeks and restarts. Cursor rendering continues throughout, and the runtime removes its listeners and timer during disposal.