### PR TITLE
feat: resize score preview panel

### DIFF
--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -8,7 +8,7 @@ import {
   SlidersHorizontalIcon,
   SparklesIcon,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useWindowEvent } from "../hooks/use-window-event";
 import { isShortcutTextInputTarget, matchKeyboardEvent } from "../lib/keyboard";
 import { flushAutoSave } from "../lib/project-session";
@@ -51,6 +51,73 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
   const [audioToMidiTrackId, setAudioToMidiTrackId] = useState<string>();
   const audioToMidiTrack = useProjectStore((state) =>
     state.audioTracks.find((track) => track.id === audioToMidiTrackId),
+  );
+  const scorePreviewResizeHandleRef = useCallback(
+    (handle: HTMLButtonElement | null) => {
+      if (!handle) {
+        return;
+      }
+
+      let drag:
+        | {
+            pointerId: number;
+            startX: number;
+            startY: number;
+            width: number;
+            height: number;
+          }
+        | undefined;
+
+      const onPointerDown = (event: PointerEvent) => {
+        const panel = handle.offsetParent;
+        if (!(panel instanceof HTMLElement)) {
+          return;
+        }
+        const rect = panel.getBoundingClientRect();
+        drag = {
+          pointerId: event.pointerId,
+          startX: event.clientX,
+          startY: event.clientY,
+          width: rect.width,
+          height: rect.height,
+        };
+        handle.setPointerCapture(event.pointerId);
+      };
+      const onPointerMove = (event: PointerEvent) => {
+        if (!drag || drag.pointerId !== event.pointerId) {
+          return;
+        }
+        setScorePreviewSize({
+          width: Math.min(
+            window.innerWidth - 32,
+            Math.max(576, drag.width + drag.startX - event.clientX),
+          ),
+          height: Math.min(
+            window.innerHeight - 32,
+            Math.max(288, drag.height + drag.startY - event.clientY),
+          ),
+        });
+      };
+      const onPointerEnd = (event: PointerEvent) => {
+        if (drag?.pointerId === event.pointerId) {
+          drag = undefined;
+        }
+      };
+
+      handle.addEventListener("pointerdown", onPointerDown);
+      handle.addEventListener("pointermove", onPointerMove);
+      handle.addEventListener("pointerup", onPointerEnd);
+      handle.addEventListener("pointercancel", onPointerEnd);
+      handle.addEventListener("lostpointercapture", onPointerEnd);
+      return () => {
+        handle.removeEventListener("pointerdown", onPointerDown);
+        handle.removeEventListener("pointermove", onPointerMove);
+        handle.removeEventListener("pointerup", onPointerEnd);
+        handle.removeEventListener("pointercancel", onPointerEnd);
+        handle.removeEventListener("lostpointercapture", onPointerEnd);
+      };
+    },
+    [setScorePreviewSize],
   );
 
   // Update document title when project name changes
@@ -189,39 +256,11 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
           style={scorePreviewSize}
         >
           <button
+            ref={scorePreviewResizeHandleRef}
             type="button"
             aria-label="Resize Score Preview"
             data-testid="score-preview-resize-handle"
             className="absolute top-0 left-0 z-10 size-4 cursor-nwse-resize touch-none border-t-2 border-l-2 border-neutral-400"
