### PR TITLE
refactor: use field controls in transport

### DIFF
--- a/e2e/transport.spec.ts
+++ b/e2e/transport.spec.ts
@@ -68,6 +68,17 @@ test.describe("Transport Controls", () => {
     await expect(tempoInput).toHaveValue("300");
   });
 
+  test("timeline value selectors", async ({ page }) => {
+    const timeSignature = page.getByTestId("time-signature-select");
+    const gridSnap = page.getByTestId("grid-snap-select");
+
+    await timeSignature.selectOption("3/4");
+    await gridSnap.selectOption("1/8T");
+
+    await expect(timeSignature).toHaveValue("3/4");
+    await expect(gridSnap).toHaveValue("1/8T");
+  });
+
   test("metronome toggle", async ({ page }) => {
     const metronomeToggle = page.getByTestId("metronome-mute-toggle");
 

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -1,6 +1,5 @@
 import {
   CheckIcon,
-  ChevronDownIcon,
   ChevronsUpDownIcon,
   PauseIcon,
   PlayIcon,
@@ -26,23 +25,15 @@ import {
   CommandItem,
   CommandList,
 } from "./ui/command";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-} from "./ui/dropdown-menu";
+import { Input } from "./ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
+import { Select } from "./ui/select";
 import { cn } from "./ui/utils";
 
 type TransportProps = {
   projectName: string;
   controls: ReactNode;
 };
-
-const choiceFieldClassName =
-  "border-neutral-600 bg-neutral-900 text-neutral-100 hover:border-neutral-500 hover:bg-neutral-900";
 
 export function Transport({ projectName, controls }: TransportProps) {
   const {
@@ -175,12 +166,12 @@ export function Transport({ projectName, controls }: TransportProps) {
       {/* Tempo: BPM input + tap button + time signature */}
       <div className="flex items-center gap-1.5">
         <span className="text-muted-foreground">BPM</span>
-        <input
+        <Input
           data-testid="tempo-input"
           type="text"
           inputMode="numeric"
           {...tempoInput.props}
-          className="h-8 w-14 rounded border border-neutral-600 bg-neutral-900 px-1 text-center font-mono text-sm text-neutral-100 focus:border-neutral-500 focus:outline-none"
+          className="w-14 px-1 text-center font-mono"
         />
         <Button
           data-testid="tap-tempo-button"
@@ -196,61 +187,43 @@ export function Transport({ projectName, controls }: TransportProps) {
       <div className="w-px h-5 bg-border" />
 
       {/* Time signature selector */}
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            data-testid="time-signature-select"
-            className={cn("h-8 gap-1.5 px-3 font-mono", choiceFieldClassName)}
-          >
-            {timeSignature.numerator}/{timeSignature.denominator}
-            <ChevronDownIcon className="size-3.5 shrink-0 opacity-50" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent>
-          <DropdownMenuRadioGroup
-            value={`${timeSignature.numerator}/${timeSignature.denominator}`}
-            onValueChange={(v) => {
-              const [numerator, denominator] = v.split("/").map(Number);
-              setTimeSignature({ numerator, denominator });
-            }}
-          >
-            {COMMON_TIME_SIGNATURES.map((ts) => (
-              <DropdownMenuRadioItem
-                key={`${ts.numerator}/${ts.denominator}`}
-                value={`${ts.numerator}/${ts.denominator}`}
-              >
-                {ts.numerator}/{ts.denominator}
-              </DropdownMenuRadioItem>
-            ))}
-          </DropdownMenuRadioGroup>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <Select
+        data-testid="time-signature-select"
+        aria-label="Time signature"
+        className="font-mono"
+        value={`${timeSignature.numerator}/${timeSignature.denominator}`}
+        onChange={(event) => {
+          const [numerator, denominator] = event.currentTarget.value
+            .split("/")
+            .map(Number);
+          setTimeSignature({ numerator, denominator });
+        }}
+      >
+        {COMMON_TIME_SIGNATURES.map((ts) => {
+          const value = `${ts.numerator}/${ts.denominator}`;
+          return (
+            <option key={value} value={value}>
+              {value}
+            </option>
+          );
+        })}
+      </Select>
 
       {/* Grid snap selector */}
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            data-testid="grid-snap-select"
-            className={cn("h-8 gap-1.5 px-3 font-mono", choiceFieldClassName)}
-          >
-            {gridSnap}
-            <ChevronDownIcon className="size-3.5 shrink-0 opacity-50" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent>
-          <DropdownMenuRadioGroup
-            value={gridSnap}
-            onValueChange={(v) => setGridSnap(v as GridSnap)}
-          >
-            <DropdownMenuRadioItem value="1/4">1/4</DropdownMenuRadioItem>
-            <DropdownMenuRadioItem value="1/8">1/8</DropdownMenuRadioItem>
-            <DropdownMenuRadioItem value="1/16">1/16</DropdownMenuRadioItem>
-            <DropdownMenuRadioItem value="1/4T">1/4T</DropdownMenuRadioItem>
-            <DropdownMenuRadioItem value="1/8T">1/8T</DropdownMenuRadioItem>
-            <DropdownMenuRadioItem value="1/16T">1/16T</DropdownMenuRadioItem>
-          </DropdownMenuRadioGroup>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <Select
+        data-testid="grid-snap-select"
+        aria-label="Grid snap"
+        className="font-mono"
+        value={gridSnap}
+        onChange={(event) => setGridSnap(event.currentTarget.value as GridSnap)}
+      >
+        <option value="1/4">1/4</option>
+        <option value="1/8">1/8</option>
+        <option value="1/16">1/16</option>
+        <option value="1/4T">1/4T</option>
+        <option value="1/8T">1/8T</option>
+        <option value="1/16T">1/16T</option>
+      </Select>
 
       {/* Divider */}
       <div className="w-px h-5 bg-border" />
@@ -370,10 +343,7 @@ function InstrumentCombobox({
           data-testid="instrument-select"
           role="combobox"
           aria-expanded={open}
-          className={cn(
-            "h-8 w-44 justify-between gap-1.5 px-3 text-sm font-normal",
-            choiceFieldClassName,
-          )}
+          className="h-8 w-44 justify-between gap-1.5 border-neutral-600 bg-neutral-900 px-3 text-sm font-normal text-neutral-100 hover:border-neutral-500 hover:bg-neutral-900"
         >
           <span className="truncate">
             {value}: {GM_PROGRAMS[value]}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,5 +1,4 @@
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
-import { CircleIcon } from "lucide-react";
 import * as React from "react";
 import { cn } from "./utils";
 
@@ -79,40 +78,5 @@ export function DropdownMenuSeparator({
       className={cn("bg-border -mx-1 my-1 h-px", className)}
       {...props}
     />
-  );
-}
-
-export function DropdownMenuRadioGroup({
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
-  return (
-    <DropdownMenuPrimitive.RadioGroup
-      data-slot="dropdown-menu-radio-group"
-      {...props}
-    />
-  );
-}
-
-export function DropdownMenuRadioItem({
-  className,
-  children,
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
-  return (
-    <DropdownMenuPrimitive.RadioItem
-      data-slot="dropdown-menu-radio-item"
-      className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className,
-      )}
-      {...props}
-    >
-      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-        <DropdownMenuPrimitive.ItemIndicator>
-          <CircleIcon className="size-2 fill-current" />
-        </DropdownMenuPrimitive.ItemIndicator>
-      </span>
-      {children}
-    </DropdownMenuPrimitive.RadioItem>
   );
 }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { cn } from "./utils";
+
+export function Input({ className, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      className={cn(
+        "h-8 rounded border border-neutral-600 bg-neutral-900 px-2 text-sm text-neutral-100 outline-none transition-colors placeholder:text-muted-foreground hover:border-neutral-500 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,24 @@
+import { ChevronDownIcon } from "lucide-react";
+import * as React from "react";
+import { cn } from "./utils";
+
+export function Select({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"select">) {
+  return (
+    <span className="relative inline-flex">
+      <select
+        className={cn(
+          "h-8 appearance-none rounded border border-neutral-600 bg-neutral-900 py-0 pr-8 pl-3 text-sm text-neutral-100 outline-none transition-colors hover:border-neutral-500 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </select>
+      <ChevronDownIcon className="pointer-events-none absolute top-1/2 right-2.5 size-3.5 -translate-y-1/2 text-neutral-400" />
+    </span>
+  );
+}


### PR DESCRIPTION
The transport styling currently relies on a local class string applied across inputs, menu triggers, and a combobox, which hides the different control semantics behind shared presentation.

This PR introduces reusable native `Input` and `Select` boundaries, converts time signature and grid snap from command-menu radio groups to closed-choice selects, and removes the now-unused dropdown radio wrappers. The searchable instrument remains a combobox and action controls remain buttons.