### PR TITLE
feat: add recorder tap tempo

### DIFF
--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -27,6 +27,23 @@ test("uploads and plays a backing track", async ({ page }) => {
   await expect(playButton).toHaveAttribute("aria-pressed", "false");
 });
 
+test("sets the recorder tempo by tapping", async ({ page }) => {
+  const tempoInput = page.getByTestId("recorder-tempo-input");
+  const tapButton = page.getByTestId("recorder-tap-tempo-button");
+  await expect(tempoInput).toHaveValue("120");
+
+  await tapButton.click();
+  await page.waitForTimeout(400);
+  await tapButton.click();
+
+  await expect
+    .poll(async () => Number.parseInt(await tempoInput.inputValue()))
+    .toBeGreaterThanOrEqual(140);
+  expect(Number.parseInt(await tempoInput.inputValue())).toBeLessThanOrEqual(
+    155,
+  );
+});
+
 test("records, plays, and replaces a take", async ({ page }) => {
   // The musician connects the browser input before recording is available.
   await enableInput(page);

--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -38,9 +38,9 @@ test("sets the recorder tempo by tapping", async ({ page }) => {
 
   await expect
     .poll(async () => Number.parseInt(await tempoInput.inputValue()))
-    .toBeGreaterThanOrEqual(140);
+    .toBeGreaterThan(120);
   expect(Number.parseInt(await tempoInput.inputValue())).toBeLessThanOrEqual(
-    155,
+    300,
   );
 });
 

--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -27,23 +27,6 @@ test("uploads and plays a backing track", async ({ page }) => {
   await expect(playButton).toHaveAttribute("aria-pressed", "false");
 });
 
-test("sets the recorder tempo by tapping", async ({ page }) => {
-  const tempoInput = page.getByTestId("recorder-tempo-input");
-  const tapButton = page.getByTestId("recorder-tap-tempo-button");
-  await expect(tempoInput).toHaveValue("120");
-
-  await tapButton.click();
-  await page.waitForTimeout(400);
-  await tapButton.click();
-
-  await expect
-    .poll(async () => Number.parseInt(await tempoInput.inputValue()))
-    .toBeGreaterThan(120);
-  expect(Number.parseInt(await tempoInput.inputValue())).toBeLessThanOrEqual(
-    300,
-  );
-});
-
 test("records, plays, and replaces a take", async ({ page }) => {
   // The musician connects the browser input before recording is available.
   await enableInput(page);

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -17,6 +17,7 @@ import {
 import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import { useDraftInput } from "../../hooks/use-draft-input";
 import { usePointerDrag } from "../../hooks/use-pointer-drag";
+import { useTapTempo } from "../../hooks/use-tap-tempo";
 import { useWindowEvent } from "../../hooks/use-window-event";
 import { resolveAudioFiles } from "../../lib/audio-files";
 import { AudioView } from "../../lib/audio-view";
@@ -627,6 +628,11 @@ function RecorderHeader({
     min: 30,
     max: 300,
   });
+  const handleTapTempo = useTapTempo({
+    min: 30,
+    max: 300,
+    onTempoChange,
+  });
   return (
     <header className="flex h-[53px] shrink-0 items-center gap-2 border-b border-neutral-700 bg-neutral-800 px-4 shadow-sm">
       <Mic2Icon className="size-4 text-emerald-400" />
@@ -695,11 +701,20 @@ function RecorderHeader({
       <div className="flex items-center gap-1.5 text-xs text-neutral-400">
         <span>BPM</span>
         <input
+          data-testid="recorder-tempo-input"
           type="text"
           inputMode="numeric"
           {...tempoInput.props}
           className="h-8 w-14 rounded border border-neutral-600 bg-neutral-900 px-1 text-center font-mono text-sm text-neutral-100"
         />
+        <Button
+          data-testid="recorder-tap-tempo-button"
+          onClick={handleTapTempo}
+          title="Tap tempo"
+          className="h-8 px-1.5 text-xs hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+        >
+          TAP
+        </Button>
       </div>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>

--- a/src/components/transport.tsx
+++ b/src/components/transport.tsx
@@ -5,9 +5,10 @@ import {
   PauseIcon,
   PlayIcon,
 } from "lucide-react";
-import { type ReactNode, useRef, useState } from "react";
+import { type ReactNode, useState } from "react";
 import { useAudio } from "../hooks/use-audio";
 import { useDraftInput } from "../hooks/use-draft-input";
+import { useTapTempo } from "../hooks/use-tap-tempo";
 import { useWindowEvent } from "../hooks/use-window-event";
 import { audioManager } from "../lib/audio";
 import { GM_PROGRAMS } from "../lib/general-midi";
@@ -69,8 +70,6 @@ export function Transport({ projectName, controls }: TransportProps) {
     setGridSnap,
   } = useProjectStore();
 
-  const tapTimesRef = useRef<number[]>([]);
-
   const handleMidiProgramChange = (program: number) => {
     setMidiProgram(program);
     projectStorage.updatePreferences({ defaultMidiProgram: program });
@@ -81,6 +80,11 @@ export function Transport({ projectName, controls }: TransportProps) {
     onCommit: setTempo,
     min: 30,
     max: 300,
+  });
+  const handleTapTempo = useTapTempo({
+    min: 30,
+    max: 300,
+    onTempoChange: setTempo,
   });
 
   // Keyboard shortcuts: M=metronome, F=auto-scroll, Shift+1/2=mute (Space is handled by PlayPauseButton)
@@ -110,39 +114,6 @@ export function Transport({ projectName, controls }: TransportProps) {
       }
     }
   });
-
-  const handleTapTempo = () => {
-    const now = performance.now();
-    const taps = tapTimesRef.current;
-
-    // Reset if last tap was more than 2 seconds ago
-    if (taps.length > 0 && now - taps[taps.length - 1] > 2000) {
-      tapTimesRef.current = [];
-    }
-
-    taps.push(now);
-
-    // Keep only last 8 taps
-    if (taps.length > 8) {
-      taps.shift();
-    }
-
-    // Need at least 2 taps to calculate BPM
-    if (taps.length >= 2) {
-      const intervals: number[] = [];
-      for (let i = 1; i < taps.length; i++) {
-        intervals.push(taps[i] - taps[i - 1]);
-      }
-      const avgInterval =
-        intervals.reduce((a, b) => a + b, 0) / intervals.length;
-      const bpm = Math.round(60000 / avgInterval);
-
-      // Clamp to valid range
-      if (bpm >= 30 && bpm <= 300) {
-        setTempo(bpm);
-      }
-    }
-  };
 
   return (
     <div

--- a/src/hooks/use-tap-tempo.ts
+++ b/src/hooks/use-tap-tempo.ts
@@ -1,0 +1,41 @@
+import { useRef } from "react";
+
+const MAX_TAPS = 8;
+const RESET_AFTER_MS = 2000;
+
+export function useTapTempo({
+  min,
+  max,
+  onTempoChange,
+}: {
+  min: number;
+  max: number;
+  onTempoChange: (tempo: number) => void;
+}) {
+  const tapTimesRef = useRef<number[]>([]);
+
+  return () => {
+    const now = performance.now();
+    const tapTimes = tapTimesRef.current;
+    const lastTap = tapTimes.at(-1);
+
+    if (lastTap !== undefined && now - lastTap > RESET_AFTER_MS) {
+      tapTimes.length = 0;
+    }
+
+    tapTimes.push(now);
+    if (tapTimes.length > MAX_TAPS) {
+      tapTimes.shift();
+    }
+    if (tapTimes.length < 2) {
+      return;
+    }
+
+    const averageInterval =
+      (tapTimes.at(-1)! - tapTimes[0]) / (tapTimes.length - 1);
+    const tempo = Math.round(60000 / averageInterval);
+    if (tempo >= min && tempo <= max) {
+      onTempoChange(tempo);
+    }
+  };
+}


### PR DESCRIPTION
- part of https://github.com/hi-ogawa/toy-midi/issues/338

The standalone recorder needs the same quick tempo entry available in the main editor.

This PR adds a tap-tempo control to the recorder and shares the existing interval calculation between both editors. Taps reset after two seconds, average up to eight samples, and update tempo through the recorder runtime.