### PR TITLE
fix: hide recorder timeline horizontal overflow

### DIFF
--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -824,7 +824,7 @@ function TimelineHeader({
   onSeek: (position: number) => void;
 }) {
   return (
-    <div className="sticky top-0 z-10 grid h-10 grid-cols-[13.5rem_minmax(0,1fr)] border-b border-neutral-700 bg-neutral-800">
+    <div className="sticky top-0 z-10 grid h-10 grid-cols-[13.5rem_1fr] border-b border-neutral-700 bg-neutral-800">
       <div className="sticky left-0 z-20 flex items-center border-r border-neutral-700 bg-neutral-800 px-3 text-xs font-semibold">
         <span>Tracks</span>
         <div className="flex-1" />
@@ -1016,7 +1016,7 @@ function TrackRow({
       : "size-7 border-neutral-600 text-neutral-300 hover:bg-neutral-700";
   return (
     <div
-      className="relative grid grid-cols-[13.5rem_minmax(0,1fr)] border-b border-neutral-700"
+      className="relative grid grid-cols-[13.5rem_1fr] border-b border-neutral-700"
       style={{ height }}
     >
       <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] gap-2 border-r border-neutral-700 bg-neutral-800 p-3">

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -195,7 +195,7 @@ export function Recorder() {
       />
 
       <div className="grid min-h-0 flex-1 grid-cols-[minmax(44rem,1fr)_18rem]">
-        <section className="relative min-w-0 overflow-auto border-r border-neutral-700">
+        <section className="relative min-w-0 overflow-x-hidden overflow-y-auto border-r border-neutral-700">
           <div
             ref={timeline.viewportRef}
             className="pointer-events-none absolute inset-y-0 left-[13.5rem] right-0"
@@ -824,7 +824,7 @@ function TimelineHeader({
   onSeek: (position: number) => void;
 }) {
   return (
-    <div className="sticky top-0 z-10 grid h-10 grid-cols-[13.5rem_1fr] border-b border-neutral-700 bg-neutral-800">
+    <div className="sticky top-0 z-10 grid h-10 grid-cols-[13.5rem_minmax(0,1fr)] border-b border-neutral-700 bg-neutral-800">
       <div className="sticky left-0 z-20 flex items-center border-r border-neutral-700 bg-neutral-800 px-3 text-xs font-semibold">
         <span>Tracks</span>
         <div className="flex-1" />
@@ -1016,7 +1016,7 @@ function TrackRow({
       : "size-7 border-neutral-600 text-neutral-300 hover:bg-neutral-700";
   return (
     <div
-      className="relative grid grid-cols-[13.5rem_1fr] border-b border-neutral-700"
+      className="relative grid grid-cols-[13.5rem_minmax(0,1fr)] border-b border-neutral-700"
       style={{ height }}
     >
       <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] gap-2 border-r border-neutral-700 bg-neutral-800 p-3">


### PR DESCRIPTION
The recorder timeline uses virtual horizontal navigation, but its container also allowed native horizontal scrolling, which exposed an unnecessary scrollbar.

This PR keeps the timeline container vertically scrollable while hiding native horizontal overflow.