### PR TITLE
refactor: measure recorder input with analyser

### DIFF
--- a/src/components/input-meter.tsx
+++ b/src/components/input-meter.tsx
@@ -1,33 +1,38 @@
 import { useEffect, useState } from "react";
 import { gainToDb, MAX_DB, MIN_DB } from "../lib/music";
-import type { PeakSource } from "../lib/recorder/capture-input";
 
 export function InputMeter({
   active,
+  analyser,
   peak,
-  peakSource,
 }: {
   active: boolean;
+  analyser?: AnalyserNode;
   peak?: number;
-  peakSource?: PeakSource;
 }) {
   const [sampledPeak, setSampledPeak] = useState(0);
   useEffect(() => {
-    if (!active || !peakSource) {
+    if (!active || !analyser) {
       setSampledPeak(0);
       return;
     }
+    const samples = new Float32Array(analyser.fftSize);
     let frame = requestAnimationFrame(function sample() {
-      setSampledPeak(peakSource.readPeak());
+      analyser.getFloatTimeDomainData(samples);
+      let nextPeak = 0;
+      for (const value of samples) {
+        nextPeak = Math.max(nextPeak, Math.abs(value));
+      }
+      setSampledPeak(nextPeak);
       frame = requestAnimationFrame(sample);
     });
     return () => cancelAnimationFrame(frame);
-  }, [active, peakSource]);
+  }, [active, analyser]);
 
   const getPosition = (value: number) =>
     ((value - MIN_DB) / (MAX_DB - MIN_DB)) * 100;
   const zeroPosition = getPosition(0);
-  const decibels = gainToDb(peakSource ? sampledPeak : (peak ?? 0));
+  const decibels = gainToDb(analyser ? sampledPeak : (peak ?? 0));
   const meterValue = Math.max(MIN_DB, Math.min(MAX_DB, decibels));
   const levelPosition = active ? getPosition(meterValue) : 0;
   const label = active ? `${decibels.toFixed(1)} dBFS` : "-∞ dBFS";

--- a/src/components/input-meter.tsx
+++ b/src/components/input-meter.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from "react";
+import type { AudioAnalyser } from "../lib/audio-analyser";
 import { gainToDb, MAX_DB, MIN_DB } from "../lib/music";
