### PR TITLE
fix: rename "all projects" link to "home"

### DIFF
--- a/e2e/help-overlay.spec.ts
+++ b/e2e/help-overlay.spec.ts
@@ -61,11 +61,9 @@ test.describe("Help Overlay", () => {
     await expect(page.getByTestId("help-overlay")).not.toBeVisible();
   });
 
-  test("returns to all projects from the application menu", async ({
-    page,
-  }) => {
+  test("navigates home from the application menu", async ({ page }) => {
     await page.getByTestId("app-menu-button").click();
-    await page.getByTestId("all-projects-menu-item").click();
+    await page.getByTestId("home-menu-item").click();
 
     await expect(page).toHaveURL("/");
     await expect(page.getByTestId("startup-screen")).toBeVisible();

--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -9,7 +9,7 @@ test("navigates between projects and the score viewer", async ({ page }) => {
   await expect(page).toHaveTitle("Score Viewer - Toy MIDI");
 
   await page.getByRole("button", { name: "More" }).click();
-  await page.getByTestId("all-projects-menu-item").click();
+  await page.getByTestId("home-menu-item").click();
   await expect(page).toHaveURL(/\/$/);
   await expect(page.getByTestId("startup-screen")).toBeVisible();
 });

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -2,7 +2,7 @@ import {
   CircleHelpIcon,
   ExternalLinkIcon,
   FileMusicIcon,
-  FolderIcon,
+  HouseIcon,
   MoreVerticalIcon,
   SettingsIcon,
   SlidersHorizontalIcon,
@@ -169,12 +169,9 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 <DropdownMenuItem asChild>
-                  <a
-                    href={routes.home.href()}
-                    data-testid="all-projects-menu-item"
-                  >
-                    <FolderIcon />
-                    All Projects
+                  <a href={routes.home.href()} data-testid="home-menu-item">
+                    <HouseIcon />
+                    Home
                   </a>
                 </DropdownMenuItem>
                 <DropdownMenuItem

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -1,8 +1,8 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   ChevronsUpDownIcon,
-  FolderIcon,
   FolderOpenIcon,
+  HouseIcon,
   MoreVerticalIcon,
   PauseIcon,
   PlayIcon,
@@ -292,9 +292,9 @@ export function ScoreViewer({
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuItem asChild>
-              <a href={routes.home.href()} data-testid="all-projects-menu-item">
-                <FolderIcon />
-                All Projects
+              <a href={routes.home.href()} data-testid="home-menu-item">
+                <HouseIcon />
+                Home
               </a>
             </DropdownMenuItem>
           </DropdownMenuContent>


### PR DESCRIPTION
The application menu's `All Projects` item is the persistent route to the index page, including from deep links and the score viewer, so the project-list wording understates its navigation role.\n\nThis PR labels the destination `Home`, uses a home icon in both menus, and aligns the navigation E2E coverage with that meaning.