### PR TITLE
refactor: keep recording limit in runtime

### DIFF
--- a/src/lib/recorder/recording.ts
+++ b/src/lib/recorder/recording.ts
@@ -3,12 +3,10 @@ import type { CaptureChunk } from "./capture-worklet.ts";
 export class ActiveRecording {
   private readonly chunks: CaptureChunk[] = [];
   private readonly startFrame: number;
-  private readonly capacityFrames: number;
   private endFrame: number;
 
-  constructor(startFrame: number, capacityFrames: number) {
+  constructor(startFrame: number) {
     this.startFrame = startFrame;
-    this.capacityFrames = capacityFrames;
     this.endFrame = startFrame;
   }
 
@@ -26,16 +24,10 @@ export class ActiveRecording {
     return this.endFrame - this.startFrame;
   }
 
-  isFull(): boolean {
-    // Capacity is elapsed AudioContext frames, including capture gaps, rather
-    // than only the number of PCM samples delivered.
-    return this.getDurationFrames() >= this.capacityFrames;
-  }
-
   finish(stopFrame: number): Float32Array | undefined {
     // Reconstruct [startFrame, stopFrame) in capture-relative coordinates.
     // Missing ranges remain zero-filled and later chunks replace overlaps.
-    const length = Math.min(stopFrame - this.startFrame, this.capacityFrames);
+    const length = stopFrame - this.startFrame;
     if (length <= 0) {
       return undefined;
     }

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -122,7 +122,8 @@ export class RecorderRuntime {
               },
             });
             if (
-              activeRecording.isFull() &&
+              activeRecording.getDurationFrames() >=
+                context.sampleRate * MAX_RECORDING_SECONDS &&
               this.store.get().status === "recording"
             ) {
               void this.stopRecording();
@@ -348,10 +349,7 @@ export class RecorderRuntime {
     // first captured frame. Convert that exact boundary to musical timeline
     // coordinates instead of using main-thread request time.
     const startFrame = await this.captureInput.startCapture();
-    this.activeRecording = new ActiveRecording(
-      startFrame,
-      Math.floor(context.sampleRate * MAX_RECORDING_SECONDS),
-    );
+    this.activeRecording = new ActiveRecording(startFrame);
     this.store.update({
       status: "recording",
       recordingTrack: {


### PR DESCRIPTION
The five-minute limit is runtime policy, but `ActiveRecording` currently receives and enforces it as a storage capacity. That makes capture assembly responsible for an application-level stop concern.

This PR moves the duration comparison into `RecorderRuntime` and lets `ActiveRecording` assemble the complete interval acknowledged by the capture worklet.