### PR TITLE
refactor: simplify score viewer header actions

### DIFF
--- a/e2e/score-viewer.spec.ts
+++ b/e2e/score-viewer.spec.ts
@@ -14,6 +14,23 @@ test("navigates between projects and the score viewer", async ({ page }) => {
   await expect(page.getByTestId("startup-screen")).toBeVisible();
 });
 
+test("opens a MusicXML file from the More menu", async ({ page }) => {
+  await page.goto("/score-viewer");
+  await page.getByRole("button", { name: "More" }).click();
+  const [fileChooser] = await Promise.all([
+    page.waitForEvent("filechooser"),
+    page.getByRole("menuitem", { name: "Open" }).click(),
+  ]);
+  await fileChooser.setFiles(
+    path.resolve("src/lib/musicxml/__snapshots__/five-string-tab.musicxml"),
+  );
+
+  await expect(page).toHaveTitle("five-string-tab.musicxml - Toy MIDI");
+  await expect(
+    page.getByTestId("score-viewer-renderer").locator("svg"),
+  ).toBeVisible();
+});
+
 test("opens the latest project state as a score in a new tab", async ({
   page,
 }) => {

--- a/src/components/file-drop-input.tsx
+++ b/src/components/file-drop-input.tsx
@@ -7,6 +7,29 @@ interface FileDropInputProps extends React.ComponentProps<typeof Button> {
   inputProps?: React.ComponentProps<"input"> & { "data-testid"?: string };
 }
 
+export function openFilePicker({
+  accept,
+  onFile,
+}: {
+  accept: string;
+  onFile: (file: File) => void;
+}) {
+  const input = document.createElement("input");
+  input.type = "file";
+  input.accept = accept;
+  input.addEventListener(
+    "change",
+    () => {
+      const file = input.files?.[0];
+      if (file) {
+        onFile(file);
+      }
+    },
+    { once: true },
+  );
+  input.click();
+}
+
 export function FileDropInput({
   accept,
   disabled,

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -17,7 +17,7 @@ import { isShortcutTextInputTarget, matchKeyboardEvent } from "../lib/keyboard";
 import { routes } from "../lib/routes";
 import { SCORE_VIEWER_SAMPLES } from "../lib/score-viewer-samples";
 import { formatTimeCompact } from "../lib/time-format";
-import { FileDropInput } from "./file-drop-input";
+import { FileDropInput, openFilePicker } from "./file-drop-input";
 import { ScoreSettings } from "./score-settings";
 import {
   INITIAL_SCORE_VIEWER_SETTINGS,
@@ -243,18 +243,44 @@ export function ScoreViewer({
             }
           />
         )}
-        <ScoreMoreMenu
-          disabled={loadMutation.isPending}
-          onFile={
-            initialSource
-              ? undefined
-              : (file) =>
-                  loadMutation.mutate({
-                    settings,
-                    source: file,
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              title="More"
+              aria-label="More"
+              className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+            >
+              <MoreVerticalIcon className="size-5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {!initialSource && (
+              <DropdownMenuItem
+                disabled={loadMutation.isPending}
+                onSelect={() =>
+                  openFilePicker({
+                    accept:
+                      ".musicxml,.xml,application/vnd.recordare.musicxml+xml",
+                    onFile: (file) =>
+                      loadMutation.mutate({
+                        settings,
+                        source: file,
+                      }),
                   })
-          }
-        />
+                }
+              >
+                <FolderOpenIcon />
+                Open
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuItem asChild>
+              <a href={routes.home.href()} data-testid="home-menu-item">
+                <HouseIcon />
+                Home
+              </a>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </header>
       {!score && !loadMutation.error && (
         <section className="min-h-0 flex-1 p-6">
@@ -341,66 +367,6 @@ function ScoreSamplesMenu({
         ))}
       </DropdownMenuContent>
     </DropdownMenu>
-  );
-}
-
-function ScoreMoreMenu({
-  disabled,
-  onFile,
-}: {
-  disabled: boolean;
-  onFile?: (file: File) => void;
-}) {
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  return (
-    <>
-      {onFile && (
-        <input
-          ref={inputRef}
-          type="file"
-          accept=".musicxml,.xml,application/vnd.recordare.musicxml+xml"
-          disabled={disabled}
-          aria-label="Open MusicXML"
-          onChange={(event) => {
-            const file = event.currentTarget.files?.[0];
-            if (file) {
-              onFile(file);
-            }
-            event.currentTarget.value = "";
-          }}
-          className="hidden"
-        />
-      )}
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            title="More"
-            aria-label="More"
-            className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
-          >
-            <MoreVerticalIcon className="size-5" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          {onFile && (
-            <DropdownMenuItem
-              disabled={disabled}
-              onSelect={() => inputRef.current?.click()}
-            >
-              <FolderOpenIcon />
-              Open
-            </DropdownMenuItem>
-          )}
-          <DropdownMenuItem asChild>
-            <a href={routes.home.href()} data-testid="home-menu-item">
-              <HouseIcon />
-              Home
-            </a>
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </>
   );
 }
 

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -146,13 +146,6 @@ export function ScoreViewer({
     }
   }
 
-  function loadFile(file: File) {
-    loadMutation.mutate({
-      settings,
-      source: file,
-    });
-  }
-
   return (
     <main
       className={cn(
@@ -252,7 +245,10 @@ export function ScoreViewer({
               onChange={(event) => {
                 const file = event.currentTarget.files?.[0];
                 if (file) {
-                  loadFile(file);
+                  loadMutation.mutate({
+                    settings,
+                    source: file,
+                  });
                 }
                 event.currentTarget.value = "";
               }}
@@ -330,7 +326,12 @@ export function ScoreViewer({
               accept=".musicxml,.xml,application/vnd.recordare.musicxml+xml"
               disabled={loadMutation.isPending}
               inputProps={{ "aria-label": "Upload MusicXML" }}
-              onFile={loadFile}
+              onFile={(file) =>
+                loadMutation.mutate({
+                  settings,
+                  source: file,
+                })
+              }
               className="group h-48 w-full max-w-4xl flex-col gap-3 border border-neutral-400 bg-white text-center text-neutral-700 shadow-xs hover:border-emerald-500 hover:text-neutral-900 data-[drag-over=true]:border-emerald-600 data-[drag-over=true]:bg-emerald-100 data-[drag-over=true]:text-emerald-950"
             >
               <span className="flex size-11 items-center justify-center rounded-full border border-neutral-400 bg-white shadow-sm group-data-[drag-over=true]:border-emerald-400">

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -1,8 +1,8 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import {
-  ChevronsUpDownIcon,
   FolderOpenIcon,
   HouseIcon,
+  LibraryIcon,
   MoreVerticalIcon,
   PauseIcon,
   PlayIcon,
@@ -42,6 +42,7 @@ export function ScoreViewer({
   initialSource?: ScoreSource;
 }) {
   const runtimeRootRef = useRef<HTMLDivElement>(null);
+  const openInputRef = useRef<HTMLInputElement>(null);
 
   const [score, setScore] = useState<ScoreSource | undefined>(initialSource);
   const [settings, setSettings] = useState(INITIAL_SCORE_VIEWER_SETTINGS);
@@ -143,6 +144,13 @@ export function ScoreViewer({
     }
   }
 
+  function loadFile(file: File) {
+    loadMutation.mutate({
+      settings,
+      source: file,
+    });
+  }
+
   return (
     <main
       className={cn(
@@ -234,26 +242,29 @@ export function ScoreViewer({
           <>
             <div className="h-5 w-px bg-border" />
 
-            <FileDropInput
+            <input
+              ref={openInputRef}
+              type="file"
               accept=".musicxml,.xml,application/vnd.recordare.musicxml+xml"
               disabled={loadMutation.isPending}
-              inputProps={{ "aria-label": "Open MusicXML" }}
-              onFile={(file) =>
-                loadMutation.mutate({
-                  settings,
-                  source: file,
-                })
-              }
-              className="h-8 gap-1.5 px-3 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
-            >
-              <FolderOpenIcon className="size-4" />
-              Open
-            </FileDropInput>
+              aria-label="Open MusicXML"
+              onChange={(event) => {
+                const file = event.currentTarget.files?.[0];
+                if (file) {
+                  loadFile(file);
+                }
+                event.currentTarget.value = "";
+              }}
+              className="hidden"
+            />
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button className="h-8 gap-1.5 px-3 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50">
-                  Samples
-                  <ChevronsUpDownIcon className="size-4 opacity-50" />
+                <Button
+                  title="Samples"
+                  aria-label="Samples"
+                  className="size-8 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+                >
+                  <LibraryIcon className="size-5" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-72">
@@ -291,6 +302,15 @@ export function ScoreViewer({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
+            {!initialSource && (
+              <DropdownMenuItem
+                disabled={loadMutation.isPending}
+                onSelect={() => openInputRef.current?.click()}
+              >
+                <FolderOpenIcon />
+                Open
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem asChild>
               <a href={routes.home.href()} data-testid="home-menu-item">
                 <HouseIcon />
@@ -307,12 +327,7 @@ export function ScoreViewer({
               accept=".musicxml,.xml,application/vnd.recordare.musicxml+xml"
               disabled={loadMutation.isPending}
               inputProps={{ "aria-label": "Upload MusicXML" }}
-              onFile={(file) =>
-                loadMutation.mutate({
-                  settings,
-                  source: file,
-                })
-              }
+              onFile={loadFile}
               className="group h-48 w-full max-w-4xl flex-col gap-3 rounded-sm border border-dashed border-neutral-500 bg-neutral-200/60 text-center text-neutral-700 shadow-none hover:border-neutral-700 hover:bg-neutral-100 hover:text-neutral-900 data-[drag-over=true]:border-blue-600 data-[drag-over=true]:bg-blue-50 data-[drag-over=true]:text-blue-900"
             >
               <span className="flex size-11 items-center justify-center rounded-full border border-neutral-400 bg-white shadow-sm group-data-[drag-over=true]:border-blue-400">

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -243,36 +243,18 @@ export function ScoreViewer({
             }
           />
         )}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              title="More"
-              aria-label="More"
-              className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
-            >
-              <MoreVerticalIcon className="size-5" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {!initialSource && (
-              <OpenScoreMenuItem
-                disabled={loadMutation.isPending}
-                onFile={(file) =>
+        <ScoreMoreMenu
+          disabled={loadMutation.isPending}
+          onFile={
+            initialSource
+              ? undefined
+              : (file) =>
                   loadMutation.mutate({
                     settings,
                     source: file,
                   })
-                }
-              />
-            )}
-            <DropdownMenuItem asChild>
-              <a href={routes.home.href()} data-testid="home-menu-item">
-                <HouseIcon />
-                Home
-              </a>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+          }
+        />
       </header>
       {!score && !loadMutation.error && (
         <section className="min-h-0 flex-1 p-6">
@@ -346,9 +328,7 @@ function ScoreSamplesMenu({
         {SCORE_VIEWER_SAMPLES.map((sample) => (
           <DropdownMenuItem
             key={sample.name}
-            onSelect={() =>
-              onSelect({ name: sample.name, xml: sample.xml })
-            }
+            onSelect={() => onSelect({ name: sample.name, xml: sample.xml })}
             className="items-start"
           >
             <div>
@@ -364,39 +344,62 @@ function ScoreSamplesMenu({
   );
 }
 
-function OpenScoreMenuItem({
+function ScoreMoreMenu({
   disabled,
   onFile,
 }: {
   disabled: boolean;
-  onFile: (file: File) => void;
+  onFile?: (file: File) => void;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
 
   return (
     <>
-      <input
-        ref={inputRef}
-        type="file"
-        accept=".musicxml,.xml,application/vnd.recordare.musicxml+xml"
-        disabled={disabled}
-        aria-label="Open MusicXML"
-        onChange={(event) => {
-          const file = event.currentTarget.files?.[0];
-          if (file) {
-            onFile(file);
-          }
-          event.currentTarget.value = "";
-        }}
-        className="hidden"
-      />
-      <DropdownMenuItem
-        disabled={disabled}
-        onSelect={() => inputRef.current?.click()}
-      >
-        <FolderOpenIcon />
-        Open
-      </DropdownMenuItem>
+      {onFile && (
+        <input
+          ref={inputRef}
+          type="file"
+          accept=".musicxml,.xml,application/vnd.recordare.musicxml+xml"
+          disabled={disabled}
+          aria-label="Open MusicXML"
+          onChange={(event) => {
+            const file = event.currentTarget.files?.[0];
+            if (file) {
+              onFile(file);
+            }
+            event.currentTarget.value = "";
+          }}
+          className="hidden"
+        />
+      )}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            title="More"
+            aria-label="More"
+            className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+          >
+            <MoreVerticalIcon className="size-5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {onFile && (
+            <DropdownMenuItem
+              disabled={disabled}
+              onSelect={() => inputRef.current?.click()}
+            >
+              <FolderOpenIcon />
+              Open
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuItem asChild>
+            <a href={routes.home.href()} data-testid="home-menu-item">
+              <HouseIcon />
+              Home
+            </a>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </>
   );
 }

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -234,40 +234,14 @@ export function ScoreViewer({
         </Button>
 
         {!initialSource && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                title="Samples"
-                aria-label="Samples"
-                className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
-              >
-                <LibraryIcon className="size-5" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-72">
-              <DropdownMenuLabel>Samples</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              {SCORE_VIEWER_SAMPLES.map((sample) => (
-                <DropdownMenuItem
-                  key={sample.name}
-                  onSelect={() =>
-                    loadMutation.mutate({
-                      settings,
-                      source: { name: sample.name, xml: sample.xml },
-                    })
-                  }
-                  className="items-start"
-                >
-                  <div>
-                    <div>{sample.name}</div>
-                    <div className="text-xs text-muted-foreground">
-                      {sample.description}
-                    </div>
-                  </div>
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <ScoreSamplesMenu
+            onSelect={(source) =>
+              loadMutation.mutate({
+                settings,
+                source,
+              })
+            }
+          />
         )}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
@@ -347,6 +321,46 @@ export function ScoreViewer({
         </FloatingPanel>
       )}
     </main>
+  );
+}
+
+function ScoreSamplesMenu({
+  onSelect,
+}: {
+  onSelect: (source: ScoreSource) => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          title="Samples"
+          aria-label="Samples"
+          className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+        >
+          <LibraryIcon className="size-5" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-72">
+        <DropdownMenuLabel>Samples</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {SCORE_VIEWER_SAMPLES.map((sample) => (
+          <DropdownMenuItem
+            key={sample.name}
+            onSelect={() =>
+              onSelect({ name: sample.name, xml: sample.xml })
+            }
+            className="items-start"
+          >
+            <div>
+              <div>{sample.name}</div>
+              <div className="text-xs text-muted-foreground">
+                {sample.description}
+              </div>
+            </div>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -213,6 +213,17 @@ export function ScoreViewer({
             />
           </label>
         </div>
+
+        <div className="flex-1" />
+
+        <span
+          data-testid="score-name"
+          title={score?.name}
+          className="max-w-[220px] truncate text-sm text-neutral-300"
+        >
+          {score?.name ?? "No score loaded"}
+        </span>
+
         <div className="h-5 w-px bg-border" />
 
         <Button
@@ -230,20 +241,8 @@ export function ScoreViewer({
           <SlidersHorizontalIcon className="size-5" />
         </Button>
 
-        <div className="flex-1" />
-
-        <span
-          data-testid="score-name"
-          title={score?.name}
-          className="max-w-[220px] truncate text-sm text-neutral-300"
-        >
-          {score?.name ?? "No score loaded"}
-        </span>
-
         {!initialSource && (
           <>
-            <div className="h-5 w-px bg-border" />
-
             <input
               ref={openInputRef}
               type="file"

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -44,7 +44,6 @@ export function ScoreViewer({
   initialSource?: ScoreSource;
 }) {
   const runtimeRootRef = useRef<HTMLDivElement>(null);
-  const openInputRef = useRef<HTMLInputElement>(null);
 
   const [score, setScore] = useState<ScoreSource | undefined>(initialSource);
   const [settings, setSettings] = useState(INITIAL_SCORE_VIEWER_SETTINGS);
@@ -235,60 +234,40 @@ export function ScoreViewer({
         </Button>
 
         {!initialSource && (
-          <>
-            <input
-              ref={openInputRef}
-              type="file"
-              accept=".musicxml,.xml,application/vnd.recordare.musicxml+xml"
-              disabled={loadMutation.isPending}
-              aria-label="Open MusicXML"
-              onChange={(event) => {
-                const file = event.currentTarget.files?.[0];
-                if (file) {
-                  loadMutation.mutate({
-                    settings,
-                    source: file,
-                  });
-                }
-                event.currentTarget.value = "";
-              }}
-              className="hidden"
-            />
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  title="Samples"
-                  aria-label="Samples"
-                  className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                title="Samples"
+                aria-label="Samples"
+                className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+              >
+                <LibraryIcon className="size-5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-72">
+              <DropdownMenuLabel>Samples</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              {SCORE_VIEWER_SAMPLES.map((sample) => (
+                <DropdownMenuItem
+                  key={sample.name}
+                  onSelect={() =>
+                    loadMutation.mutate({
+                      settings,
+                      source: { name: sample.name, xml: sample.xml },
+                    })
+                  }
+                  className="items-start"
                 >
-                  <LibraryIcon className="size-5" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-72">
-                <DropdownMenuLabel>Samples</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                {SCORE_VIEWER_SAMPLES.map((sample) => (
-                  <DropdownMenuItem
-                    key={sample.name}
-                    onSelect={() =>
-                      loadMutation.mutate({
-                        settings,
-                        source: { name: sample.name, xml: sample.xml },
-                      })
-                    }
-                    className="items-start"
-                  >
-                    <div>
-                      <div>{sample.name}</div>
-                      <div className="text-xs text-muted-foreground">
-                        {sample.description}
-                      </div>
+                  <div>
+                    <div>{sample.name}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {sample.description}
                     </div>
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </>
+                  </div>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
         )}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
@@ -302,13 +281,15 @@ export function ScoreViewer({
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             {!initialSource && (
-              <DropdownMenuItem
+              <OpenScoreMenuItem
                 disabled={loadMutation.isPending}
-                onSelect={() => openInputRef.current?.click()}
-              >
-                <FolderOpenIcon />
-                Open
-              </DropdownMenuItem>
+                onFile={(file) =>
+                  loadMutation.mutate({
+                    settings,
+                    source: file,
+                  })
+                }
+              />
             )}
             <DropdownMenuItem asChild>
               <a href={routes.home.href()} data-testid="home-menu-item">
@@ -366,6 +347,43 @@ export function ScoreViewer({
         </FloatingPanel>
       )}
     </main>
+  );
+}
+
+function OpenScoreMenuItem({
+  disabled,
+  onFile,
+}: {
+  disabled: boolean;
+  onFile: (file: File) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".musicxml,.xml,application/vnd.recordare.musicxml+xml"
+        disabled={disabled}
+        aria-label="Open MusicXML"
+        onChange={(event) => {
+          const file = event.currentTarget.files?.[0];
+          if (file) {
+            onFile(file);
+          }
+          event.currentTarget.value = "";
+        }}
+        className="hidden"
+      />
+      <DropdownMenuItem
+        disabled={disabled}
+        onSelect={() => inputRef.current?.click()}
+      >
+        <FolderOpenIcon />
+        Open
+      </DropdownMenuItem>
+    </>
   );
 }
 

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -31,6 +31,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
 import { FloatingPanel } from "./ui/floating-panel";
@@ -268,6 +270,8 @@ export function ScoreViewer({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-72">
+                <DropdownMenuLabel>Samples</DropdownMenuLabel>
+                <DropdownMenuSeparator />
                 {SCORE_VIEWER_SAMPLES.map((sample) => (
                   <DropdownMenuItem
                     key={sample.name}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -56,6 +56,32 @@ export function DropdownMenuItem({
   );
 }
 
+export function DropdownMenuLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label>) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      className={cn("px-2 py-1.5 text-sm font-medium", className)}
+      {...props}
+    />
+  );
+}
+
+export function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
 export function DropdownMenuRadioGroup({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {


### PR DESCRIPTION
The standalone Score Viewer gives Open and Samples equal text-button weight even though opening another file is secondary and Samples only needs compact access.

This PR moves Open into the More menu and replaces the Samples text trigger with an accessible library icon button. The samples menu keeps its context with a visible group label, while the empty drop region remains the primary way to open the first score.