### PR TITLE
refactor: share timeline utilities

### DIFF
--- a/src/components/piano-roll.tsx
+++ b/src/components/piano-roll.tsx
@@ -37,6 +37,8 @@ import {
 import {
   beatsToSeconds,
   getVisibleBarInterval,
+  MAX_PIXELS_PER_BEAT,
+  MIN_PIXELS_PER_BEAT,
   secondsToBeats,
 } from "../lib/timeline";
 import { GRID_SNAP_VALUES, GridSnap, Note } from "../types";
@@ -56,8 +58,6 @@ const MAX_WAVEFORM_HEIGHT = 300;
 // Zoom limits (pixels per beat/key)
 // TODO: consider discrete integer zoom levels (e.g. 1,2,3,4,6,8,...,192)
 // for simpler state and guaranteed zoom roundtrip
-const MIN_PIXELS_PER_BEAT = 1; // Allow extreme zoom out for song overview
-const MAX_PIXELS_PER_BEAT = 400;
 const MIN_PIXELS_PER_KEY = 10;
 const MAX_PIXELS_PER_KEY = 40;
 

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -17,6 +17,7 @@ import { isShortcutTextInputTarget, matchKeyboardEvent } from "../lib/keyboard";
 import { routes } from "../lib/routes";
 import { SCORE_VIEWER_SAMPLES } from "../lib/score-viewer-samples";
 import { formatTimeCompact } from "../lib/time-format";
+import { formatBarBeat } from "../lib/timeline";
 import { FileDropInput, openFilePicker } from "./file-drop-input";
 import { ScoreSettings } from "./score-settings";
 import {
@@ -368,8 +369,4 @@ function ScoreSamplesMenu({
       </DropdownMenuContent>
     </DropdownMenu>
   );
-}
-
-function formatBarBeat(bar: number, beat: number) {
-  return `${String(bar).padStart(2, "0")}|${String(beat).padStart(2, "0")}`;
 }

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -19,7 +19,11 @@ import {
   formatBarBeat as formatBarBeatPosition,
   secondsToBeats,
 } from "../lib/timeline";
-import { COMMON_TIME_SIGNATURES, type GridSnap } from "../types";
+import {
+  COMMON_TIME_SIGNATURES,
+  type GridSnap,
+  parseTimeSignature,
+} from "../types";
 import { MetronomeIcon } from "./icons";
 import { Button } from "./ui/button";
 import {
@@ -211,8 +215,7 @@ export function Transport({ projectName, controls }: TransportProps) {
           <DropdownMenuRadioGroup
             value={`${timeSignature.numerator}/${timeSignature.denominator}`}
             onValueChange={(v) => {
-              const [numerator, denominator] = v.split("/").map(Number);
-              setTimeSignature({ numerator, denominator });
+              setTimeSignature(parseTimeSignature(v));
             }}
           >
             {COMMON_TIME_SIGNATURES.map((ts) => (

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -15,6 +15,10 @@ import { isShortcutTextInputTarget, matchKeyboardEvent } from "../lib/keyboard";
 import { projectStorage } from "../lib/project-storage";
 import { useProjectStore } from "../lib/project-store";
 import { formatTimeCompact } from "../lib/time-format";
+import {
+  formatBarBeat as formatBarBeatPosition,
+  secondsToBeats,
+} from "../lib/timeline";
 import { COMMON_TIME_SIGNATURES, type GridSnap } from "../types";
 import { MetronomeIcon } from "./icons";
 import { Button } from "./ui/button";
@@ -324,11 +328,10 @@ function TimeDisplay({ tempo }: { tempo: number }) {
 }
 
 function formatBarBeat(seconds: number, tempo: number): string {
-  const beatsPerSecond = tempo / 60;
-  const totalBeats = seconds * beatsPerSecond;
+  const totalBeats = secondsToBeats(seconds, tempo);
   const bar = Math.floor(totalBeats / 4) + 1; // 4/4 time signature
   const beatInBar = Math.floor(totalBeats % 4) + 1;
-  return `${String(bar).padStart(2, "0")}|${String(beatInBar).padStart(2, "0")}`;
+  return formatBarBeatPosition(bar, beatInBar);
 }
 
 // GM instrument groups for organized display

--- a/src/lib/musicxml/model.ts
+++ b/src/lib/musicxml/model.ts
@@ -7,6 +7,7 @@ import {
   spellMidiPitch,
 } from "../pitch-spelling";
 import { resolveTabPosition, type TabPosition } from "../tab-annotation";
+import { getBeatsPerBar } from "../timeline";
 import {
   buildMeasureEvents,
   MUSICXML_DIVISIONS,
@@ -81,7 +82,7 @@ export function buildMusicXmlModel({
   validateOpenStringPitches(openStringPitches);
   // Measure length in MusicXML grid units.
   const measureDuration = toGridUnits(
-    timeSignature.numerator * (4 / timeSignature.denominator),
+    getBeatsPerBar(timeSignature),
     "time signature",
   );
   const beatDuration =

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -1,9 +1,23 @@
+import type { TimeSignature } from "../types";
+
+export const MIN_PIXELS_PER_BEAT = 1;
+export const MAX_PIXELS_PER_BEAT = 400;
+
 export function secondsToBeats(seconds: number, tempo: number): number {
   return (seconds / 60) * tempo;
 }
 
 export function beatsToSeconds(beats: number, tempo: number): number {
   return (beats / tempo) * 60;
+}
+
+export function getBeatsPerBar(timeSignature: TimeSignature): number {
+  const { numerator, denominator } = timeSignature;
+  return numerator * (4 / denominator);
+}
+
+export function formatBarBeat(bar: number, beat: number): string {
+  return `${String(bar).padStart(2, "0")}|${String(beat).padStart(2, "0")}`;
 }
 
 export function getVisibleBarInterval({

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,11 @@ export interface TimeSignature {
   denominator: number; // beat unit (e.g., 4 for quarter note, 8 for eighth note)
 }
 
+export function parseTimeSignature(value: string): TimeSignature {
+  const [numerator, denominator] = value.split("/").map(Number);
+  return { numerator, denominator };
+}
+
 export interface Locator {
   id: string;
   position: number; // Position on timeline in beats


### PR DESCRIPTION
- extracting util diff churn from https://github.com/hi-ogawa/toy-midi/pull/291

Timeline calculations, display helpers, and time-signature parsing were duplicated across existing application code and the recorder work. Keeping those changes on the recorder branch makes its feature diff larger and leaves equivalent behavior easier to drift independently.

This PR consolidates the shared pixels-per-beat limits, beats-per-bar calculation, padded bar/beat formatting, and time-signature parser, then switches existing consumers to those utilities without changing behavior.