### PR TITLE
feat: add recorder audio track composition

### DIFF
--- a/src/components/recorder.tsx
+++ b/src/components/recorder.tsx
@@ -8,6 +8,8 @@ import {
   MoreVerticalIcon,
   PauseIcon,
   PlayIcon,
+  PlusIcon,
+  Trash2Icon,
   ZoomInIcon,
   ZoomOutIcon,
   UploadIcon,
@@ -97,8 +99,9 @@ export function Recorder() {
     mutationFn: (nextDeviceId: string) =>
       runtime.startInput({ deviceId: nextDeviceId, onLevel: setInputPeak }),
   });
-  const backingMutation = useMutation({
-    mutationFn: (file: File) => runtime.setAudioTrack(0, file),
+  const audioTrackMutation = useMutation({
+    mutationFn: ({ file, id }: { file: File; id: string }) =>
+      runtime.setAudioTrack(id, file),
   });
   const playMutation = useMutation({ mutationFn: () => runtime.play() });
   const recordMutation = useMutation({
@@ -163,7 +166,6 @@ export function Recorder() {
   const hasAccess = devices.some((device) => device.label);
   const selectedDevice = devices.find((device) => device.deviceId === deviceId);
   const inputActive = state.inputSettings !== undefined;
-  const backingTrack = state.audioTracks[0];
   const take = state.recordingTrack.takes[0];
   const timelineWidth = Math.max(0, timelineViewportWidth - 216);
   const playheadX =
@@ -175,7 +177,7 @@ export function Recorder() {
     grantAccessMutation.error ??
     refreshInputsMutation.error ??
     startInputMutation.error ??
-    backingMutation.error ??
+    audioTrackMutation.error ??
     playMutation.error ??
     recordMutation.error;
 
@@ -252,58 +254,75 @@ export function Recorder() {
               scrollX={scrollX}
               tempo={tempo}
               timelineWidth={timelineWidth}
+              onAddAudioTrack={() => runtime.addAudioTrack()}
               onSeek={(position) => runtime.seek(position)}
             />
-            <TrackRow
-              title="Audio 1"
-              subtitle={backingTrack?.name ?? "No file loaded"}
-              gain={backingTrack?.gain ?? 1}
-              muted={backingTrack?.muted ?? false}
-              soloed={backingTrack?.soloed ?? false}
-              onGainChange={(gain) => runtime.setAudioTrackMix(0, { gain })}
-              onMutedChange={(muted) => runtime.setAudioTrackMix(0, { muted })}
-              onSoloedChange={(soloed) =>
-                runtime.setAudioTrackMix(0, { soloed })
-              }
-              action={
-                <label
-                  title="Load audio track"
-                  className="grid size-7 cursor-pointer place-items-center rounded border border-neutral-600 text-neutral-300 hover:bg-neutral-700"
-                >
-                  <UploadIcon className="size-3.5" />
-                  <input
-                    type="file"
-                    accept="audio/*,.wav"
-                    className="hidden"
-                    onChange={(event) => {
-                      const file = event.currentTarget.files?.[0];
-                      if (file) {
-                        backingMutation.mutate(file);
-                      }
-                      event.currentTarget.value = "";
-                    }}
-                  />
-                </label>
-              }
-            >
-              <TimelineLane
-                clip={
-                  backingTrack?.name
-                    ? {
-                        duration: backingTrack.duration,
-                        label: backingTrack.name,
-                        offset: backingTrack.timelineOffset,
-                        variant: "audio",
-                      }
-                    : undefined
+            {state.audioTracks.map((track, index) => (
+              <TrackRow
+                key={track.id}
+                title={`Audio ${index + 1}`}
+                subtitle={track.name ?? "No file loaded"}
+                gain={track.gain}
+                muted={track.muted}
+                soloed={track.soloed}
+                onGainChange={(gain) =>
+                  runtime.setAudioTrackMix(track.id, { gain })
                 }
-                pixelsPerBeat={pixelsPerBeat}
-                scrollX={scrollX}
-                tempo={tempo}
-                emptyLabel="Load an audio file"
-                onSeek={(position) => runtime.seek(position)}
-              />
-            </TrackRow>
+                onMutedChange={(muted) =>
+                  runtime.setAudioTrackMix(track.id, { muted })
+                }
+                onSoloedChange={(soloed) =>
+                  runtime.setAudioTrackMix(track.id, { soloed })
+                }
+                action={
+                  <div className="flex gap-1">
+                    <label
+                      title={`Load Audio ${index + 1}`}
+                      className="grid size-7 cursor-pointer place-items-center rounded border border-neutral-600 text-neutral-300 hover:bg-neutral-700"
+                    >
+                      <UploadIcon className="size-3.5" />
+                      <input
+                        type="file"
+                        accept="audio/*,.wav"
+                        className="hidden"
+                        onChange={(event) => {
+                          const file = event.currentTarget.files?.[0];
+                          if (file) {
+                            audioTrackMutation.mutate({ file, id: track.id });
+                          }
+                          event.currentTarget.value = "";
+                        }}
+                      />
+                    </label>
+                    <Button
+                      onClick={() => runtime.removeAudioTrack(track.id)}
+                      className="size-7 border-neutral-600 text-neutral-300 hover:bg-neutral-700"
+                      title={`Remove Audio ${index + 1}`}
+                    >
+                      <Trash2Icon className="size-3.5" />
+                    </Button>
+                  </div>
+                }
+              >
+                <TimelineLane
+                  clip={
+                    track.name
+                      ? {
+                          duration: track.duration,
+                          label: track.name,
+                          offset: track.timelineOffset,
+                          variant: "audio",
+                        }
+                      : undefined
+                  }
+                  pixelsPerBeat={pixelsPerBeat}
+                  scrollX={scrollX}
+                  tempo={tempo}
+                  emptyLabel="Load an audio file"
+                  onSeek={(position) => runtime.seek(position)}
+                />
+              </TrackRow>
+            ))}
 
             <TrackRow
               title="Capture"
@@ -542,18 +561,27 @@ function TimelineHeader({
   scrollX,
   tempo,
   timelineWidth,
+  onAddAudioTrack,
   onSeek,
 }: {
   pixelsPerBeat: number;
   scrollX: number;
   tempo: number;
   timelineWidth: number;
+  onAddAudioTrack: () => void;
   onSeek: (position: number) => void;
 }) {
   return (
     <div className="sticky top-0 z-10 grid h-10 grid-cols-[13.5rem_1fr] border-b border-neutral-700 bg-neutral-800">
-      <div className="sticky left-0 z-20 flex items-center border-r border-neutral-700 bg-neutral-800 px-3 text-xs font-semibold">
-        Tracks
+      <div className="sticky left-0 z-20 flex items-center justify-between border-r border-neutral-700 bg-neutral-800 px-3 text-xs font-semibold">
+        <span>Tracks</span>
+        <Button
+          onClick={onAddAudioTrack}
+          className="h-7 gap-1 px-2 text-[11px] hover:bg-neutral-700"
+        >
+          <PlusIcon className="size-3.5" />
+          Audio track
+        </Button>
       </div>
       <TimelineRuler
         pixelsPerBeat={pixelsPerBeat}

--- a/src/components/recorder.tsx
+++ b/src/components/recorder.tsx
@@ -41,6 +41,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
@@ -255,6 +256,10 @@ export function Recorder() {
               tempo={tempo}
               timelineWidth={timelineWidth}
               onAddAudioTrack={() => runtime.addAudioTrack()}
+              onAddAudioFile={(file) => {
+                const id = runtime.addAudioTrack();
+                audioTrackMutation.mutate({ file, id });
+              }}
               onSeek={(position) => runtime.seek(position)}
             />
             {state.audioTracks.map((track, index) => (
@@ -275,33 +280,13 @@ export function Recorder() {
                   runtime.setAudioTrackMix(track.id, { soloed })
                 }
                 action={
-                  <div className="flex gap-1">
-                    <label
-                      title={`Load Audio ${index + 1}`}
-                      className="grid size-7 cursor-pointer place-items-center rounded border border-neutral-600 text-neutral-300 hover:bg-neutral-700"
-                    >
-                      <UploadIcon className="size-3.5" />
-                      <input
-                        type="file"
-                        accept="audio/*,.wav"
-                        className="hidden"
-                        onChange={(event) => {
-                          const file = event.currentTarget.files?.[0];
-                          if (file) {
-                            audioTrackMutation.mutate({ file, id: track.id });
-                          }
-                          event.currentTarget.value = "";
-                        }}
-                      />
-                    </label>
-                    <Button
-                      onClick={() => runtime.removeAudioTrack(track.id)}
-                      className="size-7 border-neutral-600 text-neutral-300 hover:bg-neutral-700"
-                      title={`Remove Audio ${index + 1}`}
-                    >
-                      <Trash2Icon className="size-3.5" />
-                    </Button>
-                  </div>
+                  <AudioTrackActions
+                    label={`Audio ${index + 1}`}
+                    onFileChange={(file) =>
+                      audioTrackMutation.mutate({ file, id: track.id })
+                    }
+                    onRemove={() => runtime.removeAudioTrack(track.id)}
+                  />
                 }
               >
                 <TimelineLane
@@ -562,6 +547,7 @@ function TimelineHeader({
   tempo,
   timelineWidth,
   onAddAudioTrack,
+  onAddAudioFile,
   onSeek,
 }: {
   pixelsPerBeat: number;
@@ -569,19 +555,39 @@ function TimelineHeader({
   tempo: number;
   timelineWidth: number;
   onAddAudioTrack: () => void;
+  onAddAudioFile: (file: File) => void;
   onSeek: (position: number) => void;
 }) {
   return (
     <div className="sticky top-0 z-10 grid h-10 grid-cols-[13.5rem_1fr] border-b border-neutral-700 bg-neutral-800">
-      <div className="sticky left-0 z-20 flex items-center justify-between border-r border-neutral-700 bg-neutral-800 px-3 text-xs font-semibold">
+      <div className="sticky left-0 z-20 flex items-center border-r border-neutral-700 bg-neutral-800 px-3 text-xs font-semibold">
         <span>Tracks</span>
+        <div className="flex-1" />
         <Button
           onClick={onAddAudioTrack}
-          className="h-7 gap-1 px-2 text-[11px] hover:bg-neutral-700"
+          className="size-7 hover:bg-neutral-700"
+          title="Add empty audio track"
         >
           <PlusIcon className="size-3.5" />
-          Audio track
         </Button>
+        <label
+          title="Add audio track from file"
+          className="grid size-7 cursor-pointer place-items-center rounded text-neutral-300 hover:bg-neutral-700"
+        >
+          <UploadIcon className="size-3.5" />
+          <input
+            type="file"
+            accept="audio/*,.wav"
+            className="hidden"
+            onChange={(event) => {
+              const file = event.currentTarget.files?.[0];
+              if (file) {
+                onAddAudioFile(file);
+              }
+              event.currentTarget.value = "";
+            }}
+          />
+        </label>
       </div>
       <TimelineRuler
         pixelsPerBeat={pixelsPerBeat}
@@ -591,6 +597,56 @@ function TimelineHeader({
         onSeek={onSeek}
       />
     </div>
+  );
+}
+
+function AudioTrackActions({
+  label,
+  onFileChange,
+  onRemove,
+}: {
+  label: string;
+  onFileChange: (file: File) => void;
+  onRemove: () => void;
+}) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            className="size-7 border-neutral-600 text-neutral-300 hover:bg-neutral-700"
+            title={`${label} actions`}
+          >
+            <MoreVerticalIcon className="size-3.5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={() => fileInputRef.current?.click()}>
+            <UploadIcon />
+            Replace audio
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={onRemove} className="text-red-400">
+            <Trash2Icon />
+            Remove track
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="audio/*,.wav"
+        className="hidden"
+        onChange={(event) => {
+          const file = event.currentTarget.files?.[0];
+          if (file) {
+            onFileChange(file);
+          }
+          event.currentTarget.value = "";
+        }}
+      />
+    </>
   );
 }
 

--- a/src/components/recorder.tsx
+++ b/src/components/recorder.tsx
@@ -558,6 +558,7 @@ function TimelineHeader({
   onAddAudioFile: (file: File) => void;
   onSeek: (position: number) => void;
 }) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
   return (
     <div className="sticky top-0 z-10 grid h-10 grid-cols-[13.5rem_1fr] border-b border-neutral-700 bg-neutral-800">
       <div className="sticky left-0 z-20 flex items-center border-r border-neutral-700 bg-neutral-800 px-3 text-xs font-semibold">
@@ -570,24 +571,26 @@ function TimelineHeader({
         >
           <PlusIcon className="size-3.5" />
         </Button>
-        <label
+        <Button
+          onClick={() => fileInputRef.current?.click()}
           title="Add audio track from file"
-          className="grid size-7 cursor-pointer place-items-center rounded text-neutral-300 hover:bg-neutral-700"
+          className="size-7 hover:bg-neutral-700"
         >
           <UploadIcon className="size-3.5" />
-          <input
-            type="file"
-            accept="audio/*,.wav"
-            className="hidden"
-            onChange={(event) => {
-              const file = event.currentTarget.files?.[0];
-              if (file) {
-                onAddAudioFile(file);
-              }
-              event.currentTarget.value = "";
-            }}
-          />
-        </label>
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="audio/*,.wav"
+          className="hidden"
+          onChange={(event) => {
+            const file = event.currentTarget.files?.[0];
+            if (file) {
+              onAddAudioFile(file);
+            }
+            event.currentTarget.value = "";
+          }}
+        />
       </div>
       <TimelineRuler
         pixelsPerBeat={pixelsPerBeat}

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -10,6 +10,7 @@ const MAX_RECORDING_SECONDS = 5 * 60;
 type RecorderStatus = "idle" | "ready" | "recording" | "processing";
 
 interface AudioTrackState {
+  id: string;
   name?: string;
   duration: number;
   gain: number;
@@ -61,7 +62,7 @@ export class RecorderRuntime {
   private context?: AudioContext;
   private clock?: AudioContextTimelineClock;
   private captureInput?: CaptureInput;
-  private audioTrackPlaybacks: AudioBufferPlayback[] = [];
+  private audioTrackPlaybacks = new Map<string, AudioBufferPlayback>();
   private recordingTrackPlayback?: AudioBufferPlayback;
   private activeRecording?: ActiveRecording;
 
@@ -156,13 +157,23 @@ export class RecorderRuntime {
     this.store.update({ selectedChannel: channel });
   }
 
-  async setAudioTrack(index: number, file: File): Promise<void> {
+  addAudioTrack(): void {
+    const track = createAudioTrackState();
+    this.store.update({
+      audioTracks: [...this.store.get().audioTracks, track],
+    });
+  }
+
+  async setAudioTrack(id: string, file: File): Promise<void> {
     const context = this.getContext();
     const buffer = await context.decodeAudioData(await file.arrayBuffer());
-    const playback = this.getAudioTrackPlayback(index);
+    if (!this.store.get().audioTracks.some((track) => track.id === id)) {
+      return;
+    }
+    const playback = this.getAudioTrackPlayback(id);
     playback.stop();
     playback.setBuffer(buffer);
-    this.updateAudioTrack(index, (track) => ({
+    this.updateAudioTrack(id, (track) => ({
       ...track,
       name: file.name,
       duration: buffer.duration,
@@ -170,38 +181,40 @@ export class RecorderRuntime {
   }
 
   setAudioTrackMix(
-    index: number,
+    id: string,
     update: Partial<Pick<AudioTrackState, "gain" | "muted" | "soloed">>,
   ): void {
-    this.getAudioTrackPlayback(index);
-    this.updateAudioTrack(index, (track) => {
+    this.updateAudioTrack(id, (track) => {
       return { ...track, ...update };
     });
     this.syncTrackMix();
   }
 
-  setAudioTrackOffset(index: number, timelineOffset: number): void {
-    this.getAudioTrackPlayback(index).setTimelineOffset(timelineOffset);
-    this.updateAudioTrack(index, (track) => ({
+  setAudioTrackOffset(id: string, timelineOffset: number): void {
+    this.getAudioTrackPlayback(id).setTimelineOffset(timelineOffset);
+    this.updateAudioTrack(id, (track) => ({
       ...track,
       timelineOffset,
     }));
   }
 
-  removeAudioTrack(index: number): void {
-    this.audioTrackPlaybacks[index]?.stop();
-    this.audioTrackPlaybacks.splice(index, 1);
-    const tracks = this.store.get().audioTracks.slice();
-    tracks.splice(index, 1);
-    this.store.update({ audioTracks: tracks });
+  removeAudioTrack(id: string): void {
+    this.audioTrackPlaybacks.get(id)?.stop();
+    this.audioTrackPlaybacks.delete(id);
+    this.store.update({
+      audioTracks: this.store
+        .get()
+        .audioTracks.filter((track) => track.id !== id),
+    });
     this.syncTrackMix();
   }
 
   private updateAudioTrack(
-    index: number,
+    id: string,
     update: (track: AudioTrackState) => AudioTrackState,
   ): void {
     const audioTracks = this.store.get().audioTracks.slice();
+    const index = audioTracks.findIndex((track) => track.id === id);
     const track = audioTracks[index];
     if (!track) {
       throw new Error("Audio track state is missing.");
@@ -210,20 +223,22 @@ export class RecorderRuntime {
     this.store.update({ audioTracks });
   }
 
-  private getAudioTrackPlayback(index: number): AudioBufferPlayback {
-    let playback = this.audioTrackPlaybacks[index];
+  private getAudioTrackPlayback(id: string): AudioBufferPlayback {
+    let playback = this.audioTrackPlaybacks.get(id);
     if (!playback) {
       const context = this.getContext();
       playback = new AudioBufferPlayback({
         context,
         output: context.destination,
       });
-      const track = createAudioTrackState();
+      const track = this.store
+        .get()
+        .audioTracks.find((entry) => entry.id === id);
+      if (!track) {
+        throw new Error("Audio track state is missing.");
+      }
       playback.setTimelineOffset(track.timelineOffset);
-      this.audioTrackPlaybacks[index] = playback;
-      const audioTracks = this.store.get().audioTracks.slice();
-      audioTracks[index] = track;
-      this.store.update({ audioTracks });
+      this.audioTrackPlaybacks.set(id, playback);
       this.syncTrackMix();
     }
     return playback;
@@ -246,7 +261,7 @@ export class RecorderRuntime {
     // Give every source a shared future AudioContext anchor. Their relative
     // placement is then determined only by timeline offsets.
     const startTime = context.currentTime + PLAYBACK_LEAD_SECONDS;
-    for (const playback of this.audioTrackPlaybacks) {
+    for (const playback of this.audioTrackPlaybacks.values()) {
       playback.start({
         scheduledContextTime: startTime,
         playheadTime: this.store.get().position,
@@ -361,7 +376,7 @@ export class RecorderRuntime {
   }
 
   private stopPlayback(): void {
-    for (const playback of this.audioTrackPlaybacks) {
+    for (const playback of this.audioTrackPlaybacks.values()) {
       playback.stop();
     }
     this.recordingTrackPlayback?.stop();
@@ -371,10 +386,12 @@ export class RecorderRuntime {
     const { audioTracks, recordingTrack } = this.store.get();
     const anyTrackSoloed =
       recordingTrack.soloed || audioTracks.some((track) => track.soloed);
-    for (const [index, track] of audioTracks.entries()) {
-      this.audioTrackPlaybacks[index]?.setGain(
-        track.muted || (anyTrackSoloed && !track.soloed) ? 0 : track.gain,
-      );
+    for (const track of audioTracks) {
+      this.audioTrackPlaybacks
+        .get(track.id)
+        ?.setGain(
+          track.muted || (anyTrackSoloed && !track.soloed) ? 0 : track.gain,
+        );
     }
     this.recordingTrackPlayback?.setGain(
       recordingTrack.muted || (anyTrackSoloed && !recordingTrack.soloed)
@@ -438,6 +455,7 @@ export class RecorderRuntime {
 
 function createAudioTrackState(): AudioTrackState {
   return {
+    id: crypto.randomUUID(),
     duration: 0,
     gain: 1,
     muted: false,

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -157,11 +157,12 @@ export class RecorderRuntime {
     this.store.update({ selectedChannel: channel });
   }
 
-  addAudioTrack(): void {
+  addAudioTrack(): string {
     const track = createAudioTrackState();
     this.store.update({
       audioTracks: [...this.store.get().audioTracks, track],
     });
+    return track.id;
   }
 
   async setAudioTrack(id: string, file: File): Promise<void> {


### PR DESCRIPTION
- follow-up to https://github.com/hi-ogawa/toy-midi/pull/305

The recorder should start from its permanent capture track instead of implying that one backing track always exists. Audio tracks also need independent identity so removing one row does not retarget another row's playback state.

This PR adds audio tracks explicitly from the timeline header, then lets each row load or replace its file, control its mix, and remove itself. The recorder runtime owns stable track IDs and keyed playback resources so row removal also stops and releases the matching playback entry.