-            onPointerDown={(event) => {
-              const handle = event.currentTarget;
-              handle.setPointerCapture(event.pointerId);
-              const startX = event.clientX;
-              const startY = event.clientY;
-              const startSize = scorePreviewSize;
-
-              handle.onpointermove = (moveEvent) => {
-                const maxWidth = window.innerWidth - 32;
-                const maxHeight = window.innerHeight - 32;
-                setScorePreviewSize({
-                  width: Math.min(
-                    maxWidth,
-                    Math.max(576, startSize.width + startX - moveEvent.clientX),
-                  ),
-                  height: Math.min(
-                    maxHeight,
-                    Math.max(
-                      288,
-                      startSize.height + startY - moveEvent.clientY,
-                    ),
-                  ),
-                });
-              };
-              handle.onpointerup = () => {
-                handle.onpointermove = null;
-                handle.onpointerup = null;
-              };
-            }}
           />
           <ProjectScorePreview title={projectName} />
         </FloatingPanel>

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -65,24 +65,19 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
       return listenPointerDrag({
         element: handle,
         onStart: (event) => ({
-          pointer: { x: event.clientX, y: event.clientY },
-          panel: panel.getBoundingClientRect(),
+          x: event.clientX,
+          y: event.clientY,
+          panelRect: panel.getBoundingClientRect(),
         }),
         onMove: (event, start) => {
           setScorePreviewSize({
             width: Math.min(
               window.innerWidth - 32,
-              Math.max(
-                576,
-                start.panel.width + start.pointer.x - event.clientX,
-              ),
+              Math.max(576, start.panelRect.width + start.x - event.clientX),
             ),
             height: Math.min(
               window.innerHeight - 32,
-              Math.max(
-                288,
-                start.panel.height + start.pointer.y - event.clientY,
-              ),
+              Math.max(288, start.panelRect.height + start.y - event.clientY),
             ),
           });
         },

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -15,6 +15,7 @@ import { flushAutoSave } from "../lib/project-session";
 import { projectStorage } from "../lib/project-storage";
 import { useProjectStore } from "../lib/project-store";
 import { routes } from "../lib/routes";
+import { listenPointerDrag } from "../utils/pointer-drag";
 import { AudioToMidi } from "./audio-to-midi";
 import { HelpOverlay } from "./help-overlay";
 import { Mixer } from "./mixer";
@@ -57,69 +58,29 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
       if (!handle) {
         return;
       }
-
-      // Only the pointer that started the resize may move or end it.
-      let drag:
-        | {
-            pointerId: number;
-            startX: number;
-            startY: number;
-            width: number;
-            height: number;
-          }
-        | undefined;
-
-      const onPointerDown = (event: PointerEvent) => {
-        if (drag) {
-          return;
-        }
-        const panel = handle.offsetParent;
-        if (!(panel instanceof HTMLElement)) {
-          return;
-        }
-        const rect = panel.getBoundingClientRect();
-        drag = {
-          pointerId: event.pointerId,
-          startX: event.clientX,
-          startY: event.clientY,
-          width: rect.width,
-          height: rect.height,
-        };
-        handle.setPointerCapture(event.pointerId);
-      };
-      const onPointerMove = (event: PointerEvent) => {
-        if (!drag || drag.pointerId !== event.pointerId) {
-          return;
-        }
-        setScorePreviewSize({
-          width: Math.min(
-            window.innerWidth - 32,
-            Math.max(576, drag.width + drag.startX - event.clientX),
-          ),
-          height: Math.min(
-            window.innerHeight - 32,
-            Math.max(288, drag.height + drag.startY - event.clientY),
-          ),
-        });
-      };
-      const onPointerEnd = (event: PointerEvent) => {
-        if (drag?.pointerId === event.pointerId) {
-          drag = undefined;
-        }
-      };
-
-      handle.addEventListener("pointerdown", onPointerDown);
-      handle.addEventListener("pointermove", onPointerMove);
-      handle.addEventListener("pointerup", onPointerEnd);
-      handle.addEventListener("pointercancel", onPointerEnd);
-      handle.addEventListener("lostpointercapture", onPointerEnd);
-      return () => {
-        handle.removeEventListener("pointerdown", onPointerDown);
-        handle.removeEventListener("pointermove", onPointerMove);
-        handle.removeEventListener("pointerup", onPointerEnd);
-        handle.removeEventListener("pointercancel", onPointerEnd);
-        handle.removeEventListener("lostpointercapture", onPointerEnd);
-      };
+      const panel = handle.offsetParent;
+      if (!(panel instanceof HTMLElement)) {
+        return;
+      }
+      let startSize = { width: 0, height: 0 };
+      return listenPointerDrag({
+        element: handle,
+        onStart: () => {
+          startSize = panel.getBoundingClientRect();
+        },
+        onMove: ({ deltaX, deltaY }) => {
+          setScorePreviewSize({
+            width: Math.min(
+              window.innerWidth - 32,
+              Math.max(576, startSize.width - deltaX),
+            ),
+            height: Math.min(
+              window.innerHeight - 32,
+              Math.max(288, startSize.height - deltaY),
+            ),
+          });
+        },
+      });
     },
     [setScorePreviewSize],
   );

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -71,19 +71,15 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
         }),
         onMove: (event, dragData) => {
           setScorePreviewSize({
-            width: Math.min(
+            width: clamp(
+              dragData.panelRect.width + dragData.x - event.clientX,
+              576,
               window.innerWidth - 32,
-              Math.max(
-                576,
-                dragData.panelRect.width + dragData.x - event.clientX,
-              ),
             ),
-            height: Math.min(
+            height: clamp(
+              dragData.panelRect.height + dragData.y - event.clientY,
+              288,
               window.innerHeight - 32,
-              Math.max(
-                288,
-                dragData.panelRect.height + dragData.y - event.clientY,
-              ),
             ),
           });
         },
@@ -283,4 +279,8 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
       </Dialog>
     </div>
   );
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
 }

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -194,12 +194,13 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
             data-testid="score-preview-resize-handle"
             className="absolute top-0 left-0 z-10 size-4 cursor-nwse-resize touch-none border-t-2 border-l-2 border-neutral-400"
             onPointerDown={(event) => {
-              event.currentTarget.setPointerCapture(event.pointerId);
+              const handle = event.currentTarget;
+              handle.setPointerCapture(event.pointerId);
               const startX = event.clientX;
               const startY = event.clientY;
               const startSize = scorePreviewSize;
 
-              event.currentTarget.onpointermove = (moveEvent) => {
+              handle.onpointermove = (moveEvent) => {
                 const maxWidth = window.innerWidth - 32;
                 const maxHeight = window.innerHeight - 32;
                 setScorePreviewSize({
@@ -216,9 +217,9 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
                   ),
                 });
               };
-              event.currentTarget.onpointerup = () => {
-                event.currentTarget.onpointermove = null;
-                event.currentTarget.onpointerup = null;
+              handle.onpointerup = () => {
+                handle.onpointermove = null;
+                handle.onpointerup = null;
               };
             }}
           />

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -43,6 +43,10 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isMixerOpen, setIsMixerOpen] = useState(false);
   const [isScorePreviewOpen, setIsScorePreviewOpen] = useState(false);
