### PR TITLE
feat: show recorder save status

### DIFF
--- a/e2e/fake-audio/recorder-persistence.test.ts
+++ b/e2e/fake-audio/recorder-persistence.test.ts
@@ -5,6 +5,9 @@ test("saves and restores a recorder project", async ({ page }) => {
   // The musician creates a project and gives it a recognizable name.
   await createRecorderProject(page);
   const projectUrl = page.url();
+  await expect(
+    page.getByRole("status", { name: "All changes saved" }),
+  ).toBeVisible();
   await page.getByRole("button", { name: "More" }).click();
   await expect(page.getByRole("menuitem", { name: /Save/ })).toBeDisabled();
   await page.keyboard.press("Escape");
@@ -27,10 +30,18 @@ test("saves and restores a recorder project", async ({ page }) => {
   // Editing marks the project dirty, and Ctrl+S saves it without browser UI.
   await page.getByTestId("recorder-tempo-input").fill("140");
   await page.getByTestId("recorder-tempo-input").press("Enter");
+  await expect(
+    page.getByRole("status", {
+      name: "Unsaved changes (Ctrl/Cmd+S to save)",
+    }),
+  ).toBeVisible();
   await page.getByRole("button", { name: "More" }).click();
   await expect(page.getByRole("menuitem", { name: /Save/ })).toBeEnabled();
   await page.keyboard.press("Escape");
   await page.keyboard.press("Control+S");
+  await expect(
+    page.getByRole("status", { name: "All changes saved" }),
+  ).toBeVisible();
   await page.getByRole("button", { name: "More" }).click();
   await expect(page.getByRole("menuitem", { name: /Save/ })).toBeDisabled();
 

--- a/e2e/fake-audio/recorder-persistence.test.ts
+++ b/e2e/fake-audio/recorder-persistence.test.ts
@@ -6,10 +6,10 @@ test("saves and restores a recorder project", async ({ page }) => {
   await createRecorderProject(page);
   const projectUrl = page.url();
   await expect(
-    page.getByRole("status", { name: "All changes saved" }),
-  ).toBeVisible();
+    page.getByRole("button", { name: "All changes saved" }),
+  ).toBeDisabled();
   await page.getByRole("button", { name: "More" }).click();
-  await expect(page.getByRole("menuitem", { name: /Save/ })).toBeDisabled();
+  await expect(page.getByRole("menuitem", { name: /Save/ })).toHaveCount(0);
   await page.keyboard.press("Escape");
 
   page.once("dialog", (dialog) => dialog.accept("Practice take"));
@@ -31,19 +31,19 @@ test("saves and restores a recorder project", async ({ page }) => {
   await page.getByTestId("recorder-tempo-input").fill("140");
   await page.getByTestId("recorder-tempo-input").press("Enter");
   await expect(
-    page.getByRole("status", {
+    page.getByRole("button", {
       name: "Unsaved changes (Ctrl/Cmd+S to save)",
     }),
-  ).toBeVisible();
+  ).toBeEnabled();
   await page.getByRole("button", { name: "More" }).click();
-  await expect(page.getByRole("menuitem", { name: /Save/ })).toBeEnabled();
+  await expect(page.getByRole("menuitem", { name: /Save/ })).toHaveCount(0);
   await page.keyboard.press("Escape");
-  await page.keyboard.press("Control+S");
+  await page
+    .getByRole("button", { name: "Unsaved changes (Ctrl/Cmd+S to save)" })
+    .click();
   await expect(
-    page.getByRole("status", { name: "All changes saved" }),
-  ).toBeVisible();
-  await page.getByRole("button", { name: "More" }).click();
-  await expect(page.getByRole("menuitem", { name: /Save/ })).toBeDisabled();
+    page.getByRole("button", { name: "All changes saved" }),
+  ).toBeDisabled();
 
   // Reload restores document fields and PCM-backed waveform data.
   await page.reload();

--- a/e2e/fake-audio/recorder-persistence.test.ts
+++ b/e2e/fake-audio/recorder-persistence.test.ts
@@ -7,10 +7,7 @@ test("saves and restores a recorder project", async ({ page }) => {
   const projectUrl = page.url();
   await expect(
     page.getByRole("button", { name: "All changes saved" }),
-  ).toBeDisabled();
-  await page.getByRole("button", { name: "More" }).click();
-  await expect(page.getByRole("menuitem", { name: /Save/ })).toHaveCount(0);
-  await page.keyboard.press("Escape");
+  ).toHaveAttribute("aria-disabled", "true");
 
   page.once("dialog", (dialog) => dialog.accept("Practice take"));
   await page.getByTestId("recorder-project-name").click();
@@ -35,15 +32,12 @@ test("saves and restores a recorder project", async ({ page }) => {
       name: "Unsaved changes (Ctrl/Cmd+S to save)",
     }),
   ).toBeEnabled();
-  await page.getByRole("button", { name: "More" }).click();
-  await expect(page.getByRole("menuitem", { name: /Save/ })).toHaveCount(0);
-  await page.keyboard.press("Escape");
   await page
     .getByRole("button", { name: "Unsaved changes (Ctrl/Cmd+S to save)" })
     .click();
   await expect(
     page.getByRole("button", { name: "All changes saved" }),
-  ).toBeDisabled();
+  ).toHaveAttribute("aria-disabled", "true");
 
   // Reload restores document fields and PCM-backed waveform data.
   await page.reload();

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@tonejs/midi": "^2.0.28",
     "cmdk": "^1.1.1",
     "jszip": "^3.10.1",
-    "lucide-react": "^0.562.0",
+    "lucide-react": "^1.33.0",
     "opensheetmusicdisplay": "^2.1.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^3.10.1
         version: 3.10.1
       lucide-react:
-        specifier: ^0.562.0
-        version: 0.562.0(react@19.2.8)
+        specifier: ^1.33.0
+        version: 1.33.0(react@19.2.8)
       opensheetmusicdisplay:
         specifier: ^2.1.1
         version: 2.1.2
@@ -1571,8 +1571,8 @@ packages:
     resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
     engines: {node: '>= 0.6.0'}
 
-  lucide-react@0.562.0:
-    resolution: {integrity: sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==}
+  lucide-react@1.33.0:
+    resolution: {integrity: sha512-MTRwMy0ZlL8Ur/vOAiJ9XGHE+kFPC7brq6MxAm0GiGXEBj0qy0jA/pG4N675oSzciO/UCdX8T+5yUQdmDeTLxg==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -3188,7 +3188,7 @@ snapshots:
 
   loglevel@1.9.2: {}
 
-  lucide-react@0.562.0(react@19.2.8):
+  lucide-react@1.33.0(react@19.2.8):
     dependencies:
       react: 19.2.8
 

--- a/src/components/project-list-view.tsx
+++ b/src/components/project-list-view.tsx
@@ -1,7 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import {
   AudioLinesIcon,
-  Github,
+  GitForkIcon,
   Mic2Icon,
   Music2Icon,
   Pencil,
@@ -120,7 +120,7 @@ export function ProjectListView({
               rel="noreferrer"
               className="inline-flex items-center gap-1.5 hover:text-emerald-400 transition-colors"
             >
-              <Github className="size-4" />
+              <GitForkIcon className="size-4" />
               GitHub
             </a>
           </nav>

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1037,22 +1037,21 @@ function RecorderSaveButton({
     error: <CircleAlertIcon className="size-3.5" />,
   }[status];
   return (
-    <button
-      type="button"
+    <Button
       aria-label={label}
       title={label}
-      disabled={disabled}
-      onClick={onSave}
+      disabled={disabled && status !== "saved"}
+      onClick={status === "saved" ? undefined : onSave}
       className={cn(
-        "grid size-6 place-items-center disabled:cursor-default",
-        status === "saved" && "text-neutral-600",
-        status === "unsaved" && "text-neutral-400",
-        status === "saving" && "text-neutral-500",
-        status === "error" && "text-red-400",
+        "size-8 border-transparent bg-transparent hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        status === "saved" && "text-neutral-500",
+        status === "unsaved" && "text-neutral-300",
+        status === "saving" && "text-neutral-400",
+        status === "error" && "text-red-400 hover:text-red-300",
       )}
     >
       {icon}
-    </button>
+    </Button>
   );
 }
 

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -93,6 +93,8 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import { cn } from "../ui/utils";
 
+type SaveStatus = "saved" | "unsaved" | "saving" | "error";
+
 export function Recorder({ projectId }: { projectId: string }) {
   const [runtime] = useState(() => new RecorderRuntime());
   const state = useSyncExternalStore(
@@ -445,7 +447,6 @@ function useRecorderProject({
   projectId: string;
   runtime: RecorderRuntime;
 }) {
-  type SaveStatus = "saved" | "unsaved" | "saving" | "error";
   const [dirty, setDirty] = useState(false);
   const revisionRef = useRef(0);
 
@@ -788,7 +789,7 @@ function RecorderHeader({
   onGridDivisionChange,
 }: {
   title: string;
-  saveStatus: "saved" | "unsaved" | "saving" | "error";
+  saveStatus: SaveStatus;
   isPlaying: boolean;
   isProcessing: boolean;
   isRecording: boolean;
@@ -1012,7 +1013,7 @@ function RecorderSaveButton({
   status,
   onSave,
 }: {
-  status: "saved" | "unsaved" | "saving" | "error";
+  status: SaveStatus;
   onSave: () => void;
 }) {
   const canSave = status === "unsaved" || status === "error";

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -93,8 +93,6 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import { cn } from "../ui/utils";
 
-type SaveStatus = "saved" | "unsaved" | "saving" | "error";
-
 export function Recorder({ projectId }: { projectId: string }) {
   const [runtime] = useState(() => new RecorderRuntime());
   const state = useSyncExternalStore(
@@ -439,6 +437,8 @@ export function Recorder({ projectId }: { projectId: string }) {
     </main>
   );
 }
+
+type SaveStatus = "saved" | "unsaved" | "saving" | "error";
 
 function useRecorderProject({
   projectId,

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -211,7 +211,6 @@ export function Recorder({ projectId }: { projectId: string }) {
       <RecorderHeader
         title={state.title}
         saveStatus={project.saveStatus}
-        saveDisabled={saveDisabled}
         isPlaying={state.isPlaying}
         isProcessing={isProcessing}
         isRecording={isRecording}
@@ -768,7 +767,6 @@ function useRecorderTimeline({
 function RecorderHeader({
   title,
   saveStatus,
-  saveDisabled,
   isPlaying,
   isProcessing,
   isRecording,
@@ -791,7 +789,6 @@ function RecorderHeader({
 }: {
   title: string;
   saveStatus: "saved" | "unsaved" | "saving" | "error";
-  saveDisabled: boolean;
   isPlaying: boolean;
   isProcessing: boolean;
   isRecording: boolean;
@@ -966,11 +963,7 @@ function RecorderHeader({
         </DropdownMenuContent>
       </DropdownMenu>
       <div className="flex-1" />
-      <RecorderSaveButton
-        status={saveStatus}
-        disabled={saveDisabled}
-        onSave={onSave}
-      />
+      <RecorderSaveButton status={saveStatus} onSave={onSave} />
       <button
         type="button"
         data-testid="recorder-project-name"
@@ -1017,13 +1010,12 @@ function RecorderHeader({
 
 function RecorderSaveButton({
   status,
-  disabled,
   onSave,
 }: {
   status: "saved" | "unsaved" | "saving" | "error";
-  disabled: boolean;
   onSave: () => void;
 }) {
+  const canSave = status === "unsaved" || status === "error";
   const label = {
     saved: "All changes saved",
     unsaved: "Unsaved changes (Ctrl/Cmd+S to save)",
@@ -1040,8 +1032,8 @@ function RecorderSaveButton({
     <Button
       aria-label={label}
       title={label}
-      disabled={disabled && status !== "saved"}
-      onClick={status === "saved" ? undefined : onSave}
+      aria-disabled={!canSave}
+      onClick={canSave ? onSave : undefined}
       className={cn(
         "size-8 border-transparent bg-transparent hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         status === "saved" && "text-neutral-500",

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1,6 +1,8 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   ChevronDownIcon,
+  CheckIcon,
+  CircleAlertIcon,
   CircleIcon,
   CircleHelpIcon,
   CircleStopIcon,
@@ -17,7 +19,13 @@ import {
   Trash2Icon,
   UploadIcon,
 } from "lucide-react";
-import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { useDraftInput } from "../../hooks/use-draft-input";
 import { usePointerDrag } from "../../hooks/use-pointer-drag";
 import { useTapTempo } from "../../hooks/use-tap-tempo";
@@ -198,6 +206,7 @@ export function Recorder({ projectId }: { projectId: string }) {
         dirty={project.dirty}
         projectReady={project.ready}
         savePending={project.saving}
+        saveStatus={project.saveStatus}
         isPlaying={state.isPlaying}
         isProcessing={isProcessing}
         isRecording={isRecording}
@@ -432,7 +441,9 @@ function useRecorderProject({
   projectId: string;
   runtime: RecorderRuntime;
 }) {
+  type SaveStatus = "saved" | "unsaved" | "saving" | "error";
   const [dirty, setDirty] = useState(false);
+  const revisionRef = useRef(0);
 
   const projectQuery = useQuery({
     queryKey: ["recorder-project", projectId],
@@ -446,19 +457,27 @@ function useRecorderProject({
   });
 
   const saveMutation = useMutation({
-    mutationFn: () =>
-      recorderProjectStorage.save({
+    mutationFn: async () => {
+      const revision = revisionRef.current;
+      await recorderProjectStorage.save({
         id: projectId,
         content: runtime.serializeProject(),
-      }),
-    onSuccess: () => setDirty(false),
+      });
+      return revision;
+    },
+    onSuccess: (savedRevision) => {
+      setDirty(revisionRef.current !== savedRevision);
+    },
   });
 
   useEffect(() => {
     if (!projectQuery.isSuccess) {
       return;
     }
-    return runtime.store.subscribe(() => setDirty(true));
+    return runtime.store.subscribe(() => {
+      revisionRef.current += 1;
+      setDirty(true);
+    });
   }, [projectQuery.isSuccess, runtime]);
 
   useWindowEvent("beforeunload", (event) => {
@@ -467,11 +486,19 @@ function useRecorderProject({
     }
   });
 
+  const saveStatus: SaveStatus = saveMutation.isError
+    ? "error"
+    : saveMutation.isPending
+      ? "saving"
+      : dirty
+        ? "unsaved"
+        : "saved";
   return {
     dirty,
     error: projectQuery.error ?? saveMutation.error,
     ready: projectQuery.isSuccess || projectQuery.isError,
     save: saveMutation.mutate,
+    saveStatus,
     saving: saveMutation.isPending,
   };
 }
@@ -738,6 +765,7 @@ function RecorderHeader({
   dirty,
   projectReady,
   savePending,
+  saveStatus,
   isPlaying,
   isProcessing,
   isRecording,
@@ -762,6 +790,7 @@ function RecorderHeader({
   dirty: boolean;
   projectReady: boolean;
   savePending: boolean;
+  saveStatus: "saved" | "unsaved" | "saving" | "error";
   isPlaying: boolean;
   isProcessing: boolean;
   isRecording: boolean;
@@ -936,6 +965,7 @@ function RecorderHeader({
         </DropdownMenuContent>
       </DropdownMenu>
       <div className="flex-1" />
+      <RecorderSaveStatus status={saveStatus} />
       <button
         type="button"
         data-testid="recorder-project-name"
@@ -992,6 +1022,41 @@ function RecorderHeader({
         </DropdownMenuContent>
       </DropdownMenu>
     </header>
+  );
+}
+
+function RecorderSaveStatus({
+  status,
+}: {
+  status: "saved" | "unsaved" | "saving" | "error";
+}) {
+  const label = {
+    saved: "All changes saved",
+    unsaved: "Unsaved changes (Ctrl/Cmd+S to save)",
+    saving: "Saving project",
+    error: "Save failed (Ctrl/Cmd+S to retry)",
+  }[status];
+  const icon = {
+    saved: <CheckIcon className="size-3.5" />,
+    unsaved: <CircleIcon className="size-3.5 fill-current" />,
+    saving: <LoaderCircleIcon className="size-3.5 animate-spin" />,
+    error: <CircleAlertIcon className="size-3.5" />,
+  }[status];
+  return (
+    <span
+      role="status"
+      aria-label={label}
+      title={label}
+      className={cn(
+        "grid size-6 place-items-center",
+        status === "saved" && "text-neutral-500",
+        status === "unsaved" && "text-amber-400",
+        status === "saving" && "text-neutral-300",
+        status === "error" && "text-red-400",
+      )}
+    >
+      {icon}
+    </span>
   );
 }
 

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   ChevronDownIcon,
-  CheckIcon,
+  createLucideIcon,
   CircleAlertIcon,
   CircleIcon,
   CircleHelpIcon,
@@ -30,6 +30,19 @@ import { useDraftInput } from "../../hooks/use-draft-input";
 import { usePointerDrag } from "../../hooks/use-pointer-drag";
 import { useTapTempo } from "../../hooks/use-tap-tempo";
 import { useWindowEvent } from "../../hooks/use-window-event";
+
+const SaveCheckIcon = createLucideIcon("SaveCheck", [
+  [
+    "path",
+    {
+      d: "M15.2 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V8.8Z",
+      key: "1cqn1j",
+    },
+  ],
+  ["path", { d: "M17 21v-8H7v8", key: "1ydtos" }],
+  ["path", { d: "M7 3v5h8", key: "1pvjzy" }],
+  ["path", { d: "m9 13 2 2 4-4", key: "634lzl" }],
+]);
 import { resolveAudioFiles } from "../../lib/audio-files";
 import { AudioView } from "../../lib/audio-view";
 import { buildExportFileName, downloadBlob } from "../../lib/export-utils";
@@ -173,10 +186,17 @@ export function Recorder({ projectId }: { projectId: string }) {
     recordMutation.mutate(isRecording ? "stop" : "start");
   }
 
+  const saveDisabled =
+    !project.ready ||
+    !project.dirty ||
+    project.saving ||
+    isRecording ||
+    isProcessing;
+
   useWindowEvent("keydown", (event) => {
     if (matchKeyboardEvent(event, "Ctrl+S") && !event.repeat) {
       event.preventDefault();
-      if (project.ready && project.dirty && !project.saving) {
+      if (!saveDisabled) {
         project.save();
       }
       return;
@@ -203,10 +223,8 @@ export function Recorder({ projectId }: { projectId: string }) {
     <main className="flex h-screen flex-col overflow-hidden bg-neutral-900 text-neutral-100">
       <RecorderHeader
         title={state.title}
-        dirty={project.dirty}
-        projectReady={project.ready}
-        savePending={project.saving}
         saveStatus={project.saveStatus}
+        saveDisabled={saveDisabled}
         isPlaying={state.isPlaying}
         isProcessing={isProcessing}
         isRecording={isRecording}
@@ -762,10 +780,8 @@ function useRecorderTimeline({
 
 function RecorderHeader({
   title,
-  dirty,
-  projectReady,
-  savePending,
   saveStatus,
+  saveDisabled,
   isPlaying,
   isProcessing,
   isRecording,
@@ -787,10 +803,8 @@ function RecorderHeader({
   onGridDivisionChange,
 }: {
   title: string;
-  dirty: boolean;
-  projectReady: boolean;
-  savePending: boolean;
   saveStatus: "saved" | "unsaved" | "saving" | "error";
+  saveDisabled: boolean;
   isPlaying: boolean;
   isProcessing: boolean;
   isRecording: boolean;
@@ -965,7 +979,11 @@ function RecorderHeader({
         </DropdownMenuContent>
       </DropdownMenu>
       <div className="flex-1" />
-      <RecorderSaveStatus status={saveStatus} />
+      <RecorderSaveButton
+        status={saveStatus}
+        disabled={saveDisabled}
+        onSave={onSave}
+      />
       <button
         type="button"
         data-testid="recorder-project-name"
@@ -992,21 +1010,6 @@ function RecorderHeader({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem
-            onSelect={onSave}
-            disabled={
-              !projectReady ||
-              !dirty ||
-              isRecording ||
-              isProcessing ||
-              savePending
-            }
-          >
-            <SaveIcon />
-            Save
-            <span className="ml-auto text-xs text-neutral-500">Ctrl+S</span>
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
           <DropdownMenuItem asChild>
             <a href={routes.home.href()}>
               <HouseIcon />
@@ -1025,30 +1028,36 @@ function RecorderHeader({
   );
 }
 
-function RecorderSaveStatus({
+function RecorderSaveButton({
   status,
+  disabled,
+  onSave,
 }: {
   status: "saved" | "unsaved" | "saving" | "error";
+  disabled: boolean;
+  onSave: () => void;
 }) {
   const label = {
     saved: "All changes saved",
     unsaved: "Unsaved changes (Ctrl/Cmd+S to save)",
     saving: "Saving project",
-    error: "Save failed (Ctrl/Cmd+S to retry)",
+    error: "Save failed (click or Ctrl/Cmd+S to retry)",
   }[status];
   const icon = {
-    saved: <CheckIcon className="size-3.5" />,
-    unsaved: <CircleIcon className="size-3.5 fill-current" />,
+    saved: <SaveCheckIcon className="size-4" />,
+    unsaved: <SaveIcon className="size-4" />,
     saving: <LoaderCircleIcon className="size-3.5 animate-spin" />,
     error: <CircleAlertIcon className="size-3.5" />,
   }[status];
   return (
-    <span
-      role="status"
+    <button
+      type="button"
       aria-label={label}
       title={label}
+      disabled={disabled}
+      onClick={onSave}
       className={cn(
-        "grid size-6 place-items-center",
+        "grid size-6 place-items-center disabled:cursor-default",
         status === "saved" && "text-neutral-600",
         status === "unsaved" && "text-neutral-400",
         status === "saving" && "text-neutral-500",
@@ -1056,7 +1065,7 @@ function RecorderSaveStatus({
       )}
     >
       {icon}
-    </span>
+    </button>
   );
 }
 

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1049,9 +1049,9 @@ function RecorderSaveStatus({
       title={label}
       className={cn(
         "grid size-6 place-items-center",
-        status === "saved" && "text-neutral-500",
-        status === "unsaved" && "text-amber-400",
-        status === "saving" && "text-neutral-300",
+        status === "saved" && "text-neutral-600",
+        status === "unsaved" && "text-neutral-400",
+        status === "saving" && "text-neutral-500",
         status === "error" && "text-red-400",
       )}
     >

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1,7 +1,6 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   ChevronDownIcon,
-  createLucideIcon,
   CircleAlertIcon,
   CircleIcon,
   CircleHelpIcon,
@@ -16,6 +15,7 @@ import {
   PlayIcon,
   PlusIcon,
   SaveIcon,
+  SaveCheckIcon,
   Trash2Icon,
   UploadIcon,
 } from "lucide-react";
@@ -30,19 +30,6 @@ import { useDraftInput } from "../../hooks/use-draft-input";
 import { usePointerDrag } from "../../hooks/use-pointer-drag";
 import { useTapTempo } from "../../hooks/use-tap-tempo";
 import { useWindowEvent } from "../../hooks/use-window-event";
-
-const SaveCheckIcon = createLucideIcon("SaveCheck", [
-  [
-    "path",
-    {
-      d: "M15.2 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V8.8Z",
-      key: "1cqn1j",
-    },
-  ],
-  ["path", { d: "M17 21v-8H7v8", key: "1ydtos" }],
-  ["path", { d: "M7 3v5h8", key: "1pvjzy" }],
-  ["path", { d: "m9 13 2 2 4-4", key: "634lzl" }],
-]);
 import { resolveAudioFiles } from "../../lib/audio-files";
 import { AudioView } from "../../lib/audio-view";
 import { buildExportFileName, downloadBlob } from "../../lib/export-utils";


### PR DESCRIPTION
The recorder transport has no compact feedback for whether recent edits are safely persisted, and a save completing after another edit can incorrectly make the project look clean.

This PR adds a quiet save control next to the project title for saved, unsaved, saving, and failed states, replacing the indirect overflow-menu action while retaining Ctrl/Cmd+S. Save completion is revision-aware, so edits made while a write is pending remain unsaved.