-import { startAnimationFrameLoop } from "../utils/timing";
 
 export function InputMeter({
   active,
   analyser,
 }: {
   active: boolean;
-  analyser?: AnalyserNode;
+  analyser?: AudioAnalyser;
 }) {
   const sampledPeak = useAnalyserPeak({ active, analyser });
 
@@ -63,7 +63,7 @@ function useAnalyserPeak({
   analyser,
 }: {
   active: boolean;
-  analyser?: AnalyserNode;
+  analyser?: AudioAnalyser;
 }): number {
   const [peak, setPeak] = useState(0);
 
@@ -72,24 +72,7 @@ function useAnalyserPeak({
       setPeak(0);
       return;
     }
-    const samples = new Float32Array(analyser.fftSize);
-    // Match the old worklet cadence of 16 render quanta: 16 * 128 / 48 kHz is
-    // about 43 ms. This is intentionally an approximate UI throttle rather than
-    // sample-accurate timing, so assuming the common 48 kHz rate is sufficient.
-    const sampleInterval = (analyser.fftSize / 48_000) * 1000;
-    let lastSampleTime = -Infinity;
-    return startAnimationFrameLoop((time) => {
-      if (time - lastSampleTime < sampleInterval) {
-        return;
-      }
-      lastSampleTime = time;
-      analyser.getFloatTimeDomainData(samples);
-      let nextPeak = 0;
-      for (const value of samples) {
-        nextPeak = Math.max(nextPeak, Math.abs(value));
-      }
-      setPeak(nextPeak);
-    });
+    return analyser.subscribe(({ peak }) => setPeak(peak));
   }, [active, analyser]);
 
   return peak;

--- a/src/components/input-meter.tsx
+++ b/src/components/input-meter.tsx
@@ -73,7 +73,13 @@ function useAnalyserPeak({
       return;
     }
     const samples = new Float32Array(analyser.fftSize);
-    return startAnimationFrameLoop(() => {
+    const sampleInterval = (analyser.fftSize / 48_000) * 1000;
+    let lastSampleTime = -Infinity;
+    return startAnimationFrameLoop((time) => {
+      if (time - lastSampleTime < sampleInterval) {
+        return;
+      }
+      lastSampleTime = time;
       analyser.getFloatTimeDomainData(samples);
       let nextPeak = 0;
       for (const value of samples) {

--- a/src/components/input-meter.tsx
+++ b/src/components/input-meter.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { gainToDb, MAX_DB, MIN_DB } from "../lib/music";
+import { startAnimationFrameLoop } from "../utils/timing";
 
 export function InputMeter({
   active,
@@ -74,16 +75,14 @@ function useAnalyserPeak({
       return;
     }
     const samples = new Float32Array(analyser.fftSize);
-    let frame = requestAnimationFrame(function sample() {
+    return startAnimationFrameLoop(() => {
       analyser.getFloatTimeDomainData(samples);
       let nextPeak = 0;
       for (const value of samples) {
         nextPeak = Math.max(nextPeak, Math.abs(value));
       }
       setPeak(nextPeak);
-      frame = requestAnimationFrame(sample);
     });
-    return () => cancelAnimationFrame(frame);
   }, [active, analyser]);
 
   return peak;

--- a/src/components/input-meter.tsx
+++ b/src/components/input-meter.tsx
@@ -73,6 +73,9 @@ function useAnalyserPeak({
       return;
     }
     const samples = new Float32Array(analyser.fftSize);
+    // Match the old worklet cadence of 16 render quanta: 16 * 128 / 48 kHz is
+    // about 43 ms. This is intentionally an approximate UI throttle rather than
+    // sample-accurate timing, so assuming the common 48 kHz rate is sufficient.
     const sampleInterval = (analyser.fftSize / 48_000) * 1000;
     let lastSampleTime = -Infinity;
     return startAnimationFrameLoop((time) => {

--- a/src/components/input-meter.tsx
+++ b/src/components/input-meter.tsx
@@ -10,24 +10,7 @@ export function InputMeter({
   analyser?: AnalyserNode;
   peak?: number;
 }) {
-  const [sampledPeak, setSampledPeak] = useState(0);
-  useEffect(() => {
-    if (!active || !analyser) {
-      setSampledPeak(0);
-      return;
-    }
-    const samples = new Float32Array(analyser.fftSize);
-    let frame = requestAnimationFrame(function sample() {
-      analyser.getFloatTimeDomainData(samples);
-      let nextPeak = 0;
-      for (const value of samples) {
-        nextPeak = Math.max(nextPeak, Math.abs(value));
-      }
-      setSampledPeak(nextPeak);
-      frame = requestAnimationFrame(sample);
-    });
-    return () => cancelAnimationFrame(frame);
-  }, [active, analyser]);
+  const sampledPeak = useAnalyserPeak({ active, analyser });
 
   const getPosition = (value: number) =>
     ((value - MIN_DB) / (MAX_DB - MIN_DB)) * 100;
@@ -74,4 +57,34 @@ export function InputMeter({
       </output>
     </div>
   );
+}
+
+function useAnalyserPeak({
+  active,
+  analyser,
+}: {
+  active: boolean;
+  analyser?: AnalyserNode;
+}): number {
+  const [peak, setPeak] = useState(0);
+
+  useEffect(() => {
+    if (!active || !analyser) {
+      setPeak(0);
+      return;
+    }
+    const samples = new Float32Array(analyser.fftSize);
+    let frame = requestAnimationFrame(function sample() {
+      analyser.getFloatTimeDomainData(samples);
+      let nextPeak = 0;
+      for (const value of samples) {
+        nextPeak = Math.max(nextPeak, Math.abs(value));
+      }
+      setPeak(nextPeak);
+      frame = requestAnimationFrame(sample);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [active, analyser]);
+
+  return peak;
 }

--- a/src/components/input-meter.tsx
+++ b/src/components/input-meter.tsx
@@ -5,18 +5,16 @@ import { startAnimationFrameLoop } from "../utils/timing";
 export function InputMeter({
   active,
   analyser,
-  peak,
 }: {
   active: boolean;
   analyser?: AnalyserNode;
-  peak?: number;
 }) {
   const sampledPeak = useAnalyserPeak({ active, analyser });
 
   const getPosition = (value: number) =>
     ((value - MIN_DB) / (MAX_DB - MIN_DB)) * 100;
   const zeroPosition = getPosition(0);
-  const decibels = gainToDb(analyser ? sampledPeak : (peak ?? 0));
+  const decibels = gainToDb(sampledPeak);
   const meterValue = Math.max(MIN_DB, Math.min(MAX_DB, decibels));
   const levelPosition = active ? getPosition(meterValue) : 0;
   const label = active ? `${decibels.toFixed(1)} dBFS` : "-∞ dBFS";

--- a/src/components/input-meter.tsx
+++ b/src/components/input-meter.tsx
@@ -1,16 +1,33 @@
+import { useEffect, useState } from "react";
 import { gainToDb, MAX_DB, MIN_DB } from "../lib/music";
+import type { PeakSource } from "../lib/recorder/capture-input";
 
 export function InputMeter({
   active,
   peak,
+  peakSource,
 }: {
   active: boolean;
-  peak: number;
+  peak?: number;
+  peakSource?: PeakSource;
 }) {
+  const [sampledPeak, setSampledPeak] = useState(0);
+  useEffect(() => {
+    if (!active || !peakSource) {
+      setSampledPeak(0);
+      return;
+    }
+    let frame = requestAnimationFrame(function sample() {
+      setSampledPeak(peakSource.readPeak());
+      frame = requestAnimationFrame(sample);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [active, peakSource]);
+
   const getPosition = (value: number) =>
     ((value - MIN_DB) / (MAX_DB - MIN_DB)) * 100;
   const zeroPosition = getPosition(0);
-  const decibels = gainToDb(peak);
+  const decibels = gainToDb(peakSource ? sampledPeak : (peak ?? 0));
   const meterValue = Math.max(MIN_DB, Math.min(MAX_DB, decibels));
   const levelPosition = active ? getPosition(meterValue) : 0;
   const label = active ? `${decibels.toFixed(1)} dBFS` : "-∞ dBFS";

--- a/src/components/latency-checker.tsx
+++ b/src/components/latency-checker.tsx
@@ -27,7 +27,6 @@ export function LatencyChecker() {
   const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
   const [deviceId, setDeviceId] = useState<string>();
   const [channel, setChannel] = useState(0);
-  const [inputPeak, setInputPeak] = useState(0);
   const [outputLevel, setOutputLevel] = useState(-24);
 
   useEffect(() => {
@@ -72,8 +71,7 @@ export function LatencyChecker() {
   const selectedDevice = devices.find((device) => device.deviceId === deviceId);
 
   const startMonitoringMutation = useMutation({
-    mutationFn: (deviceId: string) =>
-      runtime.startMonitoring({ deviceId, onLevel: setInputPeak }),
+    mutationFn: (deviceId: string) => runtime.startMonitoring({ deviceId }),
   });
   const isMonitoring = startMonitoringMutation.isSuccess;
 
@@ -85,7 +83,6 @@ export function LatencyChecker() {
   function stopMonitoring() {
     runtime.stopMonitoring();
     setChannel(0);
-    setInputPeak(0);
     startMonitoringMutation.reset();
     calibrationMutation.reset();
   }
@@ -94,7 +91,6 @@ export function LatencyChecker() {
     if (isMonitoring) {
       stopMonitoring();
     } else if (selectedDevice) {
-      setInputPeak(0);
       startMonitoringMutation.mutate(selectedDevice.deviceId);
     }
   }
@@ -265,7 +261,10 @@ export function LatencyChecker() {
             <div className="mt-4">
               <label className="grid gap-2 text-xs font-semibold text-neutral-400">
                 Input meter
-                <InputMeter active={isMonitoring} peak={inputPeak} />
+                <InputMeter
+                  active={isMonitoring}
+                  analyser={runtime.getInputAnalyser()}
+                />
               </label>
             </div>
             {startMonitoringMutation.error && (

--- a/src/components/latency-checker.tsx
+++ b/src/components/latency-checker.tsx
@@ -263,7 +263,7 @@ export function LatencyChecker() {
                 Input meter
                 <InputMeter
                   active={isMonitoring}
-                  analyser={runtime.getInputAnalyser()}
+                  analyser={runtime.inputAnalyser}
                 />
               </label>
             </div>

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -22,6 +22,7 @@ import { useDraftInput } from "../../hooks/use-draft-input";
 import { usePointerDrag } from "../../hooks/use-pointer-drag";
 import { useTapTempo } from "../../hooks/use-tap-tempo";
 import { useWindowEvent } from "../../hooks/use-window-event";
+import type { AudioAnalyser } from "../../lib/audio-analyser";
 import { resolveAudioFiles } from "../../lib/audio-files";
 import { AudioView } from "../../lib/audio-view";
 import { buildExportFileName, downloadBlob } from "../../lib/export-utils";
@@ -1479,7 +1480,7 @@ function InputInspector({
   error?: Error | null;
   hasAccess: boolean;
   inputActive: boolean;
-  inputAnalyser?: AnalyserNode;
+  inputAnalyser?: AudioAnalyser;
   inputsInitialized: boolean;
   isProcessing: boolean;
   isRecording: boolean;

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -37,6 +37,7 @@ import {
 } from "../../lib/music";
 import {
   getCaptureInputs,
+  type PeakSource,
   requestCaptureAccess,
 } from "../../lib/recorder/capture-input";
 import { recorderProjectStorage } from "../../lib/recorder/project-storage";
@@ -393,7 +394,7 @@ export function Recorder({ projectId }: { projectId: string }) {
           error={error}
           hasAccess={input.hasAccess}
           inputActive={input.active}
-          inputPeak={input.peak}
+          inputPeakSource={runtime.getInputPeakSource()}
           inputsInitialized={input.initialized}
           isProcessing={isProcessing}
           isRecording={isRecording}
@@ -406,7 +407,6 @@ export function Recorder({ projectId }: { projectId: string }) {
           onDeviceChange={input.selectDevice}
           onInputToggle={input.toggle}
           onChannelChange={(channel) => {
-            input.setPeak(0);
             input.selectChannel(channel);
           }}
           onLatencyCompensationChange={(compensation) => {
@@ -489,7 +489,6 @@ function useRecorderInput({
   );
   const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
   const [deviceId, setDeviceId] = useState(preference.input?.deviceId);
-  const [peak, setPeak] = useState(0);
 
   async function refresh() {
     const nextDevices = await getCaptureInputs();
@@ -526,7 +525,6 @@ function useRecorderInput({
 
   function stop() {
     runtime.stopInput();
-    setPeak(0);
     startMutation.reset();
   }
 
@@ -543,7 +541,6 @@ function useRecorderInput({
     mutationFn: async (nextDeviceId: string) => {
       const { channelCount } = await runtime.startInput({
         deviceId: nextDeviceId,
-        onLevel: setPeak,
       });
       runtime.selectChannel(
         Math.min(preference.input?.channel ?? 0, channelCount - 1),
@@ -578,8 +575,6 @@ function useRecorderInput({
       refreshMutation.isPending ||
       grantMutation.isPending ||
       startMutation.isPending,
-    peak,
-    setPeak,
     selectedDevice,
     selectDevice,
     selectChannel: (channel: number) => {
@@ -612,7 +607,6 @@ function useRecorderInput({
       } else if (active) {
         stop();
       } else if (selectedDevice) {
-        setPeak(0);
         startMutation.mutate(selectedDevice.deviceId);
       }
     },
@@ -1467,7 +1461,7 @@ function InputInspector({
   error,
   hasAccess,
   inputActive,
-  inputPeak,
+  inputPeakSource,
   inputsInitialized,
   isProcessing,
   isRecording,
@@ -1486,7 +1480,7 @@ function InputInspector({
   error?: Error | null;
   hasAccess: boolean;
   inputActive: boolean;
-  inputPeak: number;
+  inputPeakSource?: PeakSource;
   inputsInitialized: boolean;
   isProcessing: boolean;
   isRecording: boolean;
@@ -1586,7 +1580,7 @@ function InputInspector({
         <label className="block text-[11px] font-medium text-neutral-400">
           Level
           <div className="mt-2">
-            <InputMeter active={inputActive} peak={inputPeak} />
+            <InputMeter active={inputActive} peakSource={inputPeakSource} />
           </div>
         </label>
         <label className="block text-[11px] font-medium text-neutral-400">

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -393,7 +393,7 @@ export function Recorder({ projectId }: { projectId: string }) {
           error={error}
           hasAccess={input.hasAccess}
           inputActive={input.active}
-          inputAnalyser={runtime.inputAnalyser}
+          inputAnalyser={runtime.captureInput?.analyser}
           inputsInitialized={input.initialized}
           isProcessing={isProcessing}
           isRecording={isRecording}

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -37,7 +37,6 @@ import {
 } from "../../lib/music";
 import {
   getCaptureInputs,
-  type PeakSource,
   requestCaptureAccess,
 } from "../../lib/recorder/capture-input";
 import { recorderProjectStorage } from "../../lib/recorder/project-storage";
@@ -394,7 +393,7 @@ export function Recorder({ projectId }: { projectId: string }) {
           error={error}
           hasAccess={input.hasAccess}
           inputActive={input.active}
-          inputPeakSource={runtime.getInputPeakSource()}
+          inputAnalyser={runtime.getInputAnalyser()}
           inputsInitialized={input.initialized}
           isProcessing={isProcessing}
           isRecording={isRecording}
@@ -1461,7 +1460,7 @@ function InputInspector({
   error,
   hasAccess,
   inputActive,
-  inputPeakSource,
+  inputAnalyser,
   inputsInitialized,
   isProcessing,
   isRecording,
@@ -1480,7 +1479,7 @@ function InputInspector({
   error?: Error | null;
   hasAccess: boolean;
   inputActive: boolean;
-  inputPeakSource?: PeakSource;
+  inputAnalyser?: AnalyserNode;
   inputsInitialized: boolean;
   isProcessing: boolean;
   isRecording: boolean;
@@ -1580,7 +1579,7 @@ function InputInspector({
         <label className="block text-[11px] font-medium text-neutral-400">
           Level
           <div className="mt-2">
-            <InputMeter active={inputActive} peakSource={inputPeakSource} />
+            <InputMeter active={inputActive} analyser={inputAnalyser} />
           </div>
         </label>
         <label className="block text-[11px] font-medium text-neutral-400">

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -393,7 +393,7 @@ export function Recorder({ projectId }: { projectId: string }) {
           error={error}
           hasAccess={input.hasAccess}
           inputActive={input.active}
-          inputAnalyser={runtime.getInputAnalyser()}
+          inputAnalyser={runtime.inputAnalyser}
           inputsInitialized={input.initialized}
           isProcessing={isProcessing}
           isRecording={isRecording}

--- a/src/lib/audio-analyser.ts
+++ b/src/lib/audio-analyser.ts
@@ -1,4 +1,4 @@
-import { startAnimationFrameLoop } from "../utils/timing.ts";
+import { startThrottledAnimationFrameLoop } from "../utils/timing.ts";
 
 export type AudioAnalysis = {
   peak: number;
@@ -21,18 +21,16 @@ export class AudioAnalyser {
   }
 
   subscribe(onAnalysis: (analysis: AudioAnalysis) => void): () => void {
-    let lastSampleTime = -Infinity;
-    return startAnimationFrameLoop((time) => {
-      if (time - lastSampleTime < this.sampleInterval) {
-        return;
-      }
-      lastSampleTime = time;
-      this.node.getFloatTimeDomainData(this.samples);
-      let peak = 0;
-      for (const sample of this.samples) {
-        peak = Math.max(peak, Math.abs(sample));
-      }
-      onAnalysis({ peak });
+    return startThrottledAnimationFrameLoop({
+      interval: this.sampleInterval,
+      callback: () => {
+        this.node.getFloatTimeDomainData(this.samples);
+        let peak = 0;
+        for (const sample of this.samples) {
+          peak = Math.max(peak, Math.abs(sample));
+        }
+        onAnalysis({ peak });
+      },
     });
   }
 

--- a/src/lib/audio-analyser.ts
+++ b/src/lib/audio-analyser.ts
@@ -1,0 +1,42 @@
+import { startAnimationFrameLoop } from "../utils/timing.ts";
+
+export type AudioAnalysis = {
+  peak: number;
+};
+
+export class AudioAnalyser {
+  readonly node: AnalyserNode;
+
+  private readonly samples: Float32Array<ArrayBuffer>;
+  private readonly sampleInterval: number;
+
+  constructor(context: BaseAudioContext) {
+    this.node = context.createAnalyser();
+    this.node.fftSize = 2048;
+    this.samples = new Float32Array(this.node.fftSize);
+    // Match the old worklet cadence of 16 render quanta. The analyser window is
+    // 16 * 128 samples, so one window at the actual context rate is the intended
+    // approximate UI update interval.
+    this.sampleInterval = (this.node.fftSize / context.sampleRate) * 1000;
+  }
+
+  subscribe(onAnalysis: (analysis: AudioAnalysis) => void): () => void {
+    let lastSampleTime = -Infinity;
+    return startAnimationFrameLoop((time) => {
+      if (time - lastSampleTime < this.sampleInterval) {
+        return;
+      }
+      lastSampleTime = time;
+      this.node.getFloatTimeDomainData(this.samples);
+      let peak = 0;
+      for (const sample of this.samples) {
+        peak = Math.max(peak, Math.abs(sample));
+      }
+      onAnalysis({ peak });
+    });
+  }
+
+  dispose(): void {
+    this.node.disconnect();
+  }
+}

--- a/src/lib/audio-analyser.ts
+++ b/src/lib/audio-analyser.ts
@@ -12,11 +12,11 @@ export class AudioAnalyser {
 
   constructor(context: BaseAudioContext) {
     this.node = context.createAnalyser();
-    this.node.fftSize = 2048;
-    this.samples = new Float32Array(this.node.fftSize);
     // Match the old worklet cadence of 16 render quanta. The analyser window is
     // 16 * 128 samples, so one window at the actual context rate is the intended
     // approximate UI update interval.
+    this.node.fftSize = 2048;
+    this.samples = new Float32Array(this.node.fftSize);
     this.sampleInterval = (this.node.fftSize / context.sampleRate) * 1000;
   }
 

--- a/src/lib/latency-checker/capture-worklet.ts
+++ b/src/lib/latency-checker/capture-worklet.ts
@@ -7,7 +7,6 @@ type ClientMessage =
 type WorkletMessage =
   | { type: "activeChanged"; requestId: number; value: boolean }
   | { type: "channels"; value: number }
-  | { type: "level"; peak: number }
   | ({ type: "samples" } & CaptureChunk);
 
 export type CaptureChunk = {
@@ -110,8 +109,6 @@ function createCaptureProcessor() {
     declare active: boolean;
     declare channel: number;
     declare lastChannelCount: number;
-    declare meterBlockCount: number;
-    declare meterPeak: number;
     declare pendingRenderActions: Array<() => void>;
 
     constructor() {
@@ -119,8 +116,6 @@ function createCaptureProcessor() {
       this.active = false;
       this.channel = 0;
       this.lastChannelCount = -1;
-      this.meterBlockCount = 0;
-      this.meterPeak = 0;
       this.pendingRenderActions = [];
       this.port.onmessage = (event: MessageEvent<ClientMessage>) => {
         if (event.data.type === "active") {
@@ -134,9 +129,6 @@ function createCaptureProcessor() {
         }
         if (event.data.type === "channel") {
           this.channel = event.data.value;
-          // Do not mix meter history from the previously selected channel.
-          this.meterBlockCount = 0;
-          this.meterPeak = 0;
         }
       };
     }
@@ -148,11 +140,6 @@ function createCaptureProcessor() {
       this.pendingRenderActions = [];
       const channels = inputs[0] || [];
       const output = outputs[0] || [];
-      // A connected output keeps the processor in the render graph, but capture
-      // must never feed input audio back to speakers.
-      for (const samples of output) {
-        samples.fill(0);
-      }
       if (channels.length !== this.lastChannelCount) {
         // Browser track settings can be incomplete, so report the channel count
         // observed in actual render quanta.
@@ -161,17 +148,7 @@ function createCaptureProcessor() {
       }
       const selected = channels[this.channel];
       if (selected) {
-        for (const sample of selected) {
-          this.meterPeak = Math.max(this.meterPeak, Math.abs(sample));
-        }
-        this.meterBlockCount++;
-        if (this.meterBlockCount >= 16) {
-          // Aggregate render quanta to avoid flooding the main thread with UI
-          // meter updates while retaining a responsive peak display.
-          this.postMessage({ type: "level", peak: this.meterPeak });
-          this.meterBlockCount = 0;
-          this.meterPeak = 0;
-        }
+        output[0]?.set(selected);
 
         if (this.active) {
           // TODO: Batch multiple render quanta before transferring. The input
@@ -189,6 +166,9 @@ function createCaptureProcessor() {
             [copy.buffer],
           );
         }
+      }
+      if (!selected) {
+        output[0]?.fill(0);
       }
       return true;
     }

--- a/src/lib/latency-checker/runtime.ts
+++ b/src/lib/latency-checker/runtime.ts
@@ -35,6 +35,7 @@ export class LatencyCheckerRuntime {
   private activeStream?: MediaStream;
   private activeSource?: MediaStreamAudioSourceNode;
   private captureWorklet?: CaptureWorkletClient;
+  private activeAnalyser?: AnalyserNode;
   private activeSilentGain?: GainNode;
   private activeSettings?: MediaTrackSettings;
   private activePreviewSources: AudioBufferSourceNode[] = [];
@@ -54,13 +55,7 @@ export class LatencyCheckerRuntime {
     );
   }
 
-  async startMonitoring({
-    deviceId,
-    onLevel,
-  }: {
-    deviceId: string;
-    onLevel: (peak: number) => void;
-  }) {
+  async startMonitoring({ deviceId }: { deviceId: string }) {
     const context = await this.ensureAudioContext();
     this.activeStream = await navigator.mediaDevices.getUserMedia(
       captureConstraints(deviceId),
@@ -86,17 +81,17 @@ export class LatencyCheckerRuntime {
             channelCount.resolve(message.value);
           }
         }
-        if (message.type === "level") {
-          onLevel(message.peak);
-        }
       },
     });
+    this.activeAnalyser = context.createAnalyser();
+    this.activeAnalyser.fftSize = 2048;
     this.activeSilentGain = context.createGain();
     this.activeSilentGain.gain.value = 0;
     // Web Audio may suspend a disconnected worklet. Route it to destination
     // through zero gain to keep processing without audible input passthrough.
     this.activeSource
       .connect(this.captureWorklet.node)
+      .connect(this.activeAnalyser)
       .connect(this.activeSilentGain)
       .connect(context.destination);
     this.setChannel(0);
@@ -110,11 +105,13 @@ export class LatencyCheckerRuntime {
   stopMonitoring() {
     this.activeSource?.disconnect();
     this.captureWorklet?.dispose();
+    this.activeAnalyser?.disconnect();
     this.activeSilentGain?.disconnect();
     this.activeStream?.getTracks().forEach((track) => track.stop());
     this.activeStream = undefined;
     this.activeSource = undefined;
     this.captureWorklet = undefined;
+    this.activeAnalyser = undefined;
     this.activeSilentGain = undefined;
     this.activeSettings = undefined;
     this.captureChunks = undefined;
@@ -123,6 +120,10 @@ export class LatencyCheckerRuntime {
 
   setChannel(channel: number) {
     this.captureWorklet?.setChannel(channel);
+  }
+
+  getInputAnalyser(): AnalyserNode | undefined {
+    return this.activeAnalyser;
   }
 
   async calibrate({

--- a/src/lib/latency-checker/runtime.ts
+++ b/src/lib/latency-checker/runtime.ts
@@ -30,12 +30,13 @@ export type LatencyResult = {
 export type PreviewVariant = "raw" | "compensated";
 
 export class LatencyCheckerRuntime {
+  inputAnalyser?: AnalyserNode;
+
   private audioContext?: AudioContext;
   private workletReady = false;
   private activeStream?: MediaStream;
   private activeSource?: MediaStreamAudioSourceNode;
   private captureWorklet?: CaptureWorkletClient;
-  private activeAnalyser?: AnalyserNode;
   private activeSilentGain?: GainNode;
   private activeSettings?: MediaTrackSettings;
   private activePreviewSources: AudioBufferSourceNode[] = [];
@@ -83,15 +84,15 @@ export class LatencyCheckerRuntime {
         }
       },
     });
-    this.activeAnalyser = context.createAnalyser();
-    this.activeAnalyser.fftSize = 2048;
+    this.inputAnalyser = context.createAnalyser();
+    this.inputAnalyser.fftSize = 2048;
     this.activeSilentGain = context.createGain();
     this.activeSilentGain.gain.value = 0;
     // Web Audio may suspend a disconnected worklet. Route it to destination
     // through zero gain to keep processing without audible input passthrough.
     this.activeSource
       .connect(this.captureWorklet.node)
-      .connect(this.activeAnalyser)
+      .connect(this.inputAnalyser)
       .connect(this.activeSilentGain)
       .connect(context.destination);
     this.setChannel(0);
@@ -105,13 +106,13 @@ export class LatencyCheckerRuntime {
   stopMonitoring() {
     this.activeSource?.disconnect();
     this.captureWorklet?.dispose();
-    this.activeAnalyser?.disconnect();
+    this.inputAnalyser?.disconnect();
     this.activeSilentGain?.disconnect();
     this.activeStream?.getTracks().forEach((track) => track.stop());
     this.activeStream = undefined;
     this.activeSource = undefined;
     this.captureWorklet = undefined;
-    this.activeAnalyser = undefined;
+    this.inputAnalyser = undefined;
     this.activeSilentGain = undefined;
     this.activeSettings = undefined;
     this.captureChunks = undefined;
@@ -120,10 +121,6 @@ export class LatencyCheckerRuntime {
 
   setChannel(channel: number) {
     this.captureWorklet?.setChannel(channel);
-  }
-
-  getInputAnalyser(): AnalyserNode | undefined {
-    return this.activeAnalyser;
   }
 
   async calibrate({

--- a/src/lib/latency-checker/runtime.ts
+++ b/src/lib/latency-checker/runtime.ts
@@ -1,3 +1,4 @@
+import { AudioAnalyser } from "../audio-analyser.ts";
 import { dbToGain } from "../music.ts";
 import {
   analyzeCalibration,
@@ -35,7 +36,7 @@ export class LatencyCheckerRuntime {
   private activeStream?: MediaStream;
   private activeSource?: MediaStreamAudioSourceNode;
   private captureWorklet?: CaptureWorkletClient;
-  inputAnalyser?: AnalyserNode;
+  inputAnalyser?: AudioAnalyser;
   private activeSilentGain?: GainNode;
   private activeSettings?: MediaTrackSettings;
   private activePreviewSources: AudioBufferSourceNode[] = [];
@@ -83,15 +84,14 @@ export class LatencyCheckerRuntime {
         }
       },
     });
-    this.inputAnalyser = context.createAnalyser();
-    this.inputAnalyser.fftSize = 2048;
+    this.inputAnalyser = new AudioAnalyser(context);
     this.activeSilentGain = context.createGain();
     this.activeSilentGain.gain.value = 0;
     // Web Audio may suspend a disconnected worklet. Route it to destination
     // through zero gain to keep processing without audible input passthrough.
     this.activeSource
       .connect(this.captureWorklet.node)
-      .connect(this.inputAnalyser)
+      .connect(this.inputAnalyser.node)
       .connect(this.activeSilentGain)
       .connect(context.destination);
     this.setChannel(0);
@@ -105,7 +105,7 @@ export class LatencyCheckerRuntime {
   stopMonitoring() {
     this.activeSource?.disconnect();
     this.captureWorklet?.dispose();
-    this.inputAnalyser?.disconnect();
+    this.inputAnalyser?.dispose();
     this.activeSilentGain?.disconnect();
     this.activeStream?.getTracks().forEach((track) => track.stop());
     this.activeStream = undefined;

--- a/src/lib/latency-checker/runtime.ts
+++ b/src/lib/latency-checker/runtime.ts
@@ -30,13 +30,12 @@ export type LatencyResult = {
 export type PreviewVariant = "raw" | "compensated";
 
 export class LatencyCheckerRuntime {
-  inputAnalyser?: AnalyserNode;
-
   private audioContext?: AudioContext;
   private workletReady = false;
   private activeStream?: MediaStream;
   private activeSource?: MediaStreamAudioSourceNode;
   private captureWorklet?: CaptureWorkletClient;
+  inputAnalyser?: AnalyserNode;
   private activeSilentGain?: GainNode;
   private activeSettings?: MediaTrackSettings;
   private activePreviewSources: AudioBufferSourceNode[] = [];

--- a/src/lib/recorder/capture-input.ts
+++ b/src/lib/recorder/capture-input.ts
@@ -6,10 +6,6 @@ import {
 
 const workletRegistrations = new WeakMap<AudioContext, Promise<void>>();
 
-export interface PeakSource {
-  readPeak(): number;
-}
-
 export async function requestCaptureAccess(): Promise<void> {
   const stream =
     await navigator.mediaDevices.getUserMedia(captureConstraints());
@@ -23,13 +19,11 @@ export async function getCaptureInputs(): Promise<MediaDeviceInfo[]> {
 }
 
 export class CaptureInput {
-  readonly peakSource: PeakSource;
+  readonly analyser: AnalyserNode;
 
   private readonly stream: MediaStream;
   private readonly source: MediaStreamAudioSourceNode;
   private readonly worklet: CaptureWorkletClient;
-  private readonly analyser: AnalyserNode;
-  private readonly analyserSamples: Float32Array<ArrayBuffer>;
   private readonly silentGain: GainNode;
 
   static async open({
@@ -92,8 +86,6 @@ export class CaptureInput {
     });
     this.analyser = context.createAnalyser();
     this.analyser.fftSize = 2048;
-    this.analyserSamples = new Float32Array(this.analyser.fftSize);
-    this.peakSource = { readPeak: () => this.readPeak() };
     this.silentGain = context.createGain();
     this.silentGain.gain.value = 0;
     // Keep the worklet connected so browsers continue rendering it. Zero gain
@@ -115,15 +107,6 @@ export class CaptureInput {
 
   stopCapture(): Promise<number> {
     return this.worklet.stop();
-  }
-
-  private readPeak(): number {
-    this.analyser.getFloatTimeDomainData(this.analyserSamples);
-    let peak = 0;
-    for (const sample of this.analyserSamples) {
-      peak = Math.max(peak, Math.abs(sample));
-    }
-    return peak;
   }
 
   dispose(): void {

--- a/src/lib/recorder/capture-input.ts
+++ b/src/lib/recorder/capture-input.ts
@@ -1,3 +1,4 @@
+import { AudioAnalyser } from "../audio-analyser.ts";
 import {
   CaptureWorkletClient,
   type CaptureWorkletNotification,
@@ -19,10 +20,11 @@ export async function getCaptureInputs(): Promise<MediaDeviceInfo[]> {
 }
 
 export class CaptureInput {
+  readonly analyser: AudioAnalyser;
+
   private readonly stream: MediaStream;
   private readonly source: MediaStreamAudioSourceNode;
   private readonly worklet: CaptureWorkletClient;
-  readonly analyser: AnalyserNode;
   private readonly silentGain: GainNode;
 
   static async open({
@@ -83,15 +85,14 @@ export class CaptureInput {
       context,
       onNotification,
     });
-    this.analyser = context.createAnalyser();
-    this.analyser.fftSize = 2048;
+    this.analyser = new AudioAnalyser(context);
     this.silentGain = context.createGain();
     this.silentGain.gain.value = 0;
     // Keep the worklet connected so browsers continue rendering it. Zero gain
     // prevents microphone monitoring and feedback at the destination.
     this.source
       .connect(this.worklet.node)
-      .connect(this.analyser)
+      .connect(this.analyser.node)
       .connect(this.silentGain)
       .connect(context.destination);
   }
@@ -111,7 +112,7 @@ export class CaptureInput {
   dispose(): void {
     this.source.disconnect();
     this.worklet.dispose();
-    this.analyser.disconnect();
+    this.analyser.dispose();
     this.silentGain.disconnect();
     for (const track of this.stream.getTracks()) {
       track.stop();

--- a/src/lib/recorder/capture-input.ts
+++ b/src/lib/recorder/capture-input.ts
@@ -19,11 +19,10 @@ export async function getCaptureInputs(): Promise<MediaDeviceInfo[]> {
 }
 
 export class CaptureInput {
-  readonly analyser: AnalyserNode;
-
   private readonly stream: MediaStream;
   private readonly source: MediaStreamAudioSourceNode;
   private readonly worklet: CaptureWorkletClient;
+  readonly analyser: AnalyserNode;
   private readonly silentGain: GainNode;
 
   static async open({

--- a/src/lib/recorder/capture-input.ts
+++ b/src/lib/recorder/capture-input.ts
@@ -1,10 +1,15 @@
 import {
   CaptureWorkletClient,
-  type CaptureWorkletNotification,
+  type CaptureWorkletNotification as WorkletNotification,
   createCaptureWorkletSource,
 } from "./capture-worklet.ts";
 
+type CaptureInputNotification =
+  | WorkletNotification
+  | { type: "level"; peak: number };
+
 const workletRegistrations = new WeakMap<AudioContext, Promise<void>>();
+const METER_INTERVAL_MS = 50;
 
 export async function requestCaptureAccess(): Promise<void> {
   const stream =
@@ -22,7 +27,10 @@ export class CaptureInput {
   private readonly stream: MediaStream;
   private readonly source: MediaStreamAudioSourceNode;
   private readonly worklet: CaptureWorkletClient;
+  private readonly analyser: AnalyserNode;
+  private readonly analyserSamples: Float32Array<ArrayBuffer>;
   private readonly silentGain: GainNode;
+  private meterInterval: number;
 
   static async open({
     context,
@@ -31,7 +39,7 @@ export class CaptureInput {
   }: {
     context: AudioContext;
     deviceId: string;
-    onNotification: (message: CaptureWorkletNotification) => void;
+    onNotification: (message: CaptureInputNotification) => void;
   }) {
     await ensureCaptureWorklet(context);
     const stream = await navigator.mediaDevices.getUserMedia(
@@ -74,7 +82,7 @@ export class CaptureInput {
   }: {
     context: AudioContext;
     stream: MediaStream;
-    onNotification: (message: CaptureWorkletNotification) => void;
+    onNotification: (message: CaptureInputNotification) => void;
   }) {
     this.stream = stream;
     this.source = context.createMediaStreamSource(stream);
@@ -82,14 +90,26 @@ export class CaptureInput {
       context,
       onNotification,
     });
+    this.analyser = context.createAnalyser();
+    this.analyser.fftSize = 2048;
+    this.analyserSamples = new Float32Array(this.analyser.fftSize);
     this.silentGain = context.createGain();
     this.silentGain.gain.value = 0;
     // Keep the worklet connected so browsers continue rendering it. Zero gain
     // prevents microphone monitoring and feedback at the destination.
     this.source
       .connect(this.worklet.node)
+      .connect(this.analyser)
       .connect(this.silentGain)
       .connect(context.destination);
+    this.meterInterval = window.setInterval(() => {
+      this.analyser.getFloatTimeDomainData(this.analyserSamples);
+      let peak = 0;
+      for (const sample of this.analyserSamples) {
+        peak = Math.max(peak, Math.abs(sample));
+      }
+      onNotification({ type: "level", peak });
+    }, METER_INTERVAL_MS);
   }
 
   setChannel(channel: number): void {
@@ -105,8 +125,10 @@ export class CaptureInput {
   }
 
   dispose(): void {
+    window.clearInterval(this.meterInterval);
     this.source.disconnect();
     this.worklet.dispose();
+    this.analyser.disconnect();
     this.silentGain.disconnect();
     for (const track of this.stream.getTracks()) {
       track.stop();

--- a/src/lib/recorder/capture-input.ts
+++ b/src/lib/recorder/capture-input.ts
@@ -1,15 +1,14 @@
 import {
   CaptureWorkletClient,
-  type CaptureWorkletNotification as WorkletNotification,
+  type CaptureWorkletNotification,
   createCaptureWorkletSource,
 } from "./capture-worklet.ts";
 
-type CaptureInputNotification =
-  | WorkletNotification
-  | { type: "level"; peak: number };
-
 const workletRegistrations = new WeakMap<AudioContext, Promise<void>>();
-const METER_INTERVAL_MS = 50;
+
+export interface PeakSource {
+  readPeak(): number;
+}
 
 export async function requestCaptureAccess(): Promise<void> {
   const stream =
@@ -24,13 +23,14 @@ export async function getCaptureInputs(): Promise<MediaDeviceInfo[]> {
 }
 
 export class CaptureInput {
+  readonly peakSource: PeakSource;
+
   private readonly stream: MediaStream;
   private readonly source: MediaStreamAudioSourceNode;
   private readonly worklet: CaptureWorkletClient;
   private readonly analyser: AnalyserNode;
   private readonly analyserSamples: Float32Array<ArrayBuffer>;
   private readonly silentGain: GainNode;
-  private meterInterval: number;
 
   static async open({
     context,
@@ -39,7 +39,7 @@ export class CaptureInput {
   }: {
     context: AudioContext;
     deviceId: string;
-    onNotification: (message: CaptureInputNotification) => void;
+    onNotification: (message: CaptureWorkletNotification) => void;
   }) {
     await ensureCaptureWorklet(context);
     const stream = await navigator.mediaDevices.getUserMedia(
@@ -82,7 +82,7 @@ export class CaptureInput {
   }: {
     context: AudioContext;
     stream: MediaStream;
-    onNotification: (message: CaptureInputNotification) => void;
+    onNotification: (message: CaptureWorkletNotification) => void;
   }) {
     this.stream = stream;
     this.source = context.createMediaStreamSource(stream);
@@ -93,6 +93,7 @@ export class CaptureInput {
     this.analyser = context.createAnalyser();
     this.analyser.fftSize = 2048;
     this.analyserSamples = new Float32Array(this.analyser.fftSize);
+    this.peakSource = { readPeak: () => this.readPeak() };
     this.silentGain = context.createGain();
     this.silentGain.gain.value = 0;
     // Keep the worklet connected so browsers continue rendering it. Zero gain
@@ -102,14 +103,6 @@ export class CaptureInput {
       .connect(this.analyser)
       .connect(this.silentGain)
       .connect(context.destination);
-    this.meterInterval = window.setInterval(() => {
-      this.analyser.getFloatTimeDomainData(this.analyserSamples);
-      let peak = 0;
-      for (const sample of this.analyserSamples) {
-        peak = Math.max(peak, Math.abs(sample));
-      }
-      onNotification({ type: "level", peak });
-    }, METER_INTERVAL_MS);
   }
 
   setChannel(channel: number): void {
@@ -124,8 +117,16 @@ export class CaptureInput {
     return this.worklet.stop();
   }
 
+  private readPeak(): number {
+    this.analyser.getFloatTimeDomainData(this.analyserSamples);
+    let peak = 0;
+    for (const sample of this.analyserSamples) {
+      peak = Math.max(peak, Math.abs(sample));
+    }
+    return peak;
+  }
+
   dispose(): void {
-    window.clearInterval(this.meterInterval);
     this.source.disconnect();
     this.worklet.dispose();
     this.analyser.disconnect();

--- a/src/lib/recorder/capture-input.ts
+++ b/src/lib/recorder/capture-input.ts
@@ -20,11 +20,10 @@ export async function getCaptureInputs(): Promise<MediaDeviceInfo[]> {
 }
 
 export class CaptureInput {
-  readonly analyser: AudioAnalyser;
-
   private readonly stream: MediaStream;
   private readonly source: MediaStreamAudioSourceNode;
   private readonly worklet: CaptureWorkletClient;
+  readonly analyser: AudioAnalyser;
   private readonly silentGain: GainNode;
 
   static async open({

--- a/src/lib/recorder/capture-worklet.ts
+++ b/src/lib/recorder/capture-worklet.ts
@@ -12,7 +12,6 @@ export type CaptureChunk = {
 
 export type CaptureWorkletNotification =
   | { type: "channels"; value: number }
-  | { type: "level"; peak: number }
   | ({ type: "samples" } & CaptureChunk);
 
 type WorkletMessage =
@@ -125,8 +124,6 @@ function createCaptureProcessor() {
     declare recording: boolean;
     declare selectedChannel: number;
     declare observedChannelCount: number;
-    declare meterBlockCount: number;
-    declare meterPeak: number;
     declare pendingRenderActions: Array<() => void>;
     declare captureBuffer: Float32Array;
     declare captureLength: number;
@@ -137,8 +134,6 @@ function createCaptureProcessor() {
       this.recording = false;
       this.selectedChannel = 0;
       this.observedChannelCount = -1;
-      this.meterBlockCount = 0;
-      this.meterPeak = 0;
       this.pendingRenderActions = [];
       this.captureBuffer = new Float32Array(4096);
       this.captureLength = 0;
@@ -147,8 +142,6 @@ function createCaptureProcessor() {
         switch (event.data.type) {
           case "channel": {
             this.selectedChannel = event.data.value;
-            this.meterBlockCount = 0;
-            this.meterPeak = 0;
             break;
           }
           case "active": {
@@ -181,11 +174,7 @@ function createCaptureProcessor() {
       }
       this.pendingRenderActions = [];
       const channels = inputs[0] ?? [];
-      // The output keeps this processor in the render graph, but input audio
-      // must never pass through to speakers.
-      for (const samples of outputs[0] ?? []) {
-        samples.fill(0);
-      }
+      const output = outputs[0]?.[0];
       if (channels.length !== this.observedChannelCount) {
         // Track settings may be absent or disagree with actual render quanta.
         this.observedChannelCount = channels.length;
@@ -196,17 +185,7 @@ function createCaptureProcessor() {
         // still produces capture from an available channel.
         const source =
           channels[Math.min(this.selectedChannel, channels.length - 1)];
-        for (const sample of source) {
-          this.meterPeak = Math.max(this.meterPeak, Math.abs(sample));
-        }
-        this.meterBlockCount++;
-        if (this.meterBlockCount >= 16) {
-          // Aggregate render quanta to avoid flooding the main thread with meter
-          // updates while retaining a responsive peak display.
-          this.postMessage({ type: "level", peak: this.meterPeak });
-          this.meterBlockCount = 0;
-          this.meterPeak = 0;
-        }
+        output?.set(source);
         if (this.recording) {
           this.appendCapture(source);
         }
@@ -214,6 +193,9 @@ function createCaptureProcessor() {
         // Flush before a gap so no chunk claims frame-contiguous PCM across
         // missing input. Take assembly leaves the absent interval as silence.
         this.flushCapture();
+      }
+      if (channels.length === 0) {
+        output?.fill(0);
       }
       return true;
     }

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -98,11 +98,10 @@ export function createDefaultRecorderRuntimeState(): RecorderRuntimeState {
 
 export class RecorderRuntime {
   readonly store = createStore(createDefaultRecorderRuntimeState);
-  inputAnalyser?: AnalyserNode;
+  captureInput?: CaptureInput;
 
   private context?: AudioContext;
   private transport?: AudioContextTransport;
-  private captureInput?: CaptureInput;
   private audioTrackPlaybacks = new Map<string, AudioBufferPlayback>();
   private recordingTrackPlayback?: AudioBufferPlayback;
   private activeRecording?: ActiveRecording;
@@ -160,7 +159,6 @@ export class RecorderRuntime {
     });
     this.closeInput();
     this.captureInput = input;
-    this.inputAnalyser = input.analyser;
 
     this.store.update({
       captureStatus: "ready",
@@ -532,7 +530,6 @@ export class RecorderRuntime {
   private closeInput(): void {
     this.captureInput?.dispose();
     this.captureInput = undefined;
-    this.inputAnalyser = undefined;
   }
 
   private clearTake(): void {

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -2,7 +2,7 @@ import { DEFAULT_TIME_SIGNATURE, type TimeSignature } from "../../types.ts";
 import { createStore } from "../../utils/store.ts";
 import { type AudioView, createAudioView } from "../audio-view.ts";
 import { AudioBufferPlayback } from "./audio-buffer-playback.ts";
-import { CaptureInput, type PeakSource } from "./capture-input.ts";
+import { CaptureInput } from "./capture-input.ts";
 import { RecorderMetronome } from "./metronome.ts";
 import {
   deserializeRecorderRuntimeState,
@@ -182,8 +182,8 @@ export class RecorderRuntime {
     this.store.update({ selectedChannel: channel });
   }
 
-  getInputPeakSource(): PeakSource | undefined {
-    return this.captureInput?.peakSource;
+  getInputAnalyser(): AnalyserNode | undefined {
+    return this.captureInput?.analyser;
   }
 
   addAudioTrack(): string {

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -98,10 +98,10 @@ export function createDefaultRecorderRuntimeState(): RecorderRuntimeState {
 
 export class RecorderRuntime {
   readonly store = createStore(createDefaultRecorderRuntimeState);
-  captureInput?: CaptureInput;
 
   private context?: AudioContext;
   private transport?: AudioContextTransport;
+  captureInput?: CaptureInput;
   private audioTrackPlaybacks = new Map<string, AudioBufferPlayback>();
   private recordingTrackPlayback?: AudioBufferPlayback;
   private activeRecording?: ActiveRecording;

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -2,7 +2,7 @@ import { DEFAULT_TIME_SIGNATURE, type TimeSignature } from "../../types.ts";
 import { createStore } from "../../utils/store.ts";
 import { type AudioView, createAudioView } from "../audio-view.ts";
 import { AudioBufferPlayback } from "./audio-buffer-playback.ts";
-import { CaptureInput } from "./capture-input.ts";
+import { CaptureInput, type PeakSource } from "./capture-input.ts";
 import { RecorderMetronome } from "./metronome.ts";
 import {
   deserializeRecorderRuntimeState,
@@ -109,10 +109,8 @@ export class RecorderRuntime {
 
   async startInput({
     deviceId,
-    onLevel,
   }: {
     deviceId: string;
-    onLevel: (peak: number) => void;
   }): Promise<{ channelCount: number }> {
     const context = this.ensureContext();
     // Open the replacement completely before closing the current input so a
@@ -122,10 +120,6 @@ export class RecorderRuntime {
       deviceId,
       onNotification: (message) => {
         switch (message.type) {
-          case "level": {
-            onLevel(message.peak);
-            break;
-          }
           case "samples": {
             const activeRecording = this.activeRecording;
             // Batched samples can arrive after stop is requested. Keep accepting
@@ -186,6 +180,10 @@ export class RecorderRuntime {
   selectChannel(channel: number): void {
     this.captureInput?.setChannel(channel);
     this.store.update({ selectedChannel: channel });
+  }
+
+  getInputPeakSource(): PeakSource | undefined {
+    return this.captureInput?.peakSource;
   }
 
   addAudioTrack(): string {

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -98,6 +98,7 @@ export function createDefaultRecorderRuntimeState(): RecorderRuntimeState {
 
 export class RecorderRuntime {
   readonly store = createStore(createDefaultRecorderRuntimeState);
+  inputAnalyser?: AnalyserNode;
 
   private context?: AudioContext;
   private transport?: AudioContextTransport;
@@ -159,6 +160,7 @@ export class RecorderRuntime {
     });
     this.closeInput();
     this.captureInput = input;
+    this.inputAnalyser = input.analyser;
 
     this.store.update({
       captureStatus: "ready",
@@ -180,10 +182,6 @@ export class RecorderRuntime {
   selectChannel(channel: number): void {
     this.captureInput?.setChannel(channel);
     this.store.update({ selectedChannel: channel });
-  }
-
-  getInputAnalyser(): AnalyserNode | undefined {
-    return this.captureInput?.analyser;
   }
 
   addAudioTrack(): string {
@@ -534,6 +532,7 @@ export class RecorderRuntime {
   private closeInput(): void {
     this.captureInput?.dispose();
     this.captureInput = undefined;
+    this.inputAnalyser = undefined;
   }
 
   private clearTake(): void {

--- a/src/lib/recorder/transport.ts
+++ b/src/lib/recorder/transport.ts
@@ -1,4 +1,5 @@
 import { createStore } from "../../utils/store.ts";
+import { startAnimationFrameLoop } from "../../utils/timing.ts";
 
 /** Gives every participant time to schedule against the same future audio frame. */
 const PLAYBACK_LEAD_SECONDS = 0.03;
@@ -130,14 +131,4 @@ export class AudioContextTransport {
     this.disposeTicking?.();
     this.disposeTicking = undefined;
   }
-}
-
-function startAnimationFrameLoop(callback: () => void): () => void {
-  let frame: number;
-  const tick = () => {
-    callback();
-    frame = requestAnimationFrame(tick);
-  };
-  frame = requestAnimationFrame(tick);
-  return () => cancelAnimationFrame(frame);
 }

--- a/src/utils/timing.ts
+++ b/src/utils/timing.ts
@@ -39,3 +39,20 @@ export function startAnimationFrameLoop(
   frame = requestAnimationFrame(tick);
   return () => cancelAnimationFrame(frame);
 }
+
+export function startThrottledAnimationFrameLoop({
+  callback,
+  interval,
+}: {
+  callback: FrameRequestCallback;
+  interval: number;
+}): () => void {
+  let lastTime = -Infinity;
+  return startAnimationFrameLoop((time) => {
+    if (time - lastTime < interval) {
+      return;
+    }
+    lastTime = time;
+    callback(time);
+  });
+}

--- a/src/utils/timing.ts
+++ b/src/utils/timing.ts
@@ -28,10 +28,12 @@ export function debounce(fn: () => void, ms: number) {
   return { schedule, cancel, flush };
 }
 
-export function startAnimationFrameLoop(callback: () => void): () => void {
+export function startAnimationFrameLoop(
+  callback: FrameRequestCallback,
+): () => void {
   let frame: number;
-  const tick = () => {
-    callback();
+  const tick = (time: number) => {
+    callback(time);
     frame = requestAnimationFrame(tick);
   };
   frame = requestAnimationFrame(tick);

--- a/src/utils/timing.ts
+++ b/src/utils/timing.ts
@@ -27,3 +27,13 @@ export function debounce(fn: () => void, ms: number) {
 
   return { schedule, cancel, flush };
 }
+
+export function startAnimationFrameLoop(callback: () => void): () => void {
+  let frame: number;
+  const tick = () => {
+    callback();
+    frame = requestAnimationFrame(tick);
+  };
+  frame = requestAnimationFrame(tick);
+  return () => cancelAnimationFrame(frame);
+}


### PR DESCRIPTION
- related to https://github.com/hi-ogawa/toy-midi/issues/357

The recorder and latency-checker capture worklets currently own input peak calculation and route periodic UI-level messages through their runtimes and component state.

This PR makes both worklets pass through their selected mono signal into a shared `AudioAnalyser` before each silent output gain. `AudioAnalyser` owns the native node, actual sample-rate cadence, buffer reuse, peak extraction, and subscription lifecycle, while the input meter only adapts analysis samples into React state. This preserves the current peak-only visual while keeping high-frequency meter updates out of runtime state and parent renders.