### PR TITLE
refactor: clarify transport control roles

### DIFF
--- a/src/components/mixer.tsx
+++ b/src/components/mixer.tsx
@@ -264,7 +264,7 @@ function MixerChannel({
           type="text"
           inputMode="decimal"
           aria-label={`${label === "Metro" ? "Metronome" : label} level in dB`}
-          className="w-12 h-6 px-1 text-xs font-mono bg-input border border-border rounded text-center text-foreground"
+          className="h-6 w-12 rounded border border-neutral-600 bg-neutral-900 px-1 text-center font-mono text-xs text-neutral-100 focus:border-neutral-500 focus:outline-none"
           {...dbInputProps}
         />
         <span>dB</span>

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -1,5 +1,6 @@
 import {
   CheckIcon,
+  ChevronDownIcon,
   ChevronsUpDownIcon,
   PauseIcon,
   PlayIcon,
@@ -39,6 +40,9 @@ type TransportProps = {
   projectName: string;
   controls: ReactNode;
 };
+
+const choiceFieldClassName =
+  "border-neutral-600 bg-neutral-900 text-neutral-100 hover:border-neutral-500 hover:bg-neutral-900";
 
 export function Transport({ projectName, controls }: TransportProps) {
   const {
@@ -176,7 +180,7 @@ export function Transport({ projectName, controls }: TransportProps) {
           type="text"
           inputMode="numeric"
           {...tempoInput.props}
-          className="w-14 h-8 px-1 text-sm font-mono bg-input border border-border rounded text-center text-foreground"
+          className="h-8 w-14 rounded border border-neutral-600 bg-neutral-900 px-1 text-center font-mono text-sm text-neutral-100 focus:border-neutral-500 focus:outline-none"
         />
         <Button
           data-testid="tap-tempo-button"
@@ -196,9 +200,10 @@ export function Transport({ projectName, controls }: TransportProps) {
         <DropdownMenuTrigger asChild>
           <Button
             data-testid="time-signature-select"
-            className="h-8 gap-1 px-3 font-mono hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+            className={cn("h-8 gap-1.5 px-3 font-mono", choiceFieldClassName)}
           >
             {timeSignature.numerator}/{timeSignature.denominator}
+            <ChevronDownIcon className="size-3.5 shrink-0 opacity-50" />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>
@@ -226,9 +231,10 @@ export function Transport({ projectName, controls }: TransportProps) {
         <DropdownMenuTrigger asChild>
           <Button
             data-testid="grid-snap-select"
-            className="h-8 gap-1 px-3 font-mono hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+            className={cn("h-8 gap-1.5 px-3 font-mono", choiceFieldClassName)}
           >
             {gridSnap}
+            <ChevronDownIcon className="size-3.5 shrink-0 opacity-50" />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>
@@ -364,7 +370,10 @@ function InstrumentCombobox({
           data-testid="instrument-select"
           role="combobox"
           aria-expanded={open}
-          className="h-8 w-44 justify-between gap-1.5 px-3 text-sm font-normal hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+          className={cn(
+            "h-8 w-44 justify-between gap-1.5 px-3 text-sm font-normal",
+            choiceFieldClassName,
+          )}
         >
           <span className="truncate">
             {value}: {GM_PROGRAMS[value]}

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -41,9 +41,6 @@ type TransportProps = {
   controls: ReactNode;
 };
 
-const choiceFieldClassName =
-  "border-neutral-600 bg-neutral-900 text-neutral-100 hover:border-neutral-500 hover:bg-neutral-900";
-
 export function Transport({ projectName, controls }: TransportProps) {
   const {
     tempo,
@@ -200,7 +197,7 @@ export function Transport({ projectName, controls }: TransportProps) {
         <DropdownMenuTrigger asChild>
           <Button
             data-testid="time-signature-select"
-            className={cn("h-8 gap-1.5 px-3 font-mono", choiceFieldClassName)}
+            className="h-8 gap-1.5 border-neutral-600 bg-neutral-900 px-3 font-mono text-neutral-100 hover:border-neutral-500 hover:bg-neutral-900"
           >
             {timeSignature.numerator}/{timeSignature.denominator}
             <ChevronDownIcon className="size-3.5 shrink-0 opacity-50" />
@@ -231,7 +228,7 @@ export function Transport({ projectName, controls }: TransportProps) {
         <DropdownMenuTrigger asChild>
           <Button
             data-testid="grid-snap-select"
-            className={cn("h-8 gap-1.5 px-3 font-mono", choiceFieldClassName)}
+            className="h-8 gap-1.5 border-neutral-600 bg-neutral-900 px-3 font-mono text-neutral-100 hover:border-neutral-500 hover:bg-neutral-900"
           >
             {gridSnap}
             <ChevronDownIcon className="size-3.5 shrink-0 opacity-50" />
@@ -370,10 +367,7 @@ function InstrumentCombobox({
           data-testid="instrument-select"
           role="combobox"
           aria-expanded={open}
-          className={cn(
-            "h-8 w-44 justify-between gap-1.5 px-3 text-sm font-normal",
-            choiceFieldClassName,
-          )}
+          className="h-8 w-44 justify-between gap-1.5 border-neutral-600 bg-neutral-900 px-3 text-sm font-normal text-neutral-100 hover:border-neutral-500 hover:bg-neutral-900"
         >
           <span className="truncate">
             {value}: {GM_PROGRAMS[value]}


### PR DESCRIPTION
Editable values and dropdown choices in the editor transport currently share the same raised treatment as action buttons, which makes their interaction roles harder to distinguish.

This PR gives BPM the existing recessed input language, applies the same field treatment to time signature, grid snap, and instrument choices, and adds subtle chevrons to the two dropdown values. Play, metronome, TAP, settings, and more remain raised action controls, with behavior unchanged.