### PR TITLE
feat: add latency input meter

### DIFF
--- a/src/components/latency-checker.tsx
+++ b/src/components/latency-checker.tsx
@@ -710,8 +710,14 @@ function Field({ label, children }: { label: string; children: ReactNode }) {
 }
 
 function InputMeter({ active, peak }: { active: boolean; peak: number }) {
+  const meterMin = -60;
+  const meterMax = 6;
   const decibels = peak > 0 ? 20 * Math.log10(peak) : -Infinity;
-  const meterValue = clamp(decibels, -60, 0);
+  const meterValue = clamp(decibels, meterMin, meterMax);
+  const position = (value: number) =>
+    ((value - meterMin) / (meterMax - meterMin)) * 100;
+  const zeroPosition = position(0);
+  const levelPosition = active ? position(meterValue) : 0;
   const label =
     active && Number.isFinite(decibels)
       ? `${decibels.toFixed(1)} dBFS`
@@ -722,17 +728,31 @@ function InputMeter({ active, peak }: { active: boolean; peak: number }) {
       <div
         role="meter"
         aria-label="Input peak level"
-        aria-valuemin={-60}
-        aria-valuemax={0}
-        aria-valuenow={active ? meterValue : -60}
+        aria-valuemin={meterMin}
+        aria-valuemax={meterMax}
+        aria-valuenow={active ? meterValue : meterMin}
         aria-valuetext={label}
-        className="h-3 overflow-hidden rounded-full bg-neutral-200"
+        className="relative h-3 overflow-hidden rounded-full bg-neutral-200"
       >
         <div
-          className="h-full bg-emerald-600 transition-[width] duration-75"
+          className="absolute inset-y-0 right-0 bg-red-100"
+          style={{ width: `${100 - zeroPosition}%` }}
+        />
+        <div
+          className="absolute inset-y-0 left-0 bg-emerald-600 transition-[width] duration-75"
+          style={{ width: `${Math.min(levelPosition, zeroPosition)}%` }}
+        />
+        <div
+          className="absolute inset-y-0 bg-red-600 transition-[width] duration-75"
           style={{
-            width: active ? `${((meterValue + 60) / 60) * 100}%` : 0,
+            left: `${zeroPosition}%`,
+            width: `${Math.max(0, levelPosition - zeroPosition)}%`,
           }}
+        />
+        <div
+          aria-hidden="true"
+          className="absolute inset-y-0 w-px bg-red-700"
+          style={{ left: `${zeroPosition}%` }}
         />
       </div>
       <output className="text-right font-mono text-xs tabular-nums text-neutral-600">

--- a/src/components/latency-checker.tsx
+++ b/src/components/latency-checker.tsx
@@ -36,6 +36,7 @@ export function LatencyChecker() {
   const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
   const [deviceId, setDeviceId] = useState("");
   const [channel, setChannel] = useState(0);
+  const [inputPeak, setInputPeak] = useState(0);
   const [outputLevel, setOutputLevel] = useState(-24);
   const [routeOpen, setRouteOpen] = useState(false);
   const [status, setStatus] = useState<Status>({
@@ -83,7 +84,7 @@ export function LatencyChecker() {
   });
 
   const openRouteMutation = useMutation({
-    mutationFn: () => runtime.openRoute({ deviceId }),
+    mutationFn: () => runtime.openRoute({ deviceId, onLevel: setInputPeak }),
     onSuccess: () => {
       setChannel(0);
       setRouteOpen(true);
@@ -142,9 +143,11 @@ export function LatencyChecker() {
   function toggleRoute() {
     if (routeOpen) {
       runtime.closeRoute();
+      setInputPeak(0);
       setRouteOpen(false);
       setStatus({ message: "Audio route closed.", state: "idle" });
     } else {
+      setInputPeak(0);
       openRouteMutation.mutate();
     }
   }
@@ -251,6 +254,10 @@ export function LatencyChecker() {
                   <option>Open route first</option>
                 )}
               </select>
+            </Field>
+
+            <Field label="Input peak">
+              <InputMeter active={routeOpen} peak={inputPeak} />
             </Field>
 
             <Field label="Calibration click level">
@@ -602,6 +609,39 @@ function Field({ label, children }: { label: string; children: ReactNode }) {
       {label}
       {children}
     </label>
+  );
+}
+
+function InputMeter({ active, peak }: { active: boolean; peak: number }) {
+  const decibels = peak > 0 ? 20 * Math.log10(peak) : -Infinity;
+  const meterValue = clamp(decibels, -60, 0);
+  const label =
+    active && Number.isFinite(decibels)
+      ? `${decibels.toFixed(1)} dBFS`
+      : "-∞ dBFS";
+
+  return (
+    <div className="grid grid-cols-[1fr_76px] items-center gap-3">
+      <div
+        role="meter"
+        aria-label="Input peak level"
+        aria-valuemin={-60}
+        aria-valuemax={0}
+        aria-valuenow={active ? meterValue : -60}
+        aria-valuetext={label}
+        className="h-3 overflow-hidden rounded-full bg-neutral-200"
+      >
+        <div
+          className="h-full bg-emerald-600 transition-[width] duration-75"
+          style={{
+            width: active ? `${((meterValue + 60) / 60) * 100}%` : 0,
+          }}
+        />
+      </div>
+      <output className="text-right font-mono text-xs tabular-nums text-neutral-600">
+        {label}
+      </output>
+    </div>
   );
 }
 

--- a/src/lib/latency-checker/runtime.ts
+++ b/src/lib/latency-checker/runtime.ts
@@ -56,7 +56,13 @@ export class LatencyCheckerRuntime {
     );
   }
 
-  async openRoute({ deviceId }: { deviceId: string }) {
+  async openRoute({
+    deviceId,
+    onLevel,
+  }: {
+    deviceId: string;
+    onLevel: (peak: number) => void;
+  }) {
     const context = await this.#ensureAudioContext();
     this.#activeStream = await navigator.mediaDevices.getUserMedia(
       captureConstraints(deviceId),
@@ -85,6 +91,9 @@ export class LatencyCheckerRuntime {
           if (event.data.value > 0) {
             resolve(event.data.value);
           }
+        }
+        if (event.data.type === "level") {
+          onLevel(event.data.peak);
         }
       };
     });

--- a/src/lib/latency-checker/worklet-factory.ts
+++ b/src/lib/latency-checker/worklet-factory.ts
@@ -2,6 +2,7 @@ export const CAPTURE_PROCESSOR_NAME = "latency-capture";
 
 export type CaptureMessage =
   | { type: "channels"; value: number }
+  | { type: "level"; peak: number }
   | { type: "samples"; frameStart: number; samples: Float32Array };
 
 type WorkletProcessorConstructor = new () => { port: MessagePort };
@@ -24,18 +25,24 @@ function createCaptureProcessor() {
     declare active: boolean;
     declare channel: number;
     declare lastChannelCount: number;
+    declare meterBlockCount: number;
+    declare meterPeak: number;
 
     constructor() {
       super();
       this.active = false;
       this.channel = 0;
       this.lastChannelCount = -1;
+      this.meterBlockCount = 0;
+      this.meterPeak = 0;
       this.port.onmessage = (event: MessageEvent<WorkletControlMessage>) => {
         if (event.data.type === "active") {
           this.active = event.data.value;
         }
         if (event.data.type === "channel") {
           this.channel = event.data.value;
+          this.meterBlockCount = 0;
+          this.meterPeak = 0;
         }
       };
     }
@@ -50,9 +57,19 @@ function createCaptureProcessor() {
         this.lastChannelCount = channels.length;
         this.port.postMessage({ type: "channels", value: channels.length });
       }
-      if (this.active && channels.length > 0) {
-        const selected = channels[this.channel];
-        if (!selected) {
+      const selected = channels[this.channel];
+      if (selected) {
+        for (const sample of selected) {
+          this.meterPeak = Math.max(this.meterPeak, Math.abs(sample));
+        }
+        this.meterBlockCount++;
+        if (this.meterBlockCount >= 16) {
+          this.port.postMessage({ type: "level", peak: this.meterPeak });
+          this.meterBlockCount = 0;
+          this.meterPeak = 0;
+        }
+
+        if (!this.active) {
           return true;
         }
         const copy = new Float32Array(selected);


### PR DESCRIPTION
Stacked on #292.

Adds a continuously updating peak meter for the selected capture channel so the input and patch can be confirmed before calibration. The capture worklet aggregates peaks into throttled level messages while keeping full PCM delivery gated to active calibration.

Verification: `pnpm lint`