### PR TITLE
fix: reorder editor tools

### DIFF
--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -5,7 +5,7 @@ import {
   HouseIcon,
   MoreVerticalIcon,
   SettingsIcon,
-  SlidersHorizontalIcon,
+  SlidersVerticalIcon,
   SparklesIcon,
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
@@ -133,7 +133,7 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
                   "bg-primary text-primary-foreground hover:bg-primary/90",
               )}
             >
-              <SlidersHorizontalIcon className="size-5" />
+              <SlidersVerticalIcon className="size-5" />
             </Button>
             <Button
               data-testid="score-preview-button"

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -123,6 +123,19 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
         controls={
           <>
             <Button
+              data-testid="mixer-button"
+              onClick={() => setIsMixerOpen((open) => !open)}
+              aria-pressed={isMixerOpen}
+              title="Mixer"
+              className={cn(
+                "size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+                isMixerOpen &&
+                  "bg-primary text-primary-foreground hover:bg-primary/90",
+              )}
+            >
+              <SlidersHorizontalIcon className="size-5" />
+            </Button>
+            <Button
               data-testid="score-preview-button"
               onClick={() => setIsScorePreviewOpen((open) => !open)}
               aria-pressed={isScorePreviewOpen}
@@ -142,19 +155,6 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
               className="size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
             >
               <SettingsIcon className="size-5" />
-            </Button>
-            <Button
-              data-testid="mixer-button"
-              onClick={() => setIsMixerOpen((open) => !open)}
-              aria-pressed={isMixerOpen}
-              title="Mixer"
-              className={cn(
-                "size-9 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-                isMixerOpen &&
-                  "bg-primary text-primary-foreground hover:bg-primary/90",
-              )}
-            >
-              <SlidersHorizontalIcon className="size-5" />
             </Button>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>


### PR DESCRIPTION
The Project control currently separates Mixer and Score even though both toggle live workspace panels, which makes the toolbar grouping feel inconsistent. The horizontal sliders icon can also read as generic settings rather than the vertical channel controls shown by the mixer.

This PR orders the editor tools as Mixer, Score, Project, and More, keeping the workspace panels together while leaving project-wide configuration and overflow actions at the end. It also uses Lucide's purpose-built vertical sliders icon for Mixer.