### PR TITLE
refactor: inject score playback clock

### DIFF
--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -94,11 +94,12 @@ export class ScoreViewerRuntime {
   readonly #listeners = new Set<() => void>();
   #manualScrollTimer?: ReturnType<typeof setTimeout>;
 
-  readonly #clock = new PlayheadClock();
+  readonly #clock: ScoreViewerClock;
 
-  constructor() {
+  constructor({ clock }: { clock: ScoreViewerClock }) {
+    this.#clock = clock;
     this.#clock.subscribe(() => {
-      const { currentTime, paused } = this.#clock.getSnapshot();
+      const { currentTime, isPlaying } = this.#clock.getSnapshot();
       const scoreTime = secondsToScoreTime(currentTime, this.#state.tempo);
       const { bar, beat } = scoreTimeToBarBeat(scoreTime, this.#timeSignature);
       if (
@@ -109,7 +110,6 @@ export class ScoreViewerRuntime {
         this.#setState({ bar, beat, currentTime });
       }
       this.#updateCursor(scoreTime);
-      const isPlaying = !paused;
       if (isPlaying !== this.#state.isPlaying) {
         this.#setState({ isPlaying });
       }
@@ -176,7 +176,6 @@ export class ScoreViewerRuntime {
     settings: ScoreViewerSettings;
   }) {
     this.#resumeAutoScroll();
-    this.#clock.stop();
     this.#setState({ isReady: false });
 
     this.#osmd.clear();
@@ -192,19 +191,23 @@ export class ScoreViewerRuntime {
     this.#positions = buildCursorPositions(this.#osmd, this.#container);
     buildMeasureTargets(this.#osmd, this.#measureLayers, this.#container);
     this.#timeSignature = parseTimeSignature(score.xml);
-    this.#clock.stop();
+    const tempo = parseTempo(score.xml);
+    const { currentTime, isPlaying } = this.#clock.getSnapshot();
+    const scoreTime = secondsToScoreTime(currentTime, tempo);
+    const { bar, beat } = scoreTimeToBarBeat(scoreTime, this.#timeSignature);
     this.#setState({
-      bar: 1,
-      beat: 1,
-      currentTime: 0,
+      bar,
+      beat,
+      currentTime,
+      isPlaying,
       isReady: true,
-      tempo: parseTempo(score.xml),
+      tempo,
     });
-    this.#updateCursor(0);
+    this.#updateCursor(scoreTime);
   }
 
   togglePlayback() {
-    if (!this.#clock.getSnapshot().paused) {
+    if (this.#clock.getSnapshot().isPlaying) {
       this.#clock.pause();
       return;
     }
@@ -216,7 +219,8 @@ export class ScoreViewerRuntime {
 
   restart() {
     this.#resumeAutoScroll();
-    this.#clock.stop();
+    this.#clock.pause();
+    this.#clock.seek(0);
     this.#scroller.scrollTo({ top: 0 });
   }
 
@@ -234,7 +238,6 @@ export class ScoreViewerRuntime {
   }
 
   dispose() {
-    this.#clock.stop();
     this.#resumeAutoScroll();
     this.#scroller.removeEventListener("wheel", this.#handleManualScroll);
     this.#scroller.removeEventListener("pointerdown", this.#handleManualScroll);
@@ -543,16 +546,24 @@ function buildMeasureTargets(
   layers.replaceChildren(...pageLayers);
 }
 
-// Temporary score-viewer transport matching the snapshot/subscription shape
-// used by the existing Tone.js transport hook infrastructure.
+// Shared transport boundary for the standalone playhead and editor audio clock.
+// The snapshot/subscription shape keeps cursor updates independent of React.
+
+export type ScoreViewerClock = {
+  getSnapshot: () => PlayheadSnapshot;
+  subscribe: (listener: () => void) => () => void;
+  play: () => void;
+  pause: () => void;
+  seek: (currentTime: number) => void;
+};
 
 type PlayheadSnapshot = {
   currentTime: number;
-  paused: boolean;
+  isPlaying: boolean;
 };
 
-class PlayheadClock {
-  #snapshot: PlayheadSnapshot = { currentTime: 0, paused: true };
+export class PlayheadClock implements ScoreViewerClock {
+  #snapshot: PlayheadSnapshot = { currentTime: 0, isPlaying: false };
   #startedAt?: number;
   #frame?: number;
   readonly #listeners = new Set<() => void>();
@@ -565,16 +576,16 @@ class PlayheadClock {
   };
 
   play() {
-    if (!this.#snapshot.paused) {
+    if (this.#snapshot.isPlaying) {
       return;
     }
     this.#startedAt = performance.now();
-    this.#setSnapshot({ paused: false });
+    this.#setSnapshot({ isPlaying: true });
     this.#frame = requestAnimationFrame(this.#tick);
   }
 
   pause() {
-    if (this.#snapshot.paused) {
+    if (!this.#snapshot.isPlaying) {
       return;
     }
     const currentTime =
@@ -583,23 +594,16 @@ class PlayheadClock {
     cancelAnimationFrame(this.#frame ?? 0);
     this.#frame = undefined;
     this.#startedAt = undefined;
-    this.#setSnapshot({ currentTime, paused: true });
-  }
-
-  stop() {
-    cancelAnimationFrame(this.#frame ?? 0);
-    this.#frame = undefined;
-    this.#startedAt = undefined;
-    this.#setSnapshot({ currentTime: 0, paused: true });
+    this.#setSnapshot({ currentTime, isPlaying: false });
   }
 
   seek(currentTime: number) {
-    this.#startedAt = this.#snapshot.paused ? undefined : performance.now();
+    this.#startedAt = this.#snapshot.isPlaying ? performance.now() : undefined;
     this.#setSnapshot({ currentTime });
   }
 
   #tick = () => {
-    if (this.#snapshot.paused || this.#startedAt === undefined) {
+    if (!this.#snapshot.isPlaying || this.#startedAt === undefined) {
       return;
     }
     const currentTime =

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -21,6 +21,7 @@ import { FileDropInput } from "./file-drop-input";
 import { ScoreSettings } from "./score-settings";
 import {
   INITIAL_SCORE_VIEWER_SETTINGS,
+  PlayheadClock,
   type ScoreSource,
   type ScoreViewerSettings,
   ScoreViewerRuntime,
@@ -54,7 +55,8 @@ export function ScoreViewer({
   }, [score]);
 
   // initialize runtime
-  const [runtime] = useState(() => new ScoreViewerRuntime());
+  const [clock] = useState(() => new PlayheadClock());
+  const [runtime] = useState(() => new ScoreViewerRuntime({ clock }));
   // TODO: Isolate the clock subscription if whole-view RAF rerenders become
   // expensive; the current component tree is small enough.
   const runtimeState = useSyncExternalStore(
@@ -68,8 +70,11 @@ export function ScoreViewer({
     }
     runtime.attach(root);
     setIsRuntimeAttached(true);
-    return () => runtime.dispose();
-  }, [runtime]);
+    return () => {
+      clock.pause();
+      runtime.dispose();
+    };
+  }, [clock, runtime]);
 
   const tempoInput = useDraftInput({
     value: runtimeState.tempo,
@@ -95,6 +100,8 @@ export function ScoreViewer({
       settings: ScoreViewerSettings;
       source: File | ScoreSource;
     }) => {
+      clock.pause();
+      clock.seek(0);
       const nextScore =
         source instanceof File
           ? { name: source.name, xml: await source.text() }

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -100,8 +100,6 @@ export function ScoreViewer({
       settings: ScoreViewerSettings;
       source: File | ScoreSource;
     }) => {
-      clock.pause();
-      clock.seek(0);
       const nextScore =
         source instanceof File
           ? { name: source.name, xml: await source.text() }


### PR DESCRIPTION
- related to https://github.com/hi-ogawa/toy-midi/issues/251

`ScoreViewerRuntime` currently creates and controls its own playhead, which ties score rendering to the standalone viewer lifecycle. This makes the renderer difficult to reuse with an existing transport without also inheriting clock resets during score loading and disposal.

This PR injects the score clock through a small snapshot/subscription interface and moves standalone clock creation, source-change reset, and cleanup into `ScoreViewer`. Standalone behavior remains the same, while runtime loading now reflects the current injected clock position and runtime disposal no longer mutates transport state it does not own.