+  const [scorePreviewSize, setScorePreviewSize] = useState({
+    width: 800,
+    height: 448,
+  });
   const [projectName, setProjectName] = useState(initialProjectName);
   const [audioToMidiTrackId, setAudioToMidiTrackId] = useState<string>();
   const audioToMidiTrack = useProjectStore((state) =>
@@ -162,8 +166,6 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
           <Mixer />
         </FloatingPanel>
       )}
-      {/* TODO: Add a top-left resize handle so the preview can grow while its
-          bottom-right anchor remains fixed. */}
       {isScorePreviewOpen && (
         <FloatingPanel
           closeLabel="Close Score Preview"
@@ -182,9 +184,44 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
             </a>
           }
           testId="score-preview-panel"
-          className="overflow-hidden"
-          contentClassName="p-0"
+          className="flex flex-col overflow-hidden"
+          contentClassName="min-h-0 flex-1 p-0"
+          style={scorePreviewSize}
         >
+          <button
+            type="button"
+            aria-label="Resize Score Preview"
+            data-testid="score-preview-resize-handle"
+            className="absolute top-0 left-0 z-10 size-4 cursor-nwse-resize touch-none border-t-2 border-l-2 border-neutral-400"
+            onPointerDown={(event) => {
+              event.currentTarget.setPointerCapture(event.pointerId);
+              const startX = event.clientX;
+              const startY = event.clientY;
+              const startSize = scorePreviewSize;
+
+              event.currentTarget.onpointermove = (moveEvent) => {
+                const maxWidth = window.innerWidth - 32;
+                const maxHeight = window.innerHeight - 32;
+                setScorePreviewSize({
+                  width: Math.min(
+                    maxWidth,
+                    Math.max(576, startSize.width + startX - moveEvent.clientX),
+                  ),
+                  height: Math.min(
+                    maxHeight,
+                    Math.max(
+                      288,
+                      startSize.height + startY - moveEvent.clientY,
+                    ),
+                  ),
+                });
+              };
+              event.currentTarget.onpointerup = () => {
+                event.currentTarget.onpointermove = null;
+                event.currentTarget.onpointerup = null;
+              };
+            }}
+          />
           <ProjectScorePreview title={projectName} />
         </FloatingPanel>
       )}

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -225,8 +225,10 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
             type="button"
             aria-label="Resize Score Preview"
             data-testid="score-preview-resize-handle"
-            className="absolute top-0 left-0 z-10 size-4 cursor-nwse-resize touch-none border-t-2 border-l-2 border-neutral-400"
-          />
+            className="group absolute top-0 left-0 z-10 flex size-5 cursor-nwse-resize touch-none items-start justify-start p-1"
+          >
+            <span className="pointer-events-none size-2.5 border-t-2 border-l-2 border-neutral-500 transition-colors group-hover:border-neutral-200 group-active:border-blue-400" />
+          </button>
           <ProjectScorePreview title={projectName} />
         </FloatingPanel>
       )}

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -62,21 +62,27 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
       if (!(panel instanceof HTMLElement)) {
         return;
       }
