### PR TITLE
fix: hide floating panels when printing scores

### DIFF
--- a/e2e/score-viewer-debug-capture.spec.ts
+++ b/e2e/score-viewer-debug-capture.spec.ts
@@ -26,6 +26,7 @@ test("capture paged score PDF", async ({ page }) => {
   const pages = page.getByTestId("score-viewer-renderer").locator("svg");
   await expect.poll(() => pages.count()).toBeGreaterThan(1);
   await page.emulateMedia({ media: "print" });
+  await expect(page.getByTestId("score-settings-panel")).not.toBeVisible();
   await page.pdf({
     path: ".tmp/score-viewer-debug-paged.pdf",
     format: "A4",

--- a/src/components/ui/floating-panel.tsx
+++ b/src/components/ui/floating-panel.tsx
@@ -19,7 +19,6 @@ export function FloatingPanel({
   return (
     <section
       data-testid={testId}
-      data-floating-panel
       className="fixed bottom-4 right-4 z-40 max-w-[calc(100vw-2rem)] rounded-lg border border-neutral-700 bg-neutral-800 shadow-2xl"
     >
       <div className="flex items-center justify-between border-b border-neutral-700 px-4 py-3">

--- a/src/components/ui/floating-panel.tsx
+++ b/src/components/ui/floating-panel.tsx
@@ -19,6 +19,7 @@ export function FloatingPanel({
   return (
     <section
       data-testid={testId}
+      data-floating-panel
       className="fixed bottom-4 right-4 z-40 max-w-[calc(100vw-2rem)] rounded-lg border border-neutral-700 bg-neutral-800 shadow-2xl"
     >
       <div className="flex items-center justify-between border-b border-neutral-700 px-4 py-3">

--- a/src/index.css
+++ b/src/index.css
@@ -88,6 +88,7 @@
   }
 
   .score-viewer-root-paged > header,
+  [data-floating-panel],
   [data-testid="score-viewer-cursor"],
   [data-testid="score-viewer-measure-layers"] {
     display: none;

--- a/src/index.css
+++ b/src/index.css
@@ -88,7 +88,7 @@
   }
 
   .score-viewer-root-paged > header,
-  [data-floating-panel],
+  [data-testid="score-settings-panel"],
   [data-testid="score-viewer-cursor"],
   [data-testid="score-viewer-measure-layers"] {
     display: none;


### PR DESCRIPTION
The score settings panel remains open after switching to paged layout, so browser print and PDF output currently include the fixed panel over the notation.

This PR marks floating panels as non-printing UI and hides them in print media. The existing PDF capture now verifies that Score Settings is not visible before generating the PDF.
