### PR TITLE
feat: add recorder auto-scroll

### DIFF
--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -555,10 +555,10 @@ function useRecorderTimeline({
     const playheadBeat = secondsToBeats(position, tempo);
     const visibleBeats = viewportWidth / pixelsPerBeat;
     if (
-      playheadBeat > viewportStartBeat + visibleBeats * 0.95 ||
+      playheadBeat > viewportStartBeat + visibleBeats * 0.9 ||
       playheadBeat < viewportStartBeat
     ) {
-      setViewportStartBeat(Math.max(0, playheadBeat - visibleBeats * 0.25));
+      setViewportStartBeat(Math.max(0, playheadBeat - visibleBeats * 0.1));
     }
   }, [
     autoScrollEnabled,

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -548,7 +548,6 @@ function useRecorderTimeline({
     (secondsToBeats(position, tempo) - viewportStartBeat) * pixelsPerBeat;
   const showPlayhead = playheadX >= 0 && playheadX <= viewportWidth;
 
-  // Let the playhead approach the right edge, then reveal the next 80% of the timeline.
   useEffect(() => {
     if (!isPlaying || !autoScrollEnabled || viewportWidth === 0) {
       return;
@@ -556,8 +555,8 @@ function useRecorderTimeline({
     const playheadBeat = secondsToBeats(position, tempo);
     const visibleBeats = viewportWidth / pixelsPerBeat;
     if (
-      playheadBeat > viewportStartBeat + visibleBeats * 0.9 ||
-      playheadBeat < viewportStartBeat
+      playheadBeat < viewportStartBeat ||
+      viewportStartBeat + visibleBeats * 0.9 < playheadBeat
     ) {
       setViewportStartBeat(Math.max(0, playheadBeat - visibleBeats * 0.1));
     }

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -555,10 +555,10 @@ function useRecorderTimeline({
     const playheadBeat = secondsToBeats(position, tempo);
     const visibleBeats = viewportWidth / pixelsPerBeat;
     if (
-      playheadBeat > viewportStartBeat + visibleBeats * 0.8 ||
+      playheadBeat > viewportStartBeat + visibleBeats * 0.95 ||
       playheadBeat < viewportStartBeat
     ) {
-      setViewportStartBeat(Math.max(0, playheadBeat - visibleBeats * 0.2));
+      setViewportStartBeat(Math.max(0, playheadBeat - visibleBeats * 0.25));
     }
   }, [
     autoScrollEnabled,

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -737,8 +737,8 @@ function RecorderHeader({
         className={cn(
           "size-9",
           metronomeEnabled
-            ? "bg-neutral-700 text-emerald-400 hover:bg-neutral-700"
-            : "text-neutral-400 hover:bg-neutral-700 hover:text-neutral-100",
+            ? "bg-neutral-700 text-neutral-100 hover:bg-neutral-700"
+            : "text-neutral-500 hover:bg-neutral-700 hover:text-neutral-200",
         )}
       >
         <MetronomeIcon className="size-5" />
@@ -750,8 +750,8 @@ function RecorderHeader({
         className={cn(
           "size-9",
           autoScrollEnabled
-            ? "bg-neutral-700 text-emerald-400 hover:bg-neutral-700"
-            : "text-neutral-400 hover:bg-neutral-700 hover:text-neutral-100",
+            ? "bg-neutral-700 text-neutral-100 hover:bg-neutral-700"
+            : "text-neutral-500 hover:bg-neutral-700 hover:text-neutral-200",
         )}
       >
         <LocateFixedIcon className="size-5" />

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -6,6 +6,7 @@ import {
   CircleStopIcon,
   HouseIcon,
   LoaderCircleIcon,
+  LocateFixedIcon,
   Mic2Icon,
   MoreVerticalIcon,
   PauseIcon,
@@ -90,6 +91,7 @@ export function Recorder() {
     state,
   });
   const timeline = useRecorderTimeline({
+    isPlaying: state.isPlaying,
     position: state.position,
     tempo: state.tempo,
     timeSignature: state.timeSignature,
@@ -169,6 +171,9 @@ export function Recorder() {
     } else if (matchKeyboardEvent(event, "M")) {
       event.preventDefault();
       runtime.setMetronomeEnabled(!state.metronomeEnabled);
+    } else if (matchKeyboardEvent(event, "F")) {
+      event.preventDefault();
+      timeline.setAutoScrollEnabled(!timeline.autoScrollEnabled);
     }
   });
 
@@ -178,6 +183,7 @@ export function Recorder() {
         isPlaying={state.isPlaying}
         isProcessing={isProcessing}
         isRecording={isRecording}
+        autoScrollEnabled={timeline.autoScrollEnabled}
         metronomeEnabled={state.metronomeEnabled}
         position={state.position}
         tempo={timeline.tempo}
@@ -186,6 +192,7 @@ export function Recorder() {
         recordDisabled={state.captureStatus === "disabled"}
         onPlayToggle={togglePlay}
         onRecordToggle={toggleRecord}
+        onAutoScrollChange={timeline.setAutoScrollEnabled}
         onTempoChange={(tempo) => runtime.setTempo(tempo)}
         onMetronomeChange={(enabled) => runtime.setMetronomeEnabled(enabled)}
         onTimeSignatureChange={(timeSignature) =>
@@ -518,10 +525,12 @@ function useRecorderInput({
 }
 
 function useRecorderTimeline({
+  isPlaying,
   position,
   tempo,
   timeSignature,
 }: {
+  isPlaying: boolean;
   position: number;
   tempo: number;
   timeSignature: TimeSignature;
@@ -529,6 +538,7 @@ function useRecorderTimeline({
   const [gridDivision, setGridDivision] = useState<GridDivision>(
     DEFAULT_GRID_DIVISION,
   );
+  const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
   const [pixelsPerBeat, setPixelsPerBeat] = useState(DEFAULT_PIXELS_PER_BEAT);
   const [viewportStartBeat, setViewportStartBeat] = useState(0);
   const [viewportWidth, setViewportWidth] = useState(0);
@@ -537,6 +547,28 @@ function useRecorderTimeline({
   const playheadX =
     (secondsToBeats(position, tempo) - viewportStartBeat) * pixelsPerBeat;
   const showPlayhead = playheadX >= 0 && playheadX <= viewportWidth;
+
+  useEffect(() => {
+    if (!isPlaying || !autoScrollEnabled || viewportWidth === 0) {
+      return;
+    }
+    const playheadBeat = secondsToBeats(position, tempo);
+    const visibleBeats = viewportWidth / pixelsPerBeat;
+    if (
+      playheadBeat > viewportStartBeat + visibleBeats * 0.8 ||
+      playheadBeat < viewportStartBeat
+    ) {
+      setViewportStartBeat(Math.max(0, playheadBeat - visibleBeats * 0.2));
+    }
+  }, [
+    autoScrollEnabled,
+    isPlaying,
+    pixelsPerBeat,
+    position,
+    tempo,
+    viewportStartBeat,
+    viewportWidth,
+  ]);
 
   function zoom(nextPixelsPerBeat: number, anchorX: number) {
     const beatAtAnchor = anchorX / pixelsPerBeat + viewportStartBeat;
@@ -588,12 +620,14 @@ function useRecorderTimeline({
   );
 
   return {
+    autoScrollEnabled,
     beatsPerBar,
     gridDivision,
     pixelsPerBeat,
     playheadX,
     viewportStartBeat,
     setGridDivision,
+    setAutoScrollEnabled,
     subdivisionsPerBeat,
     tempo,
     timeSignature,
@@ -604,6 +638,7 @@ function useRecorderTimeline({
 }
 
 function RecorderHeader({
+  autoScrollEnabled,
   isPlaying,
   isProcessing,
   isRecording,
@@ -615,11 +650,13 @@ function RecorderHeader({
   recordDisabled,
   onPlayToggle,
   onRecordToggle,
+  onAutoScrollChange,
   onTempoChange,
   onMetronomeChange,
   onTimeSignatureChange,
   onGridDivisionChange,
 }: {
+  autoScrollEnabled: boolean;
   isPlaying: boolean;
   isProcessing: boolean;
   isRecording: boolean;
@@ -631,6 +668,7 @@ function RecorderHeader({
   recordDisabled: boolean;
   onPlayToggle: () => void;
   onRecordToggle: () => void;
+  onAutoScrollChange: (enabled: boolean) => void;
   onTempoChange: (tempo: number) => void;
   onMetronomeChange: (enabled: boolean) => void;
   onTimeSignatureChange: (value: string) => void;
@@ -684,6 +722,19 @@ function RecorderHeader({
         )}
       >
         <MetronomeIcon className="size-5" />
+      </Button>
+      <Button
+        onClick={() => onAutoScrollChange(!autoScrollEnabled)}
+        aria-pressed={autoScrollEnabled}
+        title="Toggle auto-scroll (F)"
+        className={cn(
+          "size-9",
+          autoScrollEnabled
+            ? "bg-primary text-primary-foreground hover:bg-primary/90"
+            : "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        )}
+      >
+        <LocateFixedIcon className="size-5" />
       </Button>
       <Button
         data-testid="recorder-record-button"

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -620,25 +620,24 @@ function useRecorderTimeline({
   );
 
   return {
-    autoScrollEnabled,
     beatsPerBar,
     gridDivision,
     pixelsPerBeat,
     playheadX,
     viewportStartBeat,
     setGridDivision,
-    setAutoScrollEnabled,
     subdivisionsPerBeat,
     tempo,
     timeSignature,
     viewportRef,
     viewportWidth,
     showPlayhead,
+    autoScrollEnabled,
+    setAutoScrollEnabled,
   };
 }
 
 function RecorderHeader({
-  autoScrollEnabled,
   isPlaying,
   isProcessing,
   isRecording,
@@ -648,6 +647,7 @@ function RecorderHeader({
   timeSignature,
   gridDivision,
   recordDisabled,
+  autoScrollEnabled,
   onPlayToggle,
   onRecordToggle,
   onAutoScrollChange,
@@ -656,7 +656,6 @@ function RecorderHeader({
   onTimeSignatureChange,
   onGridDivisionChange,
 }: {
-  autoScrollEnabled: boolean;
   isPlaying: boolean;
   isProcessing: boolean;
   isRecording: boolean;
@@ -666,6 +665,7 @@ function RecorderHeader({
   timeSignature: TimeSignature;
   gridDivision: GridDivision;
   recordDisabled: boolean;
+  autoScrollEnabled: boolean;
   onPlayToggle: () => void;
   onRecordToggle: () => void;
   onAutoScrollChange: (enabled: boolean) => void;

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -737,8 +737,8 @@ function RecorderHeader({
         className={cn(
           "size-9",
           metronomeEnabled
-            ? "bg-primary text-primary-foreground hover:bg-primary/90"
-            : "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+            ? "bg-neutral-700 text-emerald-400 hover:bg-neutral-700"
+            : "text-neutral-400 hover:bg-neutral-700 hover:text-neutral-100",
         )}
       >
         <MetronomeIcon className="size-5" />
@@ -750,8 +750,8 @@ function RecorderHeader({
         className={cn(
           "size-9",
           autoScrollEnabled
-            ? "bg-primary text-primary-foreground hover:bg-primary/90"
-            : "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+            ? "bg-neutral-700 text-emerald-400 hover:bg-neutral-700"
+            : "text-neutral-400 hover:bg-neutral-700 hover:text-neutral-100",
         )}
       >
         <LocateFixedIcon className="size-5" />

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -711,6 +711,26 @@ function RecorderHeader({
         )}
       </Button>
       <Button
+        data-testid="recorder-record-button"
+        onClick={onRecordToggle}
+        disabled={recordDisabled || isProcessing}
+        aria-pressed={isRecording}
+        className={cn(
+          "size-9",
+          isRecording
+            ? "bg-red-600 text-white hover:bg-red-500"
+            : "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        )}
+        title={isRecording ? "Stop recording (R)" : "Record (R)"}
+      >
+        {isRecording ? (
+          <CircleStopIcon className="size-5" />
+        ) : (
+          <CircleIcon className="size-4 fill-current" />
+        )}
+      </Button>
+      <div className="mx-1 h-5 w-px bg-neutral-600" />
+      <Button
         onClick={() => onMetronomeChange(!metronomeEnabled)}
         aria-pressed={metronomeEnabled}
         title="Toggle metronome (M)"
@@ -736,26 +756,6 @@ function RecorderHeader({
       >
         <LocateFixedIcon className="size-5" />
       </Button>
-      <Button
-        data-testid="recorder-record-button"
-        onClick={onRecordToggle}
-        disabled={recordDisabled || isProcessing}
-        aria-pressed={isRecording}
-        className={cn(
-          "size-9",
-          isRecording
-            ? "bg-red-600 text-white hover:bg-red-500"
-            : "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        )}
-        title={isRecording ? "Stop recording (R)" : "Record (R)"}
-      >
-        {isRecording ? (
-          <CircleStopIcon className="size-5" />
-        ) : (
-          <CircleIcon className="size-4 fill-current" />
-        )}
-      </Button>
-      <div className="mx-1 h-5 w-px bg-neutral-600" />
       <output
         data-testid="recorder-position"
         className="font-mono text-sm tabular-nums text-neutral-300"

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -548,6 +548,7 @@ function useRecorderTimeline({
     (secondsToBeats(position, tempo) - viewportStartBeat) * pixelsPerBeat;
   const showPlayhead = playheadX >= 0 && playheadX <= viewportWidth;
 
+  // Let the playhead approach the right edge, then reveal the next 80% of the timeline.
   useEffect(() => {
     if (!isPlaying || !autoScrollEnabled || viewportWidth === 0) {
       return;


### PR DESCRIPTION
The recorder playhead can leave the visible timeline during playback or recording, which makes it hard to follow the current position on longer takes.

This PR adds a recorder-local auto-scroll toggle, enabled by default and available with the same `F` shortcut as the main editor. During playback, the timeline advances when the playhead crosses 80% of the viewport and places it back near 20%, while disabling the toggle leaves manual navigation untouched.