### PR TITLE
fix: await recorder input channel discovery

### DIFF
--- a/src/lib/recorder/capture-input.ts
+++ b/src/lib/recorder/capture-input.ts
@@ -44,22 +44,19 @@ export class CaptureInput {
     }
     let input: CaptureInput | undefined;
     try {
-      let resolveChannelCount!: (value: number) => void;
-      const channelCountPromise = new Promise<number>((resolve) => {
-        resolveChannelCount = resolve;
-      });
+      const channelCountPromise = Promise.withResolvers<number>();
       input = new CaptureInput({
         context,
         stream,
         onNotification: (message) => {
           if (message.type === "channels" && message.value > 0) {
-            resolveChannelCount(message.value);
+            channelCountPromise.resolve(message.value);
           }
           onNotification(message);
         },
       });
       const channelCount = await Promise.race([
-        channelCountPromise,
+        channelCountPromise.promise,
         new Promise<never>((_resolve, reject) => {
           window.setTimeout(() => {
             reject(new Error("Audio input channel discovery timed out."));

--- a/src/lib/recorder/capture-input.ts
+++ b/src/lib/recorder/capture-input.ts
@@ -53,7 +53,6 @@ export class CaptureInput {
         onNotification(message);
       },
     });
-
     const channelCount = await Promise.race([
       channelCountPromise.promise,
       new Promise<never>((_resolve, reject) => {

--- a/src/lib/recorder/capture-input.ts
+++ b/src/lib/recorder/capture-input.ts
@@ -32,7 +32,11 @@ export class CaptureInput {
     context: AudioContext;
     deviceId: string;
     onNotification: (message: CaptureWorkletNotification) => void;
-  }): Promise<{ input: CaptureInput; settings: MediaTrackSettings }> {
+  }): Promise<{
+    input: CaptureInput;
+    settings: MediaTrackSettings;
+    channelCount: number;
+  }> {
     await ensureCaptureWorklet(context);
     const stream = await navigator.mediaDevices.getUserMedia(
       captureConstraints(deviceId),
@@ -42,17 +46,41 @@ export class CaptureInput {
       stream.getTracks().forEach((track) => track.stop());
       throw new Error("The selected device did not provide an audio track.");
     }
+    let input: CaptureInput | undefined;
     try {
-      return {
-        input: new CaptureInput({
-          context,
-          stream,
-          onNotification,
+      let resolveChannelCount!: (value: number) => void;
+      const channelCountPromise = new Promise<number>((resolve) => {
+        resolveChannelCount = resolve;
+      });
+      input = new CaptureInput({
+        context,
+        stream,
+        onNotification: (message) => {
+          if (message.type === "channels" && message.value > 0) {
+            resolveChannelCount(message.value);
+          }
+          onNotification(message);
+        },
+      });
+      const channelCount = await Promise.race([
+        channelCountPromise,
+        new Promise<never>((_resolve, reject) => {
+          window.setTimeout(() => {
+            reject(new Error("Audio input channel discovery timed out."));
+          }, 3_000);
         }),
+      ]);
+      return {
+        input,
         settings: track.getSettings(),
+        channelCount,
       };
     } catch (error) {
-      stream.getTracks().forEach((track) => track.stop());
+      if (input) {
+        input.dispose();
+      } else {
+        stream.getTracks().forEach((track) => track.stop());
+      }
       throw error;
     }
   }

--- a/src/lib/recorder/capture-input.ts
+++ b/src/lib/recorder/capture-input.ts
@@ -42,40 +42,31 @@ export class CaptureInput {
       stream.getTracks().forEach((track) => track.stop());
       throw new Error("The selected device did not provide an audio track.");
     }
-    let input: CaptureInput | undefined;
-    try {
-      const channelCountPromise = Promise.withResolvers<number>();
-      input = new CaptureInput({
-        context,
-        stream,
-        onNotification: (message) => {
-          if (message.type === "channels" && message.value > 0) {
-            channelCountPromise.resolve(message.value);
-          }
-          onNotification(message);
-        },
-      });
-      const channelCount = await Promise.race([
-        channelCountPromise.promise,
-        new Promise<never>((_resolve, reject) => {
-          window.setTimeout(() => {
-            reject(new Error("Audio input channel discovery timed out."));
-          }, 3_000);
-        }),
-      ]);
-      return {
-        input,
-        settings: track.getSettings(),
-        channelCount,
-      };
-    } catch (error) {
-      if (input) {
-        input.dispose();
-      } else {
-        stream.getTracks().forEach((track) => track.stop());
-      }
-      throw error;
-    }
+    const channelCountPromise = Promise.withResolvers<number>();
+    const input = new CaptureInput({
+      context,
+      stream,
+      onNotification: (message) => {
+        if (message.type === "channels" && message.value > 0) {
+          channelCountPromise.resolve(message.value);
+        }
+        onNotification(message);
+      },
+    });
+
+    const channelCount = await Promise.race([
+      channelCountPromise.promise,
+      new Promise<never>((_resolve, reject) => {
+        window.setTimeout(() => {
+          reject(new Error("Audio input channel discovery timed out."));
+        }, 3_000);
+      }),
+    ]);
+    return {
+      input,
+      settings: track.getSettings(),
+      channelCount,
+    };
   }
 
   private constructor({

--- a/src/lib/recorder/capture-input.ts
+++ b/src/lib/recorder/capture-input.ts
@@ -32,11 +32,7 @@ export class CaptureInput {
     context: AudioContext;
     deviceId: string;
     onNotification: (message: CaptureWorkletNotification) => void;
-  }): Promise<{
-    input: CaptureInput;
-    settings: MediaTrackSettings;
-    channelCount: number;
-  }> {
+  }) {
     await ensureCaptureWorklet(context);
     const stream = await navigator.mediaDevices.getUserMedia(
       captureConstraints(deviceId),

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -87,7 +87,7 @@ export class RecorderRuntime {
     const context = this.getContext();
     // Open the replacement completely before closing the current input so a
     // permission or device error leaves the existing route usable.
-    const { input, settings } = await CaptureInput.open({
+    const { input, settings, channelCount } = await CaptureInput.open({
       context,
       deviceId,
       onNotification: (message) => {
@@ -148,7 +148,7 @@ export class RecorderRuntime {
     this.store.update({
       status: "ready",
       inputSettings: settings,
-      inputChannelCount: 0,
+      inputChannelCount: channelCount,
       selectedChannel: 0,
     });
   }

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -92,16 +92,6 @@ export class RecorderRuntime {
       deviceId,
       onNotification: (message) => {
         switch (message.type) {
-          case "channels": {
-            const inputChannelCount = message.value;
-            const selectedChannel = Math.min(
-              this.store.get().selectedChannel,
-              Math.max(0, inputChannelCount - 1),
-            );
-            this.store.update({ inputChannelCount, selectedChannel });
-            this.selectChannel(selectedChannel);
-            break;
-          }
           case "level": {
             onLevel(message.peak);
             break;


### PR DESCRIPTION
`CaptureInput.open()` currently resolves before the worklet reports the actual input channel count. This leaves callers observing an initialized input with `inputChannelCount: 0` and makes restoring a selected channel depend on a later notification.

Make channel discovery part of the existing open contract without changing the worklet protocol. `open()` waits for the first positive `channels` notification, returns `channelCount` with the input and track settings, and disposes the partial input if discovery times out. `RecorderRuntime.startInput()` can then publish a fully initialized ready state.

Tests:
- `pnpm lint`
- `pnpm test`