### PR TITLE
fix: keep loaded recorder projects clean

### DIFF
--- a/e2e/fake-audio/recorder-persistence.test.ts
+++ b/e2e/fake-audio/recorder-persistence.test.ts
@@ -5,6 +5,9 @@ test("saves and restores a recorder project", async ({ page }) => {
   // The musician creates a project and gives it a recognizable name.
   await createRecorderProject(page);
   const projectUrl = page.url();
+  await page.getByRole("button", { name: "More" }).click();
+  await expect(page.getByRole("menuitem", { name: /Save/ })).toBeDisabled();
+  await page.keyboard.press("Escape");
 
   page.once("dialog", (dialog) => dialog.accept("Practice take"));
   await page.getByTestId("recorder-project-name").click();

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -455,8 +455,11 @@ function useRecorderProject({
   });
 
   useEffect(() => {
-    runtime.store.subscribe(() => setDirty(true));
-  }, [runtime]);
+    if (!projectQuery.isSuccess) {
+      return;
+    }
+    return runtime.store.subscribe(() => setDirty(true));
+  }, [projectQuery.isSuccess, runtime]);
 
   useWindowEvent("beforeunload", (event) => {
     if (dirty) {


### PR DESCRIPTION
- follow-up to https://github.com/hi-ogawa/toy-midi/pull/306

Opening a recorder project currently marks it dirty because the store subscription observes the initial persistence hydration. This PR starts dirty tracking only after the project query succeeds, so a freshly opened project remains clean while subsequent edits still enable Save.