### PR TITLE
feat: persist recorder latency compensation

### DIFF
--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -444,6 +444,9 @@ function useRecorderInput({
       runtime.selectChannel(
         Math.min(preference.input?.channel ?? 0, channelCount - 1),
       );
+      runtime.setLatencyCompensation(
+        preference.input?.latencyCompensation ?? 0,
+      );
     },
   });
 

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -79,18 +79,12 @@ import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import { cn } from "../ui/utils";
 
 export function Recorder() {
-  const [preference] = useState(() => recorderStorage.readPreferences());
-  const [runtime] = useState(() => {
-    const runtime = new RecorderRuntime();
-    runtime.setLatencyCompensation(preference.input?.latencyCompensation ?? 0);
-    return runtime;
-  });
+  const [runtime] = useState(() => new RecorderRuntime());
   const state = useSyncExternalStore(
     runtime.store.subscribe,
     runtime.store.get,
   );
   const input = useRecorderInput({
-    preference,
     runtime,
     state,
   });
@@ -379,16 +373,16 @@ export function Recorder() {
 }
 
 function useRecorderInput({
-  preference: initialPreference,
   runtime,
   state,
 }: {
-  preference: ReturnType<typeof recorderStorage.readPreferences>;
   runtime: RecorderRuntime;
   state: RecorderRuntimeState;
 }) {
   const active = state.captureStatus !== "disabled";
-  const [preference, setPreference] = useState(initialPreference);
+  const [preference, setPreference] = useState(() =>
+    recorderStorage.readPreferences(),
+  );
   const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
   const [deviceId, setDeviceId] = useState(preference.input?.deviceId);
   const [peak, setPeak] = useState(0);

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -79,12 +79,18 @@ import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import { cn } from "../ui/utils";
 
 export function Recorder() {
-  const [runtime] = useState(() => new RecorderRuntime());
+  const [preference] = useState(() => recorderStorage.readPreferences());
+  const [runtime] = useState(() => {
+    const runtime = new RecorderRuntime();
+    runtime.setLatencyCompensation(preference.input?.latencyCompensation ?? 0);
+    return runtime;
+  });
   const state = useSyncExternalStore(
     runtime.store.subscribe,
     runtime.store.get,
   );
   const input = useRecorderInput({
+    preference,
     runtime,
     state,
   });
@@ -361,7 +367,7 @@ export function Recorder() {
             if (wasPlaying) {
               runtime.pause();
             }
-            runtime.setLatencyCompensation(compensation);
+            input.setLatencyCompensation(compensation);
             if (wasPlaying) {
               playMutation.mutate();
             }
@@ -373,16 +379,16 @@ export function Recorder() {
 }
 
 function useRecorderInput({
+  preference: initialPreference,
   runtime,
   state,
 }: {
+  preference: ReturnType<typeof recorderStorage.readPreferences>;
   runtime: RecorderRuntime;
   state: RecorderRuntimeState;
 }) {
   const active = state.captureStatus !== "disabled";
-  const [preference, setPreference] = useState(() =>
-    recorderStorage.readPreferences(),
-  );
+  const [preference, setPreference] = useState(initialPreference);
   const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
   const [deviceId, setDeviceId] = useState(preference.input?.deviceId);
   const [peak, setPeak] = useState(0);
@@ -482,7 +488,19 @@ function useRecorderInput({
       }
       const nextPreference = {
         ...preference,
-        input: { deviceId, channel },
+        input: { ...preference.input, deviceId, channel },
+      };
+      setPreference(nextPreference);
+      recorderStorage.writePreferences(nextPreference);
+    },
+    setLatencyCompensation: (latencyCompensation: number) => {
+      runtime.setLatencyCompensation(latencyCompensation);
+      if (!preference.input) {
+        return;
+      }
+      const nextPreference = {
+        ...preference,
+        input: { ...preference.input, latencyCompensation },
       };
       setPreference(nextPreference);
       recorderStorage.writePreferences(nextPreference);

--- a/src/lib/recorder/storage.ts
+++ b/src/lib/recorder/storage.ts
@@ -7,6 +7,7 @@ const recorderPreferencesSchema = z.object({
     .object({
       deviceId: z.string(),
       channel: z.number().int().nonnegative(),
+      latencyCompensation: z.number().nonnegative().optional(),
     })
     .optional(),
 });


### PR DESCRIPTION
Recorder latency compensation currently resets whenever the recorder is reopened, even though it is tied to the selected capture setup.

This PR stores latency compensation alongside the recorder input device and channel, initializes the runtime from that preference, and preserves it when the input channel changes. Selecting a different input starts with zero compensation.