### PR TITLE
feat: drag recorder audio clips

### DIFF
--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -959,7 +959,7 @@ function TimelineLane({
   onSeek: (position: number) => void;
 }) {
   const [isDragging, setIsDragging] = useState(false);
-  const clipDragHandlerProps = usePointerDrag({
+  const clipDragRef = usePointerDrag({
     onStart: (event) => {
       event.preventDefault();
       event.stopPropagation();
@@ -1011,7 +1011,7 @@ function TimelineLane({
     >
       {clip ? (
         <div
-          {...(onClipOffsetChange ? clipDragHandlerProps : {})}
+          ref={onClipOffsetChange ? clipDragRef : undefined}
           className={cn(
             "absolute top-4 h-14 overflow-hidden rounded-sm border px-2 py-1.5 text-[11px]",
             clipClass,

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -246,11 +246,10 @@ export function Recorder() {
                   tempo={timeline.tempo}
                   emptyLabel="Load an audio file"
                   onClipDragStart={() => {
-                    const wasPlaying = runtime.store.get().isPlaying;
-                    if (wasPlaying) {
+                    if (state.isPlaying) {
                       runtime.pause();
                     }
-                    return wasPlaying;
+                    return state.isPlaying;
                   }}
                   onClipOffsetChange={(offset) =>
                     runtime.setAudioTrackOffset(track.id, offset)

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -33,6 +33,7 @@ import {
 } from "../../lib/recorder/runtime";
 import { routes } from "../../lib/routes";
 import { getTimelineGridBackground } from "../../lib/timeline-grid";
+import { listenPointerDrag } from "../../utils/pointer-drag";
 import { openFilePicker } from "../file-drop-input";
 import { Button } from "../ui/button";
 import {
@@ -957,13 +958,43 @@ function TimelineLane({
   subdivisionsPerBeat: number;
   onSeek: (position: number) => void;
 }) {
-  const [drag, setDrag] = useState<{
-    pointerId: number;
-    startClientX: number;
-    startOffset: number;
-    pixelsPerBeat: number;
-    tempo: number;
-  }>();
+  const [isDragging, setIsDragging] = useState(false);
+  const clipDragRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      if (!element || !clip || !onClipOffsetChange) {
+        return;
+      }
+      return listenPointerDrag({
+        element,
+        onStart: (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          setIsDragging(true);
+          return {
+            startClientX: event.clientX,
+            startOffset: clip.offset,
+            pixelsPerBeat,
+            tempo,
+          };
+        },
+        onMove: (event, drag) => {
+          const deltaBeats =
+            (event.clientX - drag.startClientX) / drag.pixelsPerBeat;
+          onClipOffsetChange(
+            Math.max(
+              0,
+              drag.startOffset + recorderBeatsToSeconds(deltaBeats, drag.tempo),
+            ),
+          );
+        },
+        onEnd: () => {
+          setIsDragging(false);
+          onClipDragEnd?.();
+        },
+      });
+    },
+    [clip, onClipDragEnd, onClipOffsetChange, pixelsPerBeat, tempo],
+  );
   const clipClass = {
     audio: "border-blue-400/60 bg-blue-400/20 text-blue-100",
     take: "border-emerald-400/60 bg-emerald-400/20 text-emerald-100",
@@ -989,11 +1020,12 @@ function TimelineLane({
     >
       {clip ? (
         <div
+          ref={clipDragRef}
           className={cn(
             "absolute top-4 h-14 overflow-hidden rounded-sm border px-2 py-1.5 text-[11px]",
             clipClass,
             onClipOffsetChange && "cursor-ew-resize select-none",
-            drag && "brightness-125",
+            isDragging && "brightness-125",
           )}
           style={{
             left:
@@ -1003,56 +1035,6 @@ function TimelineLane({
               2,
               recorderSecondsToBeats(clip.duration, tempo) * pixelsPerBeat,
             ),
-          }}
-          onPointerDown={(event) => {
-            if (event.button !== 0 || !onClipOffsetChange) {
-              return;
-            }
-            event.preventDefault();
-            event.stopPropagation();
-            event.currentTarget.setPointerCapture(event.pointerId);
-            setDrag({
-              pointerId: event.pointerId,
-              startClientX: event.clientX,
-              startOffset: clip.offset,
-              pixelsPerBeat,
-              tempo,
-            });
-          }}
-          onPointerMove={(event) => {
-            if (event.pointerId !== drag?.pointerId || !onClipOffsetChange) {
-              return;
-            }
-            const deltaBeats =
-              (event.clientX - drag.startClientX) / drag.pixelsPerBeat;
-            onClipOffsetChange(
-              Math.max(
-                0,
-                drag.startOffset +
-                  recorderBeatsToSeconds(deltaBeats, drag.tempo),
-              ),
-            );
-          }}
-          onPointerUp={(event) => {
-            if (event.pointerId !== drag?.pointerId) {
-              return;
-            }
-            onClipDragEnd?.();
-            setDrag(undefined);
-          }}
-          onPointerCancel={(event) => {
-            if (event.pointerId !== drag?.pointerId) {
-              return;
-            }
-            onClipDragEnd?.();
-            setDrag(undefined);
-          }}
-          onLostPointerCapture={(event) => {
-            if (event.pointerId !== drag?.pointerId) {
-              return;
-            }
-            onClipDragEnd?.();
-            setDrag(undefined);
           }}
         >
           <span className="truncate">{clip.label}</span>

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1056,6 +1056,11 @@ function TimelineLane({
           }}
         >
           <span className="truncate">{clip.label}</span>
+          {onClipOffsetChange && clip.offset > 0 && (
+            <span className="ml-1.5 opacity-75">
+              +{clip.offset.toFixed(3)}s
+            </span>
+          )}
         </div>
       ) : (
         <div className="absolute inset-0 grid place-items-center text-xs text-neutral-600">

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -14,14 +14,9 @@ import {
   Trash2Icon,
   UploadIcon,
 } from "lucide-react";
-import {
-  useCallback,
-  useEffect,
-  useEffectEvent,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import { useDraftInput } from "../../hooks/use-draft-input";
+import { usePointerDrag } from "../../hooks/use-pointer-drag";
 import { useWindowEvent } from "../../hooks/use-window-event";
 import { resolveAudioFiles } from "../../lib/audio-files";
 import {
@@ -39,7 +34,6 @@ import {
 } from "../../lib/recorder/runtime";
 import { routes } from "../../lib/routes";
 import { getTimelineGridBackground } from "../../lib/timeline-grid";
-import { listenPointerDrag } from "../../utils/pointer-drag";
 import { openFilePicker } from "../file-drop-input";
 import { Button } from "../ui/button";
 import {
@@ -965,41 +959,33 @@ function TimelineLane({
   onSeek: (position: number) => void;
 }) {
   const [isDragging, setIsDragging] = useState(false);
-  const setupClipDrag = useEffectEvent((element: HTMLDivElement) =>
-    listenPointerDrag({
-      element,
-      onStart: (event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        setIsDragging(true);
-        return {
-          startClientX: event.clientX,
-          startOffset: clip!.offset,
-          pixelsPerBeat,
-          tempo,
-        };
-      },
-      onMove: (event, drag) => {
-        const deltaBeats =
-          (event.clientX - drag.startClientX) / drag.pixelsPerBeat;
-        onClipOffsetChange!(
-          Math.max(
-            0,
-            drag.startOffset + recorderBeatsToSeconds(deltaBeats, drag.tempo),
-          ),
-        );
-      },
-      onEnd: () => {
-        setIsDragging(false);
-        onClipDragEnd?.();
-      },
-    }),
-  );
-  const clipDragRef = useCallback((element: HTMLDivElement | null) => {
-    if (element) {
-      return setupClipDrag(element);
-    }
-  }, []);
+  const clipDragHandlerProps = usePointerDrag({
+    onStart: (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setIsDragging(true);
+      return {
+        startClientX: event.clientX,
+        startOffset: clip!.offset,
+        pixelsPerBeat,
+        tempo,
+      };
+    },
+    onMove: (event, drag) => {
+      const deltaBeats =
+        (event.clientX - drag.startClientX) / drag.pixelsPerBeat;
+      onClipOffsetChange!(
+        Math.max(
+          0,
+          drag.startOffset + recorderBeatsToSeconds(deltaBeats, drag.tempo),
+        ),
+      );
+    },
+    onEnd: () => {
+      setIsDragging(false);
+      onClipDragEnd?.();
+    },
+  });
   const clipClass = {
     audio: "border-blue-400/60 bg-blue-400/20 text-blue-100",
     take: "border-emerald-400/60 bg-emerald-400/20 text-emerald-100",
@@ -1025,7 +1011,7 @@ function TimelineLane({
     >
       {clip ? (
         <div
-          ref={clipDragRef}
+          {...(onClipOffsetChange ? clipDragHandlerProps : {})}
           className={cn(
             "absolute top-4 h-14 overflow-hidden rounded-sm border px-2 py-1.5 text-[11px]",
             clipClass,

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -225,6 +225,21 @@ export function Recorder() {
                   scrollX={timeline.scrollX}
                   tempo={timeline.tempo}
                   emptyLabel="Load an audio file"
+                  onClipDragStart={() => {
+                    const wasPlaying = runtime.store.get().isPlaying;
+                    if (wasPlaying) {
+                      runtime.pause();
+                    }
+                    return wasPlaying;
+                  }}
+                  onClipOffsetChange={(offset) =>
+                    runtime.setAudioTrackOffset(track.id, offset)
+                  }
+                  onClipDragEnd={(resumePlayback) => {
+                    if (resumePlayback) {
+                      playMutation.mutate();
+                    }
+                  }}
                   onSeek={(position) => runtime.seek(position)}
                 />
               </TrackRow>
@@ -825,6 +840,9 @@ function TimelineLane({
   pixelsPerBeat,
   scrollX,
   tempo,
+  onClipDragStart,
+  onClipOffsetChange,
+  onClipDragEnd,
   onSeek,
 }: {
   clip?: {
@@ -837,8 +855,19 @@ function TimelineLane({
   pixelsPerBeat: number;
   scrollX: number;
   tempo: number;
+  onClipDragStart?: () => boolean;
+  onClipOffsetChange?: (offset: number) => void;
+  onClipDragEnd?: (resumePlayback: boolean) => void;
   onSeek: (position: number) => void;
 }) {
+  const [drag, setDrag] = useState<{
+    pointerId: number;
+    startClientX: number;
+    startOffset: number;
+    pixelsPerBeat: number;
+    tempo: number;
+    resumePlayback: boolean;
+  }>();
   const clipClass = {
     audio: "border-blue-400/60 bg-blue-400/20 text-blue-100",
     take: "border-emerald-400/60 bg-emerald-400/20 text-emerald-100",
@@ -864,7 +893,12 @@ function TimelineLane({
     >
       {clip ? (
         <div
-          className={`absolute top-4 h-14 overflow-hidden rounded-sm border px-2 py-1.5 text-[11px] ${clipClass}`}
+          className={cn(
+            "absolute top-4 h-14 overflow-hidden rounded-sm border px-2 py-1.5 text-[11px]",
+            clipClass,
+            onClipOffsetChange && "cursor-ew-resize select-none",
+            drag && "brightness-125",
+          )}
           style={{
             left:
               (recorderSecondsToBeats(clip.offset, tempo) - scrollX) *
@@ -873,6 +907,57 @@ function TimelineLane({
               2,
               recorderSecondsToBeats(clip.duration, tempo) * pixelsPerBeat,
             ),
+          }}
+          onPointerDown={(event) => {
+            if (event.button !== 0 || !onClipOffsetChange) {
+              return;
+            }
+            event.preventDefault();
+            event.stopPropagation();
+            event.currentTarget.setPointerCapture(event.pointerId);
+            setDrag({
+              pointerId: event.pointerId,
+              startClientX: event.clientX,
+              startOffset: clip.offset,
+              pixelsPerBeat,
+              tempo,
+              resumePlayback: onClipDragStart?.() ?? false,
+            });
+          }}
+          onPointerMove={(event) => {
+            if (event.pointerId !== drag?.pointerId || !onClipOffsetChange) {
+              return;
+            }
+            const deltaBeats =
+              (event.clientX - drag.startClientX) / drag.pixelsPerBeat;
+            onClipOffsetChange(
+              Math.max(
+                0,
+                drag.startOffset +
+                  recorderBeatsToSeconds(deltaBeats, drag.tempo),
+              ),
+            );
+          }}
+          onPointerUp={(event) => {
+            if (event.pointerId !== drag?.pointerId) {
+              return;
+            }
+            onClipDragEnd?.(drag.resumePlayback);
+            setDrag(undefined);
+          }}
+          onPointerCancel={(event) => {
+            if (event.pointerId !== drag?.pointerId) {
+              return;
+            }
+            onClipDragEnd?.(drag.resumePlayback);
+            setDrag(undefined);
+          }}
+          onLostPointerCapture={(event) => {
+            if (event.pointerId !== drag?.pointerId) {
+              return;
+            }
+            onClipDragEnd?.(drag.resumePlayback);
+            setDrag(undefined);
           }}
         >
           <span className="truncate">{clip.label}</span>

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -14,7 +14,13 @@ import {
   Trash2Icon,
   UploadIcon,
 } from "lucide-react";
-import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
+import {
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { useDraftInput } from "../../hooks/use-draft-input";
 import { useWindowEvent } from "../../hooks/use-window-event";
 import { resolveAudioFiles } from "../../lib/audio-files";
@@ -959,42 +965,41 @@ function TimelineLane({
   onSeek: (position: number) => void;
 }) {
   const [isDragging, setIsDragging] = useState(false);
-  const clipDragRef = useCallback(
-    (element: HTMLDivElement | null) => {
-      if (!element || !clip || !onClipOffsetChange) {
-        return;
-      }
-      return listenPointerDrag({
-        element,
-        onStart: (event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          setIsDragging(true);
-          return {
-            startClientX: event.clientX,
-            startOffset: clip.offset,
-            pixelsPerBeat,
-            tempo,
-          };
-        },
-        onMove: (event, drag) => {
-          const deltaBeats =
-            (event.clientX - drag.startClientX) / drag.pixelsPerBeat;
-          onClipOffsetChange(
-            Math.max(
-              0,
-              drag.startOffset + recorderBeatsToSeconds(deltaBeats, drag.tempo),
-            ),
-          );
-        },
-        onEnd: () => {
-          setIsDragging(false);
-          onClipDragEnd?.();
-        },
-      });
-    },
-    [clip, onClipDragEnd, onClipOffsetChange, pixelsPerBeat, tempo],
+  const setupClipDrag = useEffectEvent((element: HTMLDivElement) =>
+    listenPointerDrag({
+      element,
+      onStart: (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        setIsDragging(true);
+        return {
+          startClientX: event.clientX,
+          startOffset: clip!.offset,
+          pixelsPerBeat,
+          tempo,
+        };
+      },
+      onMove: (event, drag) => {
+        const deltaBeats =
+          (event.clientX - drag.startClientX) / drag.pixelsPerBeat;
+        onClipOffsetChange!(
+          Math.max(
+            0,
+            drag.startOffset + recorderBeatsToSeconds(deltaBeats, drag.tempo),
+          ),
+        );
+      },
+      onEnd: () => {
+        setIsDragging(false);
+        onClipDragEnd?.();
+      },
+    }),
   );
+  const clipDragRef = useCallback((element: HTMLDivElement | null) => {
+    if (element) {
+      return setupClipDrag(element);
+    }
+  }, []);
   const clipClass = {
     audio: "border-blue-400/60 bg-blue-400/20 text-blue-100",
     take: "border-emerald-400/60 bg-emerald-400/20 text-emerald-100",

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -245,17 +245,12 @@ export function Recorder() {
                   scrollX={timeline.scrollX}
                   tempo={timeline.tempo}
                   emptyLabel="Load an audio file"
-                  onClipDragStart={() => {
-                    if (state.isPlaying) {
-                      runtime.pause();
-                    }
-                    return state.isPlaying;
-                  }}
                   onClipOffsetChange={(offset) =>
                     runtime.setAudioTrackOffset(track.id, offset)
                   }
-                  onClipDragEnd={(resumePlayback) => {
-                    if (resumePlayback) {
+                  onClipDragEnd={() => {
+                    if (state.isPlaying) {
+                      runtime.pause();
                       playMutation.mutate();
                     }
                   }}
@@ -941,7 +936,6 @@ function TimelineLane({
   pixelsPerBeat,
   scrollX,
   tempo,
-  onClipDragStart,
   onClipOffsetChange,
   onClipDragEnd,
   subdivisionsPerBeat,
@@ -958,9 +952,8 @@ function TimelineLane({
   pixelsPerBeat: number;
   scrollX: number;
   tempo: number;
-  onClipDragStart?: () => boolean;
   onClipOffsetChange?: (offset: number) => void;
-  onClipDragEnd?: (resumePlayback: boolean) => void;
+  onClipDragEnd?: () => void;
   subdivisionsPerBeat: number;
   onSeek: (position: number) => void;
 }) {
@@ -970,7 +963,6 @@ function TimelineLane({
     startOffset: number;
     pixelsPerBeat: number;
     tempo: number;
-    resumePlayback: boolean;
   }>();
   const clipClass = {
     audio: "border-blue-400/60 bg-blue-400/20 text-blue-100",
@@ -1025,7 +1017,6 @@ function TimelineLane({
               startOffset: clip.offset,
               pixelsPerBeat,
               tempo,
-              resumePlayback: onClipDragStart?.() ?? false,
             });
           }}
           onPointerMove={(event) => {
@@ -1046,21 +1037,21 @@ function TimelineLane({
             if (event.pointerId !== drag?.pointerId) {
               return;
             }
-            onClipDragEnd?.(drag.resumePlayback);
+            onClipDragEnd?.();
             setDrag(undefined);
           }}
           onPointerCancel={(event) => {
             if (event.pointerId !== drag?.pointerId) {
               return;
             }
-            onClipDragEnd?.(drag.resumePlayback);
+            onClipDragEnd?.();
             setDrag(undefined);
           }}
           onLostPointerCapture={(event) => {
             if (event.pointerId !== drag?.pointerId) {
               return;
             }
-            onClipDragEnd?.(drag.resumePlayback);
+            onClipDragEnd?.();
             setDrag(undefined);
           }}
         >

--- a/src/hooks/use-pointer-drag.ts
+++ b/src/hooks/use-pointer-drag.ts
@@ -1,0 +1,53 @@
+import { useEffectEvent, useRef } from "react";
+
+type PointerDragOptions<T> = {
+  onStart: (event: React.PointerEvent<HTMLElement>) => T;
+  onMove: (event: React.PointerEvent<HTMLElement>, data: T) => void;
+  onEnd?: (event: React.PointerEvent<HTMLElement>, data: T) => void;
+};
+
+export function usePointerDrag<T>({
+  onStart,
+  onMove,
+  onEnd,
+}: PointerDragOptions<T>) {
+  const dragRef = useRef<{ pointerId: number; data: T } | undefined>(undefined);
+  const handlePointerDown = useEffectEvent(
+    (event: React.PointerEvent<HTMLElement>) => {
+      if (event.button !== 0 || dragRef.current) {
+        return;
+      }
+      dragRef.current = {
+        pointerId: event.pointerId,
+        data: onStart(event),
+      };
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+  );
+  const handlePointerMove = useEffectEvent(
+    (event: React.PointerEvent<HTMLElement>) => {
+      const drag = dragRef.current;
+      if (!drag || drag.pointerId !== event.pointerId) {
+        return;
+      }
+      onMove(event, drag.data);
+    },
+  );
+  const handlePointerEnd = useEffectEvent(
+    (event: React.PointerEvent<HTMLElement>) => {
+      const drag = dragRef.current;
+      if (drag?.pointerId === event.pointerId) {
+        dragRef.current = undefined;
+        onEnd?.(event, drag.data);
+      }
+    },
+  );
+
+  return {
+    onPointerDown: handlePointerDown,
+    onPointerMove: handlePointerMove,
+    onPointerUp: handlePointerEnd,
+    onPointerCancel: handlePointerEnd,
+    onLostPointerCapture: handlePointerEnd,
+  };
+}

--- a/src/hooks/use-pointer-drag.ts
+++ b/src/hooks/use-pointer-drag.ts
@@ -1,11 +1,5 @@
 import { useCallback, useEffectEvent } from "react";
-import { listenPointerDrag } from "../utils/pointer-drag";
-
-type PointerDragOptions<T> = {
-  onStart: (event: PointerEvent) => T;
-  onMove: (event: PointerEvent, data: T) => void;
-  onEnd?: (event: PointerEvent, data: T) => void;
-};
+import { listenPointerDrag, PointerDragOptions } from "../utils/pointer-drag";
 
 export function usePointerDrag<T>({
   onStart,

--- a/src/hooks/use-pointer-drag.ts
+++ b/src/hooks/use-pointer-drag.ts
@@ -1,9 +1,10 @@
-import { useEffectEvent, useRef } from "react";
+import { useCallback, useEffectEvent } from "react";
+import { listenPointerDrag } from "../utils/pointer-drag";
 
 type PointerDragOptions<T> = {
-  onStart: (event: React.PointerEvent<HTMLElement>) => T;
-  onMove: (event: React.PointerEvent<HTMLElement>, data: T) => void;
-  onEnd?: (event: React.PointerEvent<HTMLElement>, data: T) => void;
+  onStart: (event: PointerEvent) => T;
+  onMove: (event: PointerEvent, data: T) => void;
+  onEnd?: (event: PointerEvent, data: T) => void;
 };
 
 export function usePointerDrag<T>({
@@ -11,43 +12,22 @@ export function usePointerDrag<T>({
   onMove,
   onEnd,
 }: PointerDragOptions<T>) {
-  const dragRef = useRef<{ pointerId: number; data: T } | undefined>(undefined);
-  const handlePointerDown = useEffectEvent(
-    (event: React.PointerEvent<HTMLElement>) => {
-      if (event.button !== 0 || dragRef.current) {
-        return;
-      }
-      dragRef.current = {
-        pointerId: event.pointerId,
-        data: onStart(event),
-      };
-      event.currentTarget.setPointerCapture(event.pointerId);
-    },
-  );
-  const handlePointerMove = useEffectEvent(
-    (event: React.PointerEvent<HTMLElement>) => {
-      const drag = dragRef.current;
-      if (!drag || drag.pointerId !== event.pointerId) {
-        return;
-      }
-      onMove(event, drag.data);
-    },
-  );
-  const handlePointerEnd = useEffectEvent(
-    (event: React.PointerEvent<HTMLElement>) => {
-      const drag = dragRef.current;
-      if (drag?.pointerId === event.pointerId) {
-        dragRef.current = undefined;
-        onEnd?.(event, drag.data);
-      }
-    },
-  );
+  const handlePointerStart = useEffectEvent(onStart);
+  const handlePointerMove = useEffectEvent(onMove);
+  const handlePointerEnd = useEffectEvent(onEnd ?? (() => {}));
 
-  return {
-    onPointerDown: handlePointerDown,
-    onPointerMove: handlePointerMove,
-    onPointerUp: handlePointerEnd,
-    onPointerCancel: handlePointerEnd,
-    onLostPointerCapture: handlePointerEnd,
-  };
+  return useCallback(
+    (element: HTMLElement | null) => {
+      if (!element) {
+        return;
+      }
+      return listenPointerDrag({
+        element,
+        onStart: handlePointerStart,
+        onMove: handlePointerMove,
+        onEnd: handlePointerEnd,
+      });
+    },
+    [handlePointerEnd, handlePointerMove, handlePointerStart],
+  );
 }

--- a/src/hooks/use-pointer-drag.ts
+++ b/src/hooks/use-pointer-drag.ts
@@ -16,18 +16,15 @@ export function usePointerDrag<T>({
   const handlePointerMove = useEffectEvent(onMove);
   const handlePointerEnd = useEffectEvent(onEnd ?? (() => {}));
 
-  return useCallback(
-    (element: HTMLElement | null) => {
-      if (!element) {
-        return;
-      }
-      return listenPointerDrag({
-        element,
-        onStart: handlePointerStart,
-        onMove: handlePointerMove,
-        onEnd: handlePointerEnd,
-      });
-    },
-    [handlePointerEnd, handlePointerMove, handlePointerStart],
-  );
+  return useCallback((element: HTMLElement | null) => {
+    if (!element) {
+      return;
+    }
+    return listenPointerDrag({
+      element,
+      onStart: handlePointerStart,
+      onMove: handlePointerMove,
+      onEnd: handlePointerEnd,
+    });
+  }, []);
 }

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -196,11 +196,10 @@ export class RecorderRuntime {
   }
 
   setAudioTrackOffset(id: string, timelineOffset: number): void {
-    const nextOffset = Math.max(0, timelineOffset);
-    this.getAudioTrackPlayback(id).setTimelineOffset(nextOffset);
+    this.getAudioTrackPlayback(id).setTimelineOffset(timelineOffset);
     this.updateAudioTrack(id, (track) => ({
       ...track,
-      timelineOffset: nextOffset,
+      timelineOffset,
     }));
   }
 

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -196,10 +196,11 @@ export class RecorderRuntime {
   }
 
   setAudioTrackOffset(id: string, timelineOffset: number): void {
-    this.getAudioTrackPlayback(id).setTimelineOffset(timelineOffset);
+    const nextOffset = Math.max(0, timelineOffset);
+    this.getAudioTrackPlayback(id).setTimelineOffset(nextOffset);
     this.updateAudioTrack(id, (track) => ({
       ...track,
-      timelineOffset,
+      timelineOffset: nextOffset,
     }));
   }
 

--- a/src/utils/pointer-drag.ts
+++ b/src/utils/pointer-drag.ts
@@ -1,5 +1,4 @@
-type PointerDragOptions<T> = {
-  element: HTMLElement;
+export type PointerDragOptions<T> = {
   onStart: (event: PointerEvent) => T;
   onMove: (event: PointerEvent, data: T) => void;
   onEnd?: (event: PointerEvent, data: T) => void;
@@ -10,7 +9,7 @@ export function listenPointerDrag<T>({
   onStart,
   onMove,
   onEnd,
-}: PointerDragOptions<T>) {
+}: PointerDragOptions<T> & { element: HTMLElement }) {
   let drag: { pointerId: number; data: T } | undefined;
 
   const handlePointerDown = (event: PointerEvent) => {


### PR DESCRIPTION
Adds horizontal drag interaction for loaded recorder audio clips. Dragging converts pointer displacement through the current timeline zoom and tempo, clamps offsets at zero, and avoids seeking the lane when grabbing a clip. If playback is active, the recorder pauses for the drag and resumes afterward so Web Audio sources use the updated offset.\n\nVerification was intentionally skipped per request.