### PR TITLE
refactor: align page design system

### DIFF
--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -227,7 +227,7 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
             data-testid="score-preview-resize-handle"
             className="group absolute top-0 left-0 z-10 flex size-5 cursor-nwse-resize touch-none items-start justify-start p-1"
           >
-            <span className="pointer-events-none size-2.5 border-t-2 border-l-2 border-neutral-500 transition-colors group-hover:border-neutral-200 group-active:border-blue-400" />
+            <span className="pointer-events-none size-2.5 border-t-2 border-l-2 border-neutral-500 transition-colors group-hover:border-neutral-200 group-active:border-emerald-400" />
           </button>
           <ProjectScorePreview title={projectName} />
         </FloatingPanel>

--- a/src/components/latency-checker.tsx
+++ b/src/components/latency-checker.tsx
@@ -117,7 +117,7 @@ export function LatencyChecker() {
             <Button
               title="More"
               aria-label="More"
-              className="size-8 hover:bg-accent hover:text-accent-foreground"
+              className="size-9 hover:bg-accent hover:text-accent-foreground"
             >
               <MoreVerticalIcon className="size-5" />
             </Button>

--- a/src/components/latency-checker.tsx
+++ b/src/components/latency-checker.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { AudioLinesIcon, FolderIcon, MoreVerticalIcon } from "lucide-react";
+import { AudioLinesIcon, HouseIcon, MoreVerticalIcon } from "lucide-react";
 import {
   type ComponentProps,
   type ReactNode,
@@ -125,7 +125,7 @@ export function LatencyChecker() {
           <DropdownMenuContent align="end">
             <DropdownMenuItem asChild>
               <a href={routes.home.href()}>
-                <FolderIcon />
+                <HouseIcon />
                 Home
               </a>
             </DropdownMenuItem>
@@ -605,7 +605,7 @@ function ActionButton({
       className={cn(
         "min-h-10 flex-1 px-3 text-sm font-semibold",
         accent
-          ? "border-orange-700 bg-orange-700 text-white hover:bg-orange-800"
+          ? "border-emerald-700 bg-emerald-700 text-white hover:bg-emerald-800"
           : "border-neutral-300 bg-white text-neutral-900 hover:bg-neutral-100",
         className,
       )}

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -212,7 +212,7 @@ export function ScoreViewer({
           title="Score settings"
           aria-label="Score settings"
           className={cn(
-            "size-8 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+            "size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
             isSettingsOpen &&
               "bg-primary text-primary-foreground hover:bg-primary/90",
           )}
@@ -285,7 +285,7 @@ export function ScoreViewer({
             <Button
               title="More"
               aria-label="More"
-              className="size-8 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+              className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
             >
               <MoreVerticalIcon className="size-5" />
             </Button>

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -313,7 +313,7 @@ export function ScoreViewer({
                   source: file,
                 })
               }
-              className="group h-48 w-full max-w-4xl flex-col gap-3 rounded-xl border border-dashed border-neutral-500 bg-white/60 text-center text-neutral-700 shadow-none hover:border-neutral-700 hover:bg-white hover:text-neutral-900 data-[drag-over=true]:border-emerald-600 data-[drag-over=true]:bg-emerald-50 data-[drag-over=true]:text-emerald-900"
+              className="group h-48 w-full max-w-4xl flex-col gap-3 rounded-xl border border-dashed border-neutral-400 bg-white text-center text-neutral-700 shadow-sm transition-[border-color,background-color,box-shadow] hover:border-neutral-600 hover:text-neutral-900 hover:shadow-md data-[drag-over=true]:border-emerald-600 data-[drag-over=true]:bg-emerald-50 data-[drag-over=true]:text-emerald-900 data-[drag-over=true]:shadow-md data-[drag-over=true]:ring-4 data-[drag-over=true]:ring-emerald-200"
             >
               <span className="flex size-11 items-center justify-center rounded-full border border-neutral-400 bg-white shadow-sm group-data-[drag-over=true]:border-emerald-400">
                 <UploadIcon className="size-5" />

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -146,11 +146,11 @@ export function ScoreViewer({
   return (
     <main
       className={cn(
-        "flex h-screen flex-col overflow-hidden bg-neutral-300 text-neutral-950",
+        "flex h-screen flex-col overflow-hidden bg-neutral-100 text-neutral-950",
         settings.layout === "paged" && "score-viewer-root-paged",
       )}
     >
-      <header className="flex items-center gap-2 border-b border-neutral-700 bg-neutral-800 px-3 py-2 text-neutral-100">
+      <header className="flex h-[53px] shrink-0 items-center gap-2 border-b border-neutral-700 bg-neutral-800 px-4 text-neutral-100 shadow-sm">
         <Button
           data-testid="score-play-pause-button"
           disabled={!runtimeState.isReady}
@@ -313,13 +313,13 @@ export function ScoreViewer({
                   source: file,
                 })
               }
-              className="group h-48 w-full max-w-4xl flex-col gap-3 rounded-sm border border-dashed border-neutral-500 bg-neutral-200/60 text-center text-neutral-700 shadow-none hover:border-neutral-700 hover:bg-neutral-100 hover:text-neutral-900 data-[drag-over=true]:border-blue-600 data-[drag-over=true]:bg-blue-50 data-[drag-over=true]:text-blue-900"
+              className="group h-48 w-full max-w-4xl flex-col gap-3 rounded-xl border border-dashed border-neutral-500 bg-white/60 text-center text-neutral-700 shadow-none hover:border-neutral-700 hover:bg-white hover:text-neutral-900 data-[drag-over=true]:border-emerald-600 data-[drag-over=true]:bg-emerald-50 data-[drag-over=true]:text-emerald-900"
             >
-              <span className="flex size-11 items-center justify-center rounded-full border border-neutral-400 bg-white shadow-sm group-data-[drag-over=true]:border-blue-400">
+              <span className="flex size-11 items-center justify-center rounded-full border border-neutral-400 bg-white shadow-sm group-data-[drag-over=true]:border-emerald-400">
                 <UploadIcon className="size-5" />
               </span>
               <span className="font-medium">Drop a MusicXML score here</span>
-              <span className="text-xs text-neutral-500 group-data-[drag-over=true]:text-blue-700">
+              <span className="text-xs text-neutral-500 group-data-[drag-over=true]:text-emerald-700">
                 or click to choose an .xml or .musicxml file
               </span>
             </FileDropInput>

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -313,13 +313,13 @@ export function ScoreViewer({
                   source: file,
                 })
               }
-              className="group h-48 w-full max-w-4xl flex-col gap-3 border border-dashed border-neutral-300 bg-white text-center text-neutral-700 shadow-xs hover:border-neutral-400 hover:bg-neutral-50 hover:text-neutral-900 data-[drag-over=true]:border-emerald-500/60 data-[drag-over=true]:bg-emerald-50 data-[drag-over=true]:text-emerald-900"
+              className="group h-48 w-full max-w-4xl flex-col gap-3 border border-dashed border-neutral-400 bg-white text-center text-neutral-700 shadow-xs hover:border-emerald-500 hover:text-neutral-900 data-[drag-over=true]:border-emerald-600 data-[drag-over=true]:bg-emerald-100 data-[drag-over=true]:text-emerald-950"
             >
               <span className="flex size-11 items-center justify-center rounded-full border border-neutral-400 bg-white shadow-sm group-data-[drag-over=true]:border-emerald-400">
                 <UploadIcon className="size-5" />
               </span>
               <span className="font-medium">Drop a MusicXML score here</span>
-              <span className="text-xs text-neutral-500 group-data-[drag-over=true]:text-emerald-700">
+              <span className="text-xs text-neutral-500 group-data-[drag-over=true]:text-emerald-800">
                 or click to choose an .xml or .musicxml file
               </span>
             </FileDropInput>

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -313,7 +313,7 @@ export function ScoreViewer({
                   source: file,
                 })
               }
-              className="group h-48 w-full max-w-4xl flex-col gap-3 border border-dashed border-neutral-400 bg-white text-center text-neutral-700 shadow-xs hover:border-emerald-500 hover:text-neutral-900 data-[drag-over=true]:border-emerald-600 data-[drag-over=true]:bg-emerald-100 data-[drag-over=true]:text-emerald-950"
+              className="group h-48 w-full max-w-4xl flex-col gap-3 border border-neutral-400 bg-white text-center text-neutral-700 shadow-xs hover:border-emerald-500 hover:text-neutral-900 data-[drag-over=true]:border-emerald-600 data-[drag-over=true]:bg-emerald-100 data-[drag-over=true]:text-emerald-950"
             >
               <span className="flex size-11 items-center justify-center rounded-full border border-neutral-400 bg-white shadow-sm group-data-[drag-over=true]:border-emerald-400">
                 <UploadIcon className="size-5" />

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -313,7 +313,7 @@ export function ScoreViewer({
                   source: file,
                 })
               }
-              className="group h-48 w-full max-w-4xl flex-col gap-3 rounded-xl border border-dashed border-neutral-400 bg-white text-center text-neutral-700 shadow-sm transition-[border-color,background-color,box-shadow] hover:border-neutral-600 hover:text-neutral-900 hover:shadow-md data-[drag-over=true]:border-emerald-600 data-[drag-over=true]:bg-emerald-50 data-[drag-over=true]:text-emerald-900 data-[drag-over=true]:shadow-md data-[drag-over=true]:ring-4 data-[drag-over=true]:ring-emerald-200"
+              className="group h-48 w-full max-w-4xl flex-col gap-3 border border-dashed border-neutral-300 bg-white text-center text-neutral-700 shadow-xs hover:border-neutral-400 hover:bg-neutral-50 hover:text-neutral-900 data-[drag-over=true]:border-emerald-500/60 data-[drag-over=true]:bg-emerald-50 data-[drag-over=true]:text-emerald-900"
             >
               <span className="flex size-11 items-center justify-center rounded-full border border-neutral-400 bg-white shadow-sm group-data-[drag-over=true]:border-emerald-400">
                 <UploadIcon className="size-5" />

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -138,7 +138,7 @@ export function Transport({ projectName, controls }: TransportProps) {
   return (
     <div
       data-testid="transport"
-      className="flex items-center gap-2 px-3 py-2 bg-neutral-800 border-b border-neutral-700"
+      className="flex h-[53px] shrink-0 items-center gap-2 border-b border-neutral-700 bg-neutral-800 px-4 shadow-sm"
     >
       {/* Play/Pause button */}
       <PlayPauseButton />


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/toy-midi/issues/299

The editor, score viewer, and latency checker use the same basic application chrome but had drifted in header geometry, light-surface colors, and accent semantics.

This PR standardizes their 53px header geometry and spacing, moves Score Viewer onto the shared `neutral-100` light canvas, and consistently uses emerald for interactive accents and the house icon for Home. Their workspace and utility-specific layouts stay unchanged, and Recorder remains deferred until its dark or light direction is decided.