### PR TITLE
feat: add adaptive recorder timeline grid

### DIFF
--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -31,6 +31,10 @@ import {
   RecorderRuntimeState,
 } from "../../lib/recorder/runtime";
 import { routes } from "../../lib/routes";
+import {
+  calculateTimelineGridLayers,
+  TimelineGridLayer,
+} from "../../lib/timeline-grid";
 import { openFilePicker } from "../file-drop-input";
 import { Button } from "../ui/button";
 import {
@@ -705,15 +709,11 @@ function TimelineRuler({
   const visibleBeats = timelineWidth / pixelsPerBeat;
   const labelCount =
     Math.ceil((scrollX + visibleBeats - firstLabelBeat) / labelEveryBeats) + 1;
-  const barWidth = BEATS_PER_BAR * pixelsPerBeat;
+  const gridStyle = getTimelineGridStyle({ pixelsPerBeat, scrollX });
   return (
     <div
       className="relative cursor-pointer font-mono text-[10px] text-neutral-400"
-      style={{
-        backgroundImage: `linear-gradient(to right, rgb(82 82 82) 1px, transparent 1px)`,
-        backgroundPositionX: `${-(scrollX * pixelsPerBeat)}px`,
-        backgroundSize: `${barWidth}px 100%`,
-      }}
+      style={gridStyle}
       onPointerDown={(event) => {
         const rect = event.currentTarget.getBoundingClientRect();
         const beat = Math.max(
@@ -844,15 +844,11 @@ function TimelineLane({
     take: "border-emerald-400/60 bg-emerald-400/20 text-emerald-100",
     recording: "border-red-400/70 bg-red-400/20 text-red-100",
   }[clip?.variant ?? "audio"];
+  const gridStyle = getTimelineGridStyle({ pixelsPerBeat, scrollX });
   return (
     <div
       className="relative min-h-24 overflow-hidden bg-neutral-900"
-      style={{
-        backgroundImage:
-          "linear-gradient(to right, rgb(64 64 64) 1px, transparent 1px)",
-        backgroundPositionX: `${-(scrollX * pixelsPerBeat)}px`,
-        backgroundSize: `${BEATS_PER_BAR * pixelsPerBeat}px 100%`,
-      }}
+      style={gridStyle}
       onPointerDown={(event) => {
         const rect = event.currentTarget.getBoundingClientRect();
         const beat = Math.max(
@@ -884,6 +880,41 @@ function TimelineLane({
       )}
     </div>
   );
+}
+
+function getTimelineGridStyle({
+  pixelsPerBeat,
+  scrollX,
+}: {
+  pixelsPerBeat: number;
+  scrollX: number;
+}): React.CSSProperties {
+  const colors: Record<TimelineGridLayer["kind"], string> = {
+    bar: "rgb(82 82 82)",
+    beat: "rgb(64 64 64)",
+    subdivision: "rgb(51 51 51)",
+  };
+  const layers = calculateTimelineGridLayers({
+    beatsPerBar: BEATS_PER_BAR,
+    minimumPixelSpacing: 8,
+    pixelsPerBeat,
+    scrollBeat: scrollX,
+    subdivisionsPerBeat: 4,
+  });
+  return {
+    backgroundImage: layers
+      .map(
+        ({ kind }) =>
+          `linear-gradient(to right, ${colors[kind]} 1px, transparent 1px)`,
+      )
+      .join(", "),
+    backgroundPosition: layers
+      .map(({ offsetPixels }) => `${offsetPixels}px 0`)
+      .join(", "),
+    backgroundSize: layers
+      .map(({ spacingPixels }) => `${spacingPixels}px 100%`)
+      .join(", "),
+  };
 }
 
 function InputInspector({

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -706,11 +706,10 @@ function TimelineRuler({
   const visibleBeats = timelineWidth / pixelsPerBeat;
   const labelCount =
     Math.ceil((scrollX + visibleBeats - firstLabelBeat) / labelEveryBeats) + 1;
-  const gridStyle = getTimelineGridStyle({ pixelsPerBeat, scrollX });
   return (
     <div
       className="relative cursor-pointer font-mono text-[10px] text-neutral-400"
-      style={gridStyle}
+      style={getTimelineGridStyle({ pixelsPerBeat, scrollX })}
       onPointerDown={(event) => {
         const rect = event.currentTarget.getBoundingClientRect();
         const beat = Math.max(
@@ -841,11 +840,10 @@ function TimelineLane({
     take: "border-emerald-400/60 bg-emerald-400/20 text-emerald-100",
     recording: "border-red-400/70 bg-red-400/20 text-red-100",
   }[clip?.variant ?? "audio"];
-  const gridStyle = getTimelineGridStyle({ pixelsPerBeat, scrollX });
   return (
     <div
       className="relative min-h-24 overflow-hidden bg-neutral-900"
-      style={gridStyle}
+      style={getTimelineGridStyle({ pixelsPerBeat, scrollX })}
       onPointerDown={(event) => {
         const rect = event.currentTarget.getBoundingClientRect();
         const beat = Math.max(

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -31,10 +31,7 @@ import {
   RecorderRuntimeState,
 } from "../../lib/recorder/runtime";
 import { routes } from "../../lib/routes";
-import {
-  calculateTimelineGridLayers,
-  TimelineGridLayer,
-} from "../../lib/timeline-grid";
+import { getTimelineGridBackground } from "../../lib/timeline-grid";
 import { openFilePicker } from "../file-drop-input";
 import { Button } from "../ui/button";
 import {
@@ -889,32 +886,18 @@ function getTimelineGridStyle({
   pixelsPerBeat: number;
   scrollX: number;
 }): React.CSSProperties {
-  const colors: Record<TimelineGridLayer["kind"], string> = {
-    bar: "rgb(82 82 82)",
-    beat: "rgb(64 64 64)",
-    subdivision: "rgb(51 51 51)",
-  };
-  const layers = calculateTimelineGridLayers({
+  return getTimelineGridBackground({
     beatsPerBar: BEATS_PER_BAR,
+    colors: {
+      bar: "rgb(82 82 82)",
+      beat: "rgb(64 64 64)",
+      subdivision: "rgb(51 51 51)",
+    },
     minimumPixelSpacing: 8,
     pixelsPerBeat,
     scrollBeat: scrollX,
     subdivisionsPerBeat: 4,
   });
-  return {
-    backgroundImage: layers
-      .map(
-        ({ kind }) =>
-          `linear-gradient(to right, ${colors[kind]} 1px, transparent 1px)`,
-      )
-      .join(", "),
-    backgroundPosition: layers
-      .map(({ offsetPixels }) => `${offsetPixels}px 0`)
-      .join(", "),
-    backgroundSize: layers
-      .map(({ spacingPixels }) => `${spacingPixels}px 100%`)
-      .join(", "),
-  };
 }
 
 function InputInspector({

--- a/src/lib/timeline-grid.test.ts
+++ b/src/lib/timeline-grid.test.ts
@@ -1,54 +1,46 @@
 import { describe, expect, test } from "vitest";
-import { calculateTimelineGridLayers } from "./timeline-grid";
+import { getTimelineGridBackground } from "./timeline-grid";
 
-describe(calculateTimelineGridLayers, () => {
+const colors = {
+  bar: "bar-color",
+  beat: "beat-color",
+  subdivision: "subdivision-color",
+};
+
+describe(getTimelineGridBackground, () => {
   test("returns bar, beat, and subdivision layers when they are visible", () => {
     expect(
-      calculateTimelineGridLayers({
+      getTimelineGridBackground({
         beatsPerBar: 4,
+        colors,
         minimumPixelSpacing: 8,
         pixelsPerBeat: 80,
         scrollBeat: 1.5,
         subdivisionsPerBeat: 4,
       }),
-    ).toEqual([
-      {
-        intervalBeats: 4,
-        kind: "bar",
-        offsetPixels: -120,
-        spacingPixels: 320,
-      },
-      {
-        intervalBeats: 1,
-        kind: "beat",
-        offsetPixels: -40,
-        spacingPixels: 80,
-      },
-      {
-        intervalBeats: 0.25,
-        kind: "subdivision",
-        offsetPixels: -0,
-        spacingPixels: 20,
-      },
-    ]);
+    ).toEqual({
+      backgroundImage:
+        "linear-gradient(to right, bar-color 1px, transparent 1px), linear-gradient(to right, beat-color 1px, transparent 1px), linear-gradient(to right, subdivision-color 1px, transparent 1px)",
+      backgroundPosition: "-120px 0, -40px 0, 0px 0",
+      backgroundSize: "320px 100%, 80px 100%, 20px 100%",
+    });
   });
 
   test("hides dense layers and coarsens bars", () => {
     expect(
-      calculateTimelineGridLayers({
+      getTimelineGridBackground({
         beatsPerBar: 4,
+        colors,
         minimumPixelSpacing: 8,
         pixelsPerBeat: 1,
         scrollBeat: 5,
         subdivisionsPerBeat: 4,
       }),
-    ).toEqual([
-      {
-        intervalBeats: 8,
-        kind: "bar",
-        offsetPixels: -5,
-        spacingPixels: 8,
-      },
-    ]);
+    ).toEqual({
+      backgroundImage:
+        "linear-gradient(to right, bar-color 1px, transparent 1px)",
+      backgroundPosition: "-5px 0",
+      backgroundSize: "8px 100%",
+    });
   });
 });

--- a/src/lib/timeline-grid.test.ts
+++ b/src/lib/timeline-grid.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest";
+import { calculateTimelineGridLayers } from "./timeline-grid";
+
+describe(calculateTimelineGridLayers, () => {
+  test("returns bar, beat, and subdivision layers when they are visible", () => {
+    expect(
+      calculateTimelineGridLayers({
+        beatsPerBar: 4,
+        minimumPixelSpacing: 8,
+        pixelsPerBeat: 80,
+        scrollBeat: 1.5,
+        subdivisionsPerBeat: 4,
+      }),
+    ).toEqual([
+      {
+        intervalBeats: 4,
+        kind: "bar",
+        offsetPixels: -120,
+        spacingPixels: 320,
+      },
+      {
+        intervalBeats: 1,
+        kind: "beat",
+        offsetPixels: -40,
+        spacingPixels: 80,
+      },
+      {
+        intervalBeats: 0.25,
+        kind: "subdivision",
+        offsetPixels: -0,
+        spacingPixels: 20,
+      },
+    ]);
+  });
+
+  test("hides dense layers and coarsens bars", () => {
+    expect(
+      calculateTimelineGridLayers({
+        beatsPerBar: 4,
+        minimumPixelSpacing: 8,
+        pixelsPerBeat: 1,
+        scrollBeat: 5,
+        subdivisionsPerBeat: 4,
+      }),
+    ).toEqual([
+      {
+        intervalBeats: 8,
+        kind: "bar",
+        offsetPixels: -5,
+        spacingPixels: 8,
+      },
+    ]);
+  });
+});

--- a/src/lib/timeline-grid.ts
+++ b/src/lib/timeline-grid.ts
@@ -1,0 +1,79 @@
+export type TimelineGridLayer = {
+  intervalBeats: number;
+  kind: "bar" | "beat" | "subdivision";
+  offsetPixels: number;
+  spacingPixels: number;
+};
+
+export function calculateTimelineGridLayers({
+  beatsPerBar,
+  minimumPixelSpacing,
+  pixelsPerBeat,
+  scrollBeat,
+  subdivisionsPerBeat,
+}: {
+  beatsPerBar: number;
+  minimumPixelSpacing: number;
+  pixelsPerBeat: number;
+  scrollBeat: number;
+  subdivisionsPerBeat: number;
+}): TimelineGridLayer[] {
+  const layers: TimelineGridLayer[] = [];
+  let barInterval = beatsPerBar;
+  while (barInterval * pixelsPerBeat < minimumPixelSpacing) {
+    barInterval *= 2;
+  }
+  layers.push(
+    createLayer({
+      intervalBeats: barInterval,
+      kind: "bar",
+      pixelsPerBeat,
+      scrollBeat,
+    }),
+  );
+
+  if (pixelsPerBeat >= minimumPixelSpacing) {
+    layers.push(
+      createLayer({
+        intervalBeats: 1,
+        kind: "beat",
+        pixelsPerBeat,
+        scrollBeat,
+      }),
+    );
+  }
+
+  const subdivisionInterval = 1 / subdivisionsPerBeat;
+  if (subdivisionInterval * pixelsPerBeat >= minimumPixelSpacing) {
+    layers.push(
+      createLayer({
+        intervalBeats: subdivisionInterval,
+        kind: "subdivision",
+        pixelsPerBeat,
+        scrollBeat,
+      }),
+    );
+  }
+
+  return layers;
+}
+
+function createLayer({
+  intervalBeats,
+  kind,
+  pixelsPerBeat,
+  scrollBeat,
+}: {
+  intervalBeats: number;
+  kind: TimelineGridLayer["kind"];
+  pixelsPerBeat: number;
+  scrollBeat: number;
+}): TimelineGridLayer {
+  const spacingPixels = intervalBeats * pixelsPerBeat;
+  return {
+    intervalBeats,
+    kind,
+    offsetPixels: -(scrollBeat * pixelsPerBeat) % spacingPixels,
+    spacingPixels,
+  };
+}

--- a/src/lib/timeline-grid.ts
+++ b/src/lib/timeline-grid.ts
@@ -6,6 +6,7 @@ type TimelineGridLayer = {
   spacingPixels: number;
 };
 
+// TODO: Migrate the main editor's grid rendering to this shared utility.
 export function getTimelineGridBackground({
   beatsPerBar,
   colors,

--- a/src/lib/timeline-grid.ts
+++ b/src/lib/timeline-grid.ts
@@ -1,11 +1,54 @@
-export type TimelineGridLayer = {
-  intervalBeats: number;
-  kind: "bar" | "beat" | "subdivision";
+type TimelineGridKind = "bar" | "beat" | "subdivision";
+
+type TimelineGridLayer = {
+  kind: TimelineGridKind;
   offsetPixels: number;
   spacingPixels: number;
 };
 
-export function calculateTimelineGridLayers({
+export function getTimelineGridBackground({
+  beatsPerBar,
+  colors,
+  minimumPixelSpacing,
+  pixelsPerBeat,
+  scrollBeat,
+  subdivisionsPerBeat,
+}: {
+  beatsPerBar: number;
+  colors: Record<TimelineGridKind, string>;
+  minimumPixelSpacing: number;
+  pixelsPerBeat: number;
+  scrollBeat: number;
+  subdivisionsPerBeat: number;
+}): {
+  backgroundImage: string;
+  backgroundPosition: string;
+  backgroundSize: string;
+} {
+  const layers = calculateTimelineGridLayers({
+    beatsPerBar,
+    minimumPixelSpacing,
+    pixelsPerBeat,
+    scrollBeat,
+    subdivisionsPerBeat,
+  });
+  return {
+    backgroundImage: layers
+      .map(
+        ({ kind }) =>
+          `linear-gradient(to right, ${colors[kind]} 1px, transparent 1px)`,
+      )
+      .join(", "),
+    backgroundPosition: layers
+      .map(({ offsetPixels }) => `${offsetPixels}px 0`)
+      .join(", "),
+    backgroundSize: layers
+      .map(({ spacingPixels }) => `${spacingPixels}px 100%`)
+      .join(", "),
+  };
+}
+
+function calculateTimelineGridLayers({
   beatsPerBar,
   minimumPixelSpacing,
   pixelsPerBeat,
@@ -65,13 +108,12 @@ function createLayer({
   scrollBeat,
 }: {
   intervalBeats: number;
-  kind: TimelineGridLayer["kind"];
+  kind: TimelineGridKind;
   pixelsPerBeat: number;
   scrollBeat: number;
 }): TimelineGridLayer {
   const spacingPixels = intervalBeats * pixelsPerBeat;
   return {
-    intervalBeats,
     kind,
     offsetPixels: -(scrollBeat * pixelsPerBeat) % spacingPixels,
     spacingPixels,


### PR DESCRIPTION
The recorder timeline currently only marks bars, so zooming in gives no beat or sixteenth-note orientation while zooming far out leaves bar lines too dense.

This PR adds a rendering-independent timeline grid calculation that exposes semantic bar, beat, and subdivision layers with adaptive spacing. The recorder renders those layers as a fixed 4/4, sixteenth-note grid, hides detail below the minimum line spacing, and coarsens bars at overview zoom levels.