-      let startSize = { width: 0, height: 0 };
       return listenPointerDrag({
         element: handle,
-        onStart: () => {
-          startSize = panel.getBoundingClientRect();
-        },
-        onMove: ({ deltaX, deltaY }) => {
+        onStart: (event) => ({
+          pointer: { x: event.clientX, y: event.clientY },
+          panel: panel.getBoundingClientRect(),
+        }),
+        onMove: (event, start) => {
           setScorePreviewSize({
             width: Math.min(
               window.innerWidth - 32,
-              Math.max(576, startSize.width - deltaX),
+              Math.max(
+                576,
+                start.panel.width + start.pointer.x - event.clientX,
+              ),
             ),
             height: Math.min(
               window.innerHeight - 32,
-              Math.max(288, startSize.height - deltaY),
+              Math.max(
+                288,
+                start.panel.height + start.pointer.y - event.clientY,
+              ),
             ),
           });
         },

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -69,15 +69,21 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
           y: event.clientY,
           panelRect: panel.getBoundingClientRect(),
         }),
-        onMove: (event, start) => {
+        onMove: (event, dragData) => {
           setScorePreviewSize({
             width: Math.min(
               window.innerWidth - 32,
-              Math.max(576, start.panelRect.width + start.x - event.clientX),
+              Math.max(
+                576,
+                dragData.panelRect.width + dragData.x - event.clientX,
+              ),
             ),
             height: Math.min(
               window.innerHeight - 32,
-              Math.max(288, start.panelRect.height + start.y - event.clientY),
+              Math.max(
+                288,
+                dragData.panelRect.height + dragData.y - event.clientY,
+              ),
             ),
           });
         },

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -58,6 +58,7 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
         return;
       }
 
+      // Only the pointer that started the resize may move or end it.
       let drag:
         | {
             pointerId: number;

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -69,6 +69,9 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
         | undefined;
 
       const onPointerDown = (event: PointerEvent) => {
+        if (drag) {
+          return;
+        }
         const panel = handle.offsetParent;
         if (!(panel instanceof HTMLElement)) {
           return;

--- a/src/components/project-score-preview.tsx
+++ b/src/components/project-score-preview.tsx
@@ -119,7 +119,7 @@ export function ProjectScorePreview({ title }: { title: string }) {
     <div
       ref={rootRef}
       data-testid="project-score-preview"
-      className="score-preview-runtime h-[28rem] w-[50rem] overflow-hidden bg-neutral-300 text-neutral-950"
+      className="score-preview-runtime h-full w-full overflow-hidden bg-neutral-300 text-neutral-950"
     />
   );
 }

--- a/src/components/score-viewer-runtime.ts
+++ b/src/components/score-viewer-runtime.ts
@@ -234,7 +234,7 @@ export class ScoreViewerRuntime {
 
     this.#sheet.className =
       settings.layout === "continuous"
-        ? "relative bg-white px-4 shadow-xl"
+        ? "relative box-content bg-white px-4 shadow-xl"
         : "relative";
     this.#updateScale();
     this.#positions = buildCursorPositions(this.#osmd, this.#container);

--- a/src/components/ui/floating-panel.tsx
+++ b/src/components/ui/floating-panel.tsx
@@ -1,5 +1,5 @@
 import { XIcon } from "lucide-react";
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { cn } from "./utils";
 
 type FloatingPanelProps = {
@@ -11,6 +11,7 @@ type FloatingPanelProps = {
   testId?: string;
   className?: string;
   contentClassName?: string;
+  style?: CSSProperties;
 };
 
 export function FloatingPanel({
@@ -22,10 +23,12 @@ export function FloatingPanel({
   testId,
   className,
   contentClassName,
+  style,
 }: FloatingPanelProps) {
   return (
     <section
       data-testid={testId}
+      style={style}
       className={cn(
         "fixed bottom-4 right-4 z-40 max-w-[calc(100vw-2rem)] rounded-lg border border-neutral-700 bg-neutral-800 shadow-2xl",
         className,

--- a/src/utils/pointer-drag.ts
+++ b/src/utils/pointer-drag.ts
@@ -1,37 +1,37 @@
-type PointerDragOptions = {
+type PointerDragOptions<T> = {
   element: HTMLElement;
-  onStart: () => void;
-  onMove: (delta: { deltaX: number; deltaY: number }) => void;
+  onStart: (event: PointerEvent) => T;
+  onMove: (event: PointerEvent, data: T) => void;
+  onEnd?: (event: PointerEvent, data: T) => void;
 };
 
-export function listenPointerDrag({
+export function listenPointerDrag<T>({
   element,
   onStart,
   onMove,
-}: PointerDragOptions) {
-  let drag: { pointerId: number; x: number; y: number } | undefined;
+  onEnd,
+}: PointerDragOptions<T>) {
+  let drag: { pointerId: number; data: T } | undefined;
 
   const handlePointerDown = (event: PointerEvent) => {
     if (event.button !== 0 || drag) {
       return;
     }
-    drag = { pointerId: event.pointerId, x: event.clientX, y: event.clientY };
+    drag = { pointerId: event.pointerId, data: onStart(event) };
     element.setPointerCapture(event.pointerId);
-    onStart();
   };
   const handlePointerMove = (event: PointerEvent) => {
     if (!drag || drag.pointerId !== event.pointerId) {
       return;
     }
-    onMove({
-      deltaX: event.clientX - drag.x,
-      deltaY: event.clientY - drag.y,
-    });
+    onMove(event, drag.data);
   };
   const handlePointerEnd = (event: PointerEvent) => {
     // Only the pointer that started the drag may end it.
     if (drag?.pointerId === event.pointerId) {
+      const { data } = drag;
       drag = undefined;
+      onEnd?.(event, data);
     }
   };
 

--- a/src/utils/pointer-drag.ts
+++ b/src/utils/pointer-drag.ts
@@ -1,0 +1,50 @@
+type PointerDragOptions = {
+  element: HTMLElement;
+  onStart: () => void;
+  onMove: (delta: { deltaX: number; deltaY: number }) => void;
+};
+
+export function listenPointerDrag({
+  element,
+  onStart,
+  onMove,
+}: PointerDragOptions) {
+  let drag: { pointerId: number; x: number; y: number } | undefined;
+
+  const handlePointerDown = (event: PointerEvent) => {
+    if (event.button !== 0 || drag) {
+      return;
+    }
+    drag = { pointerId: event.pointerId, x: event.clientX, y: event.clientY };
+    element.setPointerCapture(event.pointerId);
+    onStart();
+  };
+  const handlePointerMove = (event: PointerEvent) => {
+    if (!drag || drag.pointerId !== event.pointerId) {
+      return;
+    }
+    onMove({
+      deltaX: event.clientX - drag.x,
+      deltaY: event.clientY - drag.y,
+    });
+  };
+  const handlePointerEnd = (event: PointerEvent) => {
+    // Only the pointer that started the drag may end it.
+    if (drag?.pointerId === event.pointerId) {
+      drag = undefined;
+    }
+  };
+
+  element.addEventListener("pointerdown", handlePointerDown);
+  element.addEventListener("pointermove", handlePointerMove);
+  element.addEventListener("pointerup", handlePointerEnd);
+  element.addEventListener("pointercancel", handlePointerEnd);
+  element.addEventListener("lostpointercapture", handlePointerEnd);
+  return () => {
+    element.removeEventListener("pointerdown", handlePointerDown);
+    element.removeEventListener("pointermove", handlePointerMove);
+    element.removeEventListener("pointerup", handlePointerEnd);
+    element.removeEventListener("pointercancel", handlePointerEnd);
+    element.removeEventListener("lostpointercapture", handlePointerEnd);
+  };
+}

--- a/src/utils/pointer-drag.ts
+++ b/src/utils/pointer-drag.ts
@@ -17,7 +17,10 @@ export function listenPointerDrag<T>({
     if (event.button !== 0 || drag) {
       return;
     }
-    drag = { pointerId: event.pointerId, data: onStart(event) };
+    drag = {
+      pointerId: event.pointerId,
+      data: onStart(event),
+    };
     element.setPointerCapture(event.pointerId);
   };
   const handlePointerMove = (event: PointerEvent) => {


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/toy-midi/issues/285

The fixed score preview size limits how much notation can be inspected without opening the full score. This PR adds a top-left resize handle while keeping the panel anchored at the bottom-right.

The panel size stays in editor UI state and is clamped to useful minimums and the available viewport. The preview now fills the resized panel, so its existing resize observer refits the score without remounting the runtime.