### PR TITLE
fix: remove ineffective MIDI dynamic import

### DIFF
--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -12,7 +12,11 @@ import { audioManager, loadAudioFile } from "../lib/audio";
 import { resolveAudioFiles } from "../lib/audio-files";
 import { buildExportFileName, downloadBlob } from "../lib/export-utils";
 import { exportMidi } from "../lib/midi-export";
-import { importMidiNotes, type MidiImportOptions } from "../lib/midi-import";
+import {
+  importMidiNotes,
+  parseMidiFile,
+  type MidiImportOptions,
+} from "../lib/midi-import";
 import { exportMusicXml } from "../lib/musicxml/render";
 import { KEY_SIGNATURE_OPTION_GROUPS } from "../lib/pitch-spelling";
 import { exportProjectFile } from "../lib/project-file";
@@ -77,9 +81,7 @@ export function Settings({
   const importMidiMutation = useMutation({
     mutationFn: async (file: File) => {
       // First parse to get available tracks
-      const parsed = await import("../lib/midi-import").then((m) =>
-        m.parseMidiFile(file),
-      );
+      const parsed = await parseMidiFile(file);
 
       // Import all tracks
       const options: MidiImportOptions = {


### PR DESCRIPTION
- follow-up to https://github.com/hi-ogawa/toy-midi/pull/313

`midi-import.ts` was imported both statically and dynamically from Settings, so the dynamic import could not create a separate chunk and Vite reported `INEFFECTIVE_DYNAMIC_IMPORT` on every production build.

This PR imports `parseMidiFile` through the existing static module edge, removing the dead async import and build warning without changing MIDI import behavior.