### PR TITLE
feat: move recorder input setup into capture track

### DIFF
--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -112,7 +112,7 @@ async function seekRecorderByPixels(page: Page, pixels: number) {
 async function enableInput(page: Page) {
   // Fake audio still exercises permission, device discovery, and channel setup.
   const route = page.getByRole("button", {
-    name: /Set up input|Fake Default Audio Input · Input 1/,
+    name: /Microphone access required · Set up|Fake Default Audio Input · Input 1/,
   });
   await expect(page.getByTestId("recorder-input-toggle")).toHaveAttribute(
     "aria-pressed",

--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -39,8 +39,10 @@ test("records, plays, and replaces a take", async ({ page }) => {
   // Recording starts capture and rolls the stopped transport.
   const recordButton = page.getByTestId("recorder-record-button");
   const playButton = page.getByTestId("recorder-play-button");
-  const downloadButton = page.getByTestId("recorder-download-take");
-  await expect(downloadButton).toBeDisabled();
+  const captureActions = page.getByRole("button", { name: "Capture actions" });
+  await captureActions.click();
+  await expect(page.getByTestId("recorder-download-take")).toBeDisabled();
+  await page.keyboard.press("Escape");
   await recordButton.click();
   await expect(recordButton).toHaveAttribute("aria-pressed", "true");
   await expect(playButton).toHaveAttribute("aria-pressed", "true");
@@ -62,14 +64,17 @@ test("records, plays, and replaces a take", async ({ page }) => {
   const take = page.getByTestId("recorder-clip-take");
   await expect(take).toContainText("Take 1");
   await expect(take.locator("svg")).toBeVisible();
-  await expect(downloadButton).toBeEnabled();
+  await captureActions.click();
+  await expect(page.getByTestId("recorder-download-take")).toBeEnabled();
+  await page.keyboard.press("Escape");
   expect(
     Number.parseFloat(await take.evaluate((element) => element.style.left)),
   ).toBeCloseTo(160, -2);
 
   // The finalized take downloads as a timestamped WAV file.
   const downloadPromise = page.waitForEvent("download");
-  await downloadButton.click();
+  await captureActions.click();
+  await page.getByTestId("recorder-download-take").click();
   const download = await downloadPromise;
   expect(download.suggestedFilename()).toMatch(/^toy-midi-take-1-.*\.wav$/);
   const downloadPath = test.info().outputPath("take.wav");
@@ -106,14 +111,36 @@ async function seekRecorderByPixels(page: Page, pixels: number) {
 
 async function enableInput(page: Page) {
   // Fake audio still exercises permission, device discovery, and channel setup.
-  const inputButton = page.getByRole("button", { name: "Enable input" });
-  await expect(inputButton).toBeVisible();
-  await inputButton.click();
+  const route = page.getByRole("button", {
+    name: /Set up input|Fake Default Audio Input · Input 1/,
+  });
+  await expect(page.getByTestId("recorder-input-toggle")).toHaveAttribute(
+    "aria-pressed",
+    "false",
+  );
+  await route.click();
   await expect(
-    page.getByRole("button", { name: "Disable input" }),
+    page.getByRole("heading", { name: "Audio Input Setup" }),
+  ).toBeVisible();
+  const setup = page.getByTestId("recorder-input-setup");
+  await setup
+    .getByRole("button", { name: /Grant access|Enable input/ })
+    .click();
+  await expect(
+    setup.getByRole("button", { name: "Disable input" }),
   ).toBeVisible();
   await expect(page.getByLabel("Device")).toContainText(
     "Fake Default Audio Input",
   );
   await expect(page.getByLabel("Channel")).toContainText("Channel 1");
+  await page.getByRole("button", { name: "Close" }).click();
+  await expect(
+    page.getByRole("button", {
+      name: "Fake Default Audio Input · Input 1",
+    }),
+  ).toBeVisible();
+  await expect(page.getByTestId("recorder-input-toggle")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
 }

--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -112,7 +112,7 @@ async function seekRecorderByPixels(page: Page, pixels: number) {
 async function enableInput(page: Page) {
   // Fake audio still exercises permission, device discovery, and channel setup.
   const route = page.getByRole("button", {
-    name: /Microphone access required · Set up|Fake Default Audio Input · Input 1/,
+    name: "Fake Default Audio Input · Input 1",
   });
   await expect(page.getByTestId("recorder-input-toggle")).toHaveAttribute(
     "aria-pressed",
@@ -123,9 +123,7 @@ async function enableInput(page: Page) {
     page.getByRole("heading", { name: "Audio Input Setup" }),
   ).toBeVisible();
   const setup = page.getByTestId("recorder-input-setup");
-  await setup
-    .getByRole("button", { name: /Grant access|Enable input/ })
-    .click();
+  await setup.getByRole("button", { name: "Enable input" }).click();
   await expect(
     setup.getByRole("button", { name: "Disable input" }),
   ).toBeVisible();

--- a/src/components/input-meter.tsx
+++ b/src/components/input-meter.tsx
@@ -5,9 +5,11 @@ import { gainToDb, MAX_DB, MIN_DB } from "../lib/music";
 export function InputMeter({
   active,
   analyser,
+  compact = false,
 }: {
   active: boolean;
   analyser?: AudioAnalyser;
+  compact?: boolean;
 }) {
   const sampledPeak = useAnalyserPeak({ active, analyser });
 
@@ -20,7 +22,13 @@ export function InputMeter({
   const label = active ? `${decibels.toFixed(1)} dBFS` : "-∞ dBFS";
 
   return (
-    <div className="grid grid-cols-[1fr_76px] items-center gap-3">
+    <div
+      className={
+        compact
+          ? "grid items-center"
+          : "grid grid-cols-[1fr_76px] items-center gap-3"
+      }
+    >
       <div
         role="meter"
         aria-label="Input peak level"
@@ -51,9 +59,11 @@ export function InputMeter({
           style={{ left: `${zeroPosition}%` }}
         />
       </div>
-      <output className="text-right font-mono text-xs tabular-nums text-neutral-400">
-        {label}
-      </output>
+      {!compact && (
+        <output className="text-right font-mono text-xs tabular-nums text-neutral-400">
+          {label}
+        </output>
+      )}
     </div>
   );
 }

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -95,6 +95,8 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import { cn } from "../ui/utils";
 
+const MIN_CAPTURE_TRACK_HEIGHT = 128;
+
 export function Recorder({ projectId }: { projectId: string }) {
   const [runtime] = useState(() => new RecorderRuntime());
   const [isInputSetupOpen, setIsInputSetupOpen] = useState(false);
@@ -1366,7 +1368,12 @@ function CaptureTrackRow({
       return { startClientY: event.clientY, startHeight: height };
     },
     onMove: (event, drag) => {
-      onHeightChange(drag.startHeight + event.clientY - drag.startClientY);
+      onHeightChange(
+        Math.max(
+          MIN_CAPTURE_TRACK_HEIGHT,
+          drag.startHeight + event.clientY - drag.startClientY,
+        ),
+      );
     },
   });
   const mixToggleClass = (active: boolean) =>
@@ -1374,7 +1381,10 @@ function CaptureTrackRow({
       ? "size-7 border-emerald-600 bg-emerald-700 text-white hover:bg-emerald-600"
       : "size-7 border-neutral-600 text-neutral-300 hover:bg-neutral-700";
   return (
-    <div className="relative grid grid-cols-[15rem_1fr]" style={{ height }}>
+    <div
+      className="relative grid grid-cols-[15rem_1fr]"
+      style={{ height: Math.max(MIN_CAPTURE_TRACK_HEIGHT, height) }}
+    >
       <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 p-3">
         <div className="min-w-0">
           <div className="truncate text-xs font-semibold">Capture</div>

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -610,7 +610,10 @@ function useRecorderInput({
 
   // The initial device enumeration has settled, so the UI can leave loading state.
   const initialized = refreshMutation.isSuccess || refreshMutation.isError;
-  const hasAccess = devices.some((device) => device.label);
+  // Optimistically treat a pending grant as access so the UI does not flash
+  // the permission callout between a successful prompt and device refresh.
+  const hasAccess =
+    grantMutation.isPending || devices.some((device) => device.label);
   const selectedDevice = devices.find((device) => device.deviceId === deviceId);
 
   return {

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -279,7 +279,7 @@ export function Recorder({ projectId }: { projectId: string }) {
                 onHeightChange={(height) =>
                   runtime.setAudioTrackHeight(track.id, height)
                 }
-                action={
+                actions={
                   <AudioTrackActions
                     label={`Audio ${index + 1}`}
                     onFileChange={(file) =>
@@ -1227,7 +1227,7 @@ function TrackRow({
   gain,
   muted,
   soloed,
-  action,
+  actions,
   onGainChange,
   onMutedChange,
   onSoloedChange,
@@ -1240,7 +1240,7 @@ function TrackRow({
   gain: number;
   muted: boolean;
   soloed: boolean;
-  action?: React.ReactNode;
+  actions: React.ReactNode;
   onGainChange: (gain: number) => void;
   onMutedChange: (muted: boolean) => void;
   onSoloedChange: (soloed: boolean) => void;
@@ -1273,7 +1273,7 @@ function TrackRow({
           </div>
         </div>
         <div className="flex gap-1">
-          {action}
+          {actions}
           <Button
             onClick={() => onMutedChange(!muted)}
             className={toggleClass(muted)}

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -82,6 +82,7 @@ import { openFilePicker } from "../file-drop-input";
 import { MetronomeIcon } from "../icons";
 import { InputMeter } from "../input-meter";
 import { Button } from "../ui/button";
+import { Dialog } from "../ui/dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -96,6 +97,7 @@ import { cn } from "../ui/utils";
 
 export function Recorder({ projectId }: { projectId: string }) {
   const [runtime] = useState(() => new RecorderRuntime());
+  const [isInputSetupOpen, setIsInputSetupOpen] = useState(false);
   const state = useSyncExternalStore(
     runtime.store.subscribe,
     runtime.store.get,
@@ -146,14 +148,6 @@ export function Recorder({ projectId }: { projectId: string }) {
   const take = state.recordingTrack.takes[0];
   const isRecording = state.captureStatus === "recording";
   const isProcessing = state.captureStatus === "processing";
-  const error =
-    input.error ??
-    project.error ??
-    addAudioMutation.error ??
-    audioTrackMutation.error ??
-    playMutation.error ??
-    recordMutation.error;
-
   function togglePlay() {
     if (isProcessing) {
       return;
@@ -237,15 +231,15 @@ export function Recorder({ projectId }: { projectId: string }) {
         onGridDivisionChange={timeline.setGridDivision}
       />
 
-      <div className="grid min-h-0 flex-1 grid-cols-[minmax(44rem,1fr)_18rem]">
-        <section className="relative min-w-0 overflow-x-hidden overflow-y-auto border-r border-neutral-700">
+      <div className="min-h-0 flex-1">
+        <section className="relative h-full min-w-0 overflow-x-hidden overflow-y-auto">
           <div
             ref={timeline.viewportRef}
-            className="pointer-events-none absolute inset-y-0 left-[13.5rem] right-0"
+            className="pointer-events-none absolute inset-y-0 left-[15rem] right-0"
           />
           <div className="relative">
             {timeline.showPlayhead && (
-              <div className="pointer-events-none absolute inset-y-0 left-[13.5rem] right-0 z-30 overflow-hidden">
+              <div className="pointer-events-none absolute inset-y-0 left-[15rem] right-0 z-30 overflow-hidden">
                 <div
                   className="absolute inset-y-0 w-px bg-sky-400"
                   style={{ left: timeline.playheadX }}
@@ -328,20 +322,36 @@ export function Recorder({ projectId }: { projectId: string }) {
               </TrackRow>
             ))}
 
-            <TrackRow
-              title="Capture"
+            <CaptureTrackRow
+              route={
+                input.selectedDevice
+                  ? `${input.selectedDevice.label || "Audio input"} · Input ${state.selectedChannel + 1}`
+                  : "Set up input"
+              }
               subtitle={
-                isRecording
-                  ? `Recording · ${formatTimeWithMilliseconds(take?.duration ?? 0)}`
-                  : take
-                    ? `Take 1 · ${formatTimeWithMilliseconds(take.duration)}`
-                    : "No take"
+                isProcessing
+                  ? "Finalizing take…"
+                  : isRecording
+                    ? `Recording · ${formatTimeWithMilliseconds(take?.duration ?? 0)}`
+                    : take
+                      ? `Take 1 · ${formatTimeWithMilliseconds(take.duration)}`
+                      : "No take"
               }
               gain={state.recordingTrack.gain}
               height={state.recordingTrack.height}
+              inputActive={input.active}
+              inputAnalyser={runtime.captureInput?.analyser}
+              inputToggleDisabled={
+                input.mutationPending || isRecording || isProcessing
+              }
               muted={state.recordingTrack.muted}
               soloed={state.recordingTrack.soloed}
+              takeDownloadDisabled={
+                !take?.buffer || isRecording || isProcessing
+              }
               onGainChange={(gain) => runtime.setRecordingTrackMix({ gain })}
+              onInputSetup={() => setIsInputSetupOpen(true)}
+              onInputToggle={input.toggle}
               onMutedChange={(muted) => runtime.setRecordingTrackMix({ muted })}
               onSoloedChange={(soloed) =>
                 runtime.setRecordingTrackMix({ soloed })
@@ -349,29 +359,18 @@ export function Recorder({ projectId }: { projectId: string }) {
               onHeightChange={(height) =>
                 runtime.setRecordingTrackHeight(height)
               }
-              action={
-                <Button
-                  data-testid="recorder-download-take"
-                  disabled={!take?.buffer || isRecording || isProcessing}
-                  onClick={() => {
-                    if (!take?.buffer) {
-                      return;
-                    }
-                    downloadBlob(
-                      encodeWav(take.buffer),
-                      buildExportFileName({
-                        baseName: "toy-midi-take-1",
-                        extension: "wav",
-                      }),
-                    );
-                  }}
-                  className="size-7 border-neutral-600 text-neutral-300 hover:bg-neutral-700"
-                  title="Download take"
-                  aria-label="Download take"
-                >
-                  <DownloadIcon className="size-3.5" />
-                </Button>
-              }
+              onTakeDownload={() => {
+                if (!take?.buffer) {
+                  return;
+                }
+                downloadBlob(
+                  encodeWav(take.buffer),
+                  buildExportFileName({
+                    baseName: "toy-midi-take-1",
+                    extension: "wav",
+                  }),
+                );
+              }}
             >
               <TimelineLane
                 clip={
@@ -398,41 +397,46 @@ export function Recorder({ projectId }: { projectId: string }) {
                 emptyLabel="Enable input, place the playhead, then record"
                 onSeek={(position) => runtime.seek(position)}
               />
-            </TrackRow>
+            </CaptureTrackRow>
           </div>
         </section>
 
-        <InputInspector
-          devices={input.devices}
-          error={error}
-          hasAccess={input.hasAccess}
-          inputActive={input.active}
-          inputAnalyser={runtime.captureInput?.analyser}
-          inputsInitialized={input.initialized}
-          isProcessing={isProcessing}
-          isRecording={isRecording}
-          selectedDevice={input.selectedDevice}
-          selectedChannel={state.selectedChannel}
-          inputChannelCount={state.inputChannelCount}
-          latencyCompensation={state.latencyCompensation}
-          inputTogglePending={input.togglePending}
-          mutationPending={input.mutationPending}
-          onDeviceChange={input.selectDevice}
-          onInputToggle={input.toggle}
-          onChannelChange={(channel) => {
-            input.selectChannel(channel);
-          }}
-          onLatencyCompensationChange={(compensation) => {
-            const wasPlaying = state.isPlaying;
-            if (wasPlaying) {
-              runtime.pause();
-            }
-            input.setLatencyCompensation(compensation);
-            if (wasPlaying) {
-              playMutation.mutate();
-            }
-          }}
-        />
+        <Dialog
+          isOpen={isInputSetupOpen}
+          onClose={() => setIsInputSetupOpen(false)}
+          title="Audio Input Setup"
+          testId="recorder-input-setup"
+        >
+          <InputSetup
+            devices={input.devices}
+            error={input.error}
+            hasAccess={input.hasAccess}
+            inputActive={input.active}
+            inputAnalyser={runtime.captureInput?.analyser}
+            inputsInitialized={input.initialized}
+            isProcessing={isProcessing}
+            isRecording={isRecording}
+            selectedDevice={input.selectedDevice}
+            selectedChannel={state.selectedChannel}
+            inputChannelCount={state.inputChannelCount}
+            latencyCompensation={state.latencyCompensation}
+            inputTogglePending={input.togglePending}
+            mutationPending={input.mutationPending}
+            onDeviceChange={input.selectDevice}
+            onInputToggle={input.toggle}
+            onChannelChange={input.selectChannel}
+            onLatencyCompensationChange={(compensation) => {
+              const wasPlaying = state.isPlaying;
+              if (wasPlaying) {
+                runtime.pause();
+              }
+              input.setLatencyCompensation(compensation);
+              if (wasPlaying) {
+                playMutation.mutate();
+              }
+            }}
+          />
+        </Dialog>
       </div>
     </main>
   );
@@ -1066,7 +1070,7 @@ function TimelineHeader({
   onSeek: (position: number) => void;
 }) {
   return (
-    <div className="sticky top-0 z-10 grid h-10 grid-cols-[13.5rem_1fr] border-b border-neutral-700 bg-neutral-800">
+    <div className="sticky top-0 z-10 grid h-10 grid-cols-[15rem_1fr] border-b border-neutral-700 bg-neutral-800">
       <div className="sticky left-0 z-20 flex items-center border-r border-neutral-700 bg-neutral-800 px-3 text-xs font-semibold">
         <span>Tracks</span>
         <div className="flex-1" />
@@ -1258,7 +1262,7 @@ function TrackRow({
       : "size-7 border-neutral-600 text-neutral-300 hover:bg-neutral-700";
   return (
     <div
-      className="relative grid grid-cols-[13.5rem_1fr] border-b border-neutral-700"
+      className="relative grid grid-cols-[15rem_1fr] border-b border-neutral-700"
       style={{ height }}
     >
       <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] gap-2 border-r border-neutral-700 bg-neutral-800 p-3">
@@ -1312,6 +1316,164 @@ function TrackRow({
         ref={resizeRef}
         className="absolute inset-x-0 -bottom-1 z-30 h-2 cursor-ns-resize"
         title={`Resize ${title}`}
+      />
+    </div>
+  );
+}
+
+function CaptureTrackRow({
+  route,
+  subtitle,
+  height,
+  gain,
+  inputActive,
+  inputAnalyser,
+  inputToggleDisabled,
+  muted,
+  soloed,
+  takeDownloadDisabled,
+  onGainChange,
+  onInputSetup,
+  onInputToggle,
+  onMutedChange,
+  onSoloedChange,
+  onTakeDownload,
+  onHeightChange,
+  children,
+}: {
+  route: string;
+  subtitle: string;
+  height: number;
+  gain: number;
+  inputActive: boolean;
+  inputAnalyser?: AudioAnalyser;
+  inputToggleDisabled: boolean;
+  muted: boolean;
+  soloed: boolean;
+  takeDownloadDisabled: boolean;
+  onGainChange: (gain: number) => void;
+  onInputSetup: () => void;
+  onInputToggle: () => void;
+  onMutedChange: (muted: boolean) => void;
+  onSoloedChange: (soloed: boolean) => void;
+  onTakeDownload: () => void;
+  onHeightChange: (height: number) => void;
+  children: React.ReactNode;
+}) {
+  const resizeRef = usePointerDrag({
+    onStart: (event) => {
+      event.preventDefault();
+      return { startClientY: event.clientY, startHeight: height };
+    },
+    onMove: (event, drag) => {
+      onHeightChange(drag.startHeight + event.clientY - drag.startClientY);
+    },
+  });
+  const mixToggleClass = (active: boolean) =>
+    active
+      ? "size-7 border-emerald-600 bg-emerald-700 text-white hover:bg-emerald-600"
+      : "size-7 border-neutral-600 text-neutral-300 hover:bg-neutral-700";
+  return (
+    <div
+      className="relative grid grid-cols-[15rem_1fr] border-b border-neutral-700"
+      style={{ height }}
+    >
+      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 p-3">
+        <div className="min-w-0">
+          <div className="truncate text-xs font-semibold">Capture</div>
+          <div className="mt-0.5 truncate text-[11px] text-neutral-400">
+            {subtitle}
+          </div>
+        </div>
+        <div className="flex gap-1">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                className="size-7 border-neutral-600 text-neutral-300 hover:bg-neutral-700"
+                title="Capture actions"
+                aria-label="Capture actions"
+              >
+                <MoreVerticalIcon className="size-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                data-testid="recorder-download-take"
+                disabled={takeDownloadDisabled}
+                onSelect={onTakeDownload}
+              >
+                <DownloadIcon />
+                Download take
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <Button
+            data-testid="recorder-input-toggle"
+            disabled={inputToggleDisabled}
+            onClick={onInputToggle}
+            className={
+              inputActive
+                ? "size-7 border-red-600 bg-red-700 text-white hover:bg-red-600"
+                : "size-7 border-neutral-600 text-neutral-300 hover:bg-neutral-700"
+            }
+            title={inputActive ? "Disable input" : "Enable input"}
+            aria-label={inputActive ? "Disable input" : "Enable input"}
+            aria-pressed={inputActive}
+          >
+            R
+          </Button>
+          <Button
+            onClick={() => onMutedChange(!muted)}
+            className={mixToggleClass(muted)}
+            title={muted ? "Unmute Capture" : "Mute Capture"}
+          >
+            M
+          </Button>
+          <Button
+            onClick={() => onSoloedChange(!soloed)}
+            className={mixToggleClass(soloed)}
+            title={soloed ? "Disable Capture solo" : "Solo Capture"}
+          >
+            S
+          </Button>
+        </div>
+        <button
+          type="button"
+          onClick={onInputSetup}
+          className="col-span-2 min-w-0 truncate text-left text-[11px] text-neutral-400 hover:text-neutral-100 hover:underline"
+        >
+          {route}
+        </button>
+        <div className="col-span-2">
+          <InputMeter active={inputActive} analyser={inputAnalyser} compact />
+        </div>
+        <label className="col-span-2 mt-auto grid grid-cols-[1fr_3.5rem] items-center gap-2 text-[10px] text-neutral-400">
+          <div className="relative">
+            <div
+              className="pointer-events-none absolute top-1/2 h-3 w-px -translate-y-1/2 bg-neutral-500/70"
+              style={{ left: `${dbToPercent(0)}%` }}
+            />
+            <input
+              aria-label="Capture gain"
+              type="range"
+              min={0}
+              max={100}
+              step={1}
+              value={gainToPercent(gain)}
+              onChange={(event) =>
+                onGainChange(percentToGain(event.currentTarget.valueAsNumber))
+              }
+              className="w-full accent-emerald-600"
+            />
+          </div>
+          <span className="text-right font-mono">{formatGainDb(gain)}</span>
+        </label>
+      </div>
+      {children}
+      <div
+        ref={resizeRef}
+        className="absolute inset-x-0 -bottom-1 z-30 h-2 cursor-ns-resize"
+        title="Resize Capture"
       />
     </div>
   );
@@ -1509,7 +1671,7 @@ function getTimelineGridStyle({
   });
 }
 
-function InputInspector({
+function InputSetup({
   devices,
   error,
   hasAccess,
@@ -1558,11 +1720,8 @@ function InputInspector({
   const inputClass =
     "mt-1 h-8 w-full rounded border border-neutral-600 bg-neutral-900 px-2 text-xs text-neutral-100 disabled:text-neutral-500";
   return (
-    <aside className="min-h-0 overflow-y-auto bg-neutral-800">
-      <h2 className="flex h-10 items-center border-b border-neutral-700 px-3 text-xs font-semibold">
-        Input
-      </h2>
-      <div className="space-y-4 border-b border-neutral-700 p-3">
+    <div className="max-h-[70vh] overflow-y-auto">
+      <div className="space-y-4">
         <label className="block text-[11px] font-medium text-neutral-400">
           Device
           <select
@@ -1681,10 +1840,10 @@ function InputInspector({
       </div>
 
       {error && (
-        <div className="m-3 border border-orange-700/60 bg-orange-950/40 p-3 text-xs text-orange-200">
+        <div className="mt-4 border border-orange-700/60 bg-orange-950/40 p-3 text-xs text-orange-200">
           {error.message}
         </div>
       )}
-    </aside>
+    </div>
   );
 }

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1401,7 +1401,7 @@ function CaptureTrackRow({
       className="relative grid grid-cols-[15rem_1fr]"
       style={{ height: Math.max(MIN_CAPTURE_TRACK_HEIGHT, height) }}
     >
-      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 p-3">
+      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[2rem_1rem_0.75rem_1fr] gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 p-3">
         <div className="min-w-0">
           <div className="truncate text-xs font-semibold">Capture</div>
           <div className="mt-0.5 truncate text-[11px] text-neutral-400">
@@ -1475,7 +1475,7 @@ function CaptureTrackRow({
         <div className="col-span-2">
           <InputMeter active={inputActive} analyser={inputAnalyser} compact />
         </div>
-        <label className="col-span-2 mt-auto grid grid-cols-[1fr_3.5rem] items-center gap-2 text-[10px] text-neutral-400">
+        <label className="col-span-2 grid grid-cols-[1fr_3.5rem] items-end gap-2 text-[10px] text-neutral-400">
           <div className="relative">
             <div
               className="pointer-events-none absolute top-1/2 h-3 w-px -translate-y-1/2 bg-neutral-500/70"

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -151,7 +151,7 @@ export function Recorder({ projectId }: { projectId: string }) {
   const isRecording = state.captureStatus === "recording";
   const isProcessing = state.captureStatus === "processing";
   const inputRoute = !input.initialized
-    ? { label: "Loading audio inputs…", needsSetup: true }
+    ? { label: "Loading audio inputs…", needsSetup: false }
     : !input.hasAccess
       ? { label: "Microphone access required · Set up", needsSetup: true }
       : input.selectedDevice
@@ -352,6 +352,7 @@ export function Recorder({ projectId }: { projectId: string }) {
               inputAnalyser={runtime.captureInput?.analyser}
               inputToggleDisabled={
                 input.mutationPending ||
+                !input.initialized ||
                 isRecording ||
                 isProcessing ||
                 (!input.active && inputRoute.needsSetup)

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -237,7 +237,7 @@ export function Recorder({ projectId }: { projectId: string }) {
             ref={timeline.viewportRef}
             className="pointer-events-none absolute inset-y-0 left-[15rem] right-0"
           />
-          <div className="relative">
+          <div className="relative min-h-full">
             {timeline.showPlayhead && (
               <div className="pointer-events-none absolute inset-y-0 left-[15rem] right-0 z-30 overflow-hidden">
                 <div

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -279,7 +279,7 @@ export function Recorder({ projectId }: { projectId: string }) {
                 onHeightChange={(height) =>
                   runtime.setAudioTrackHeight(track.id, height)
                 }
-                actions={
+                action={
                   <AudioTrackActions
                     label={`Audio ${index + 1}`}
                     onFileChange={(file) =>
@@ -1227,7 +1227,7 @@ function TrackRow({
   gain,
   muted,
   soloed,
-  actions,
+  action,
   onGainChange,
   onMutedChange,
   onSoloedChange,
@@ -1240,7 +1240,7 @@ function TrackRow({
   gain: number;
   muted: boolean;
   soloed: boolean;
-  actions: React.ReactNode;
+  action: React.ReactNode;
   onGainChange: (gain: number) => void;
   onMutedChange: (muted: boolean) => void;
   onSoloedChange: (soloed: boolean) => void;
@@ -1273,7 +1273,7 @@ function TrackRow({
           </div>
         </div>
         <div className="flex gap-1">
-          {actions}
+          {action}
           <Button
             onClick={() => onMutedChange(!muted)}
             className={toggleClass(muted)}

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -26,6 +26,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
+import { toast } from "sonner";
 import { useDraftInput } from "../../hooks/use-draft-input";
 import { usePointerDrag } from "../../hooks/use-pointer-drag";
 import { useTapTempo } from "../../hooks/use-tap-tempo";
@@ -230,12 +231,6 @@ export function Recorder({ projectId }: { projectId: string }) {
         }
         onGridDivisionChange={timeline.setGridDivision}
       />
-
-      {project.error && (
-        <div className="border-b border-orange-700/60 bg-orange-950/40 px-4 py-3 text-xs text-orange-200">
-          {project.error.message}
-        </div>
-      )}
 
       <div className="min-h-0 flex-1">
         <section className="relative h-full min-w-0 overflow-x-hidden overflow-y-auto">
@@ -466,9 +461,14 @@ function useRecorderProject({
     retry: false,
     staleTime: Infinity,
     queryFn: async () => {
-      const project = await recorderProjectStorage.load(projectId);
-      runtime.deserializeProject(project);
-      return true;
+      try {
+        const project = await recorderProjectStorage.load(projectId);
+        runtime.deserializeProject(project);
+        return true;
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Unknown error");
+        throw error;
+      }
     },
   });
 

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -95,8 +95,6 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import { cn } from "../ui/utils";
 
-const MIN_CAPTURE_TRACK_HEIGHT = 128;
-
 export function Recorder({ projectId }: { projectId: string }) {
   const [runtime] = useState(() => new RecorderRuntime());
   const [isInputSetupOpen, setIsInputSetupOpen] = useState(false);
@@ -1385,12 +1383,7 @@ function CaptureTrackRow({
       return { startClientY: event.clientY, startHeight: height };
     },
     onMove: (event, drag) => {
-      onHeightChange(
-        Math.max(
-          MIN_CAPTURE_TRACK_HEIGHT,
-          drag.startHeight + event.clientY - drag.startClientY,
-        ),
-      );
+      onHeightChange(drag.startHeight + event.clientY - drag.startClientY);
     },
   });
   const mixToggleClass = (active: boolean) =>
@@ -1398,10 +1391,7 @@ function CaptureTrackRow({
       ? "size-7 border-emerald-600 bg-emerald-700 text-white hover:bg-emerald-600"
       : "size-7 border-neutral-600 text-neutral-300 hover:bg-neutral-700";
   return (
-    <div
-      className="relative grid grid-cols-[15rem_1fr]"
-      style={{ height: Math.max(MIN_CAPTURE_TRACK_HEIGHT, height) }}
-    >
+    <div className="relative grid grid-cols-[15rem_1fr]" style={{ height }}>
       <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[2rem_1rem_0.75rem_1fr] gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 p-3">
         <div className="min-w-0">
           <div className="truncate text-xs font-semibold">Capture</div>

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -150,16 +150,6 @@ export function Recorder({ projectId }: { projectId: string }) {
   const take = state.recordingTrack.takes[0];
   const isRecording = state.captureStatus === "recording";
   const isProcessing = state.captureStatus === "processing";
-  const inputRoute = !input.initialized
-    ? { label: "Loading audio inputs…", needsSetup: false }
-    : !input.hasAccess
-      ? { label: "Microphone access required · Set up", needsSetup: true }
-      : input.selectedDevice
-        ? {
-            label: `${input.selectedDevice.label || "Audio input"} · Input ${state.selectedChannel + 1}`,
-            needsSetup: false,
-          }
-        : { label: "No input configured · Set up", needsSetup: true };
   function togglePlay() {
     if (isProcessing) {
       return;
@@ -335,8 +325,8 @@ export function Recorder({ projectId }: { projectId: string }) {
             ))}
 
             <CaptureTrackRow
-              route={inputRoute.label}
-              routeNeedsSetup={inputRoute.needsSetup}
+              route={input.route.label}
+              routeNeedsSetup={input.route.needsSetup}
               subtitle={
                 isProcessing
                   ? "Finalizing take…"
@@ -355,7 +345,7 @@ export function Recorder({ projectId }: { projectId: string }) {
                 !input.initialized ||
                 isRecording ||
                 isProcessing ||
-                (!input.active && inputRoute.needsSetup)
+                (!input.active && input.route.needsSetup)
               }
               muted={state.recordingTrack.muted}
               soloed={state.recordingTrack.soloed}
@@ -616,6 +606,16 @@ function useRecorderInput({
   const hasAccess =
     grantMutation.isPending || devices.some((device) => device.label);
   const selectedDevice = devices.find((device) => device.deviceId === deviceId);
+  const route = !initialized
+    ? { label: "Loading audio inputs…", needsSetup: false }
+    : !hasAccess
+      ? { label: "Microphone access required · Set up", needsSetup: true }
+      : selectedDevice
+        ? {
+            label: `${selectedDevice.label || "Audio input"} · Input ${state.selectedChannel + 1}`,
+            needsSetup: false,
+          }
+        : { label: "No input configured · Set up", needsSetup: true };
 
   return {
     active,
@@ -627,6 +627,7 @@ function useRecorderInput({
       refreshMutation.isPending ||
       grantMutation.isPending ||
       startMutation.isPending,
+    route,
     selectedDevice,
     selectDevice,
     selectChannel: (channel: number) => {

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -150,6 +150,16 @@ export function Recorder({ projectId }: { projectId: string }) {
   const take = state.recordingTrack.takes[0];
   const isRecording = state.captureStatus === "recording";
   const isProcessing = state.captureStatus === "processing";
+  const inputRoute = !input.initialized
+    ? { label: "Loading audio inputs…", needsSetup: true }
+    : !input.hasAccess
+      ? { label: "Microphone access required · Set up", needsSetup: true }
+      : input.selectedDevice
+        ? {
+            label: `${input.selectedDevice.label || "Audio input"} · Input ${state.selectedChannel + 1}`,
+            needsSetup: false,
+          }
+        : { label: "No input configured · Set up", needsSetup: true };
   function togglePlay() {
     if (isProcessing) {
       return;
@@ -325,11 +335,8 @@ export function Recorder({ projectId }: { projectId: string }) {
             ))}
 
             <CaptureTrackRow
-              route={
-                input.selectedDevice
-                  ? `${input.selectedDevice.label || "Audio input"} · Input ${state.selectedChannel + 1}`
-                  : "Set up input"
-              }
+              route={inputRoute.label}
+              routeNeedsSetup={inputRoute.needsSetup}
               subtitle={
                 isProcessing
                   ? "Finalizing take…"
@@ -344,7 +351,10 @@ export function Recorder({ projectId }: { projectId: string }) {
               inputActive={input.active}
               inputAnalyser={runtime.captureInput?.analyser}
               inputToggleDisabled={
-                input.mutationPending || isRecording || isProcessing
+                input.mutationPending ||
+                isRecording ||
+                isProcessing ||
+                (!input.active && inputRoute.needsSetup)
               }
               muted={state.recordingTrack.muted}
               soloed={state.recordingTrack.soloed}
@@ -1325,6 +1335,7 @@ function TrackRow({
 
 function CaptureTrackRow({
   route,
+  routeNeedsSetup,
   subtitle,
   height,
   gain,
@@ -1344,6 +1355,7 @@ function CaptureTrackRow({
   children,
 }: {
   route: string;
+  routeNeedsSetup: boolean;
   subtitle: string;
   height: number;
   gain: number;
@@ -1447,7 +1459,12 @@ function CaptureTrackRow({
         <button
           type="button"
           onClick={onInputSetup}
-          className="col-span-2 min-w-0 truncate text-left text-[11px] text-neutral-400 hover:text-neutral-100 hover:underline"
+          className={cn(
+            "col-span-2 min-w-0 truncate text-left text-[11px] hover:underline",
+            routeNeedsSetup
+              ? "font-medium text-orange-300 hover:text-orange-200"
+              : "text-neutral-400 hover:text-neutral-100",
+          )}
         >
           {route}
         </button>

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -231,6 +231,12 @@ export function Recorder({ projectId }: { projectId: string }) {
         onGridDivisionChange={timeline.setGridDivision}
       />
 
+      {project.error && (
+        <div className="border-b border-orange-700/60 bg-orange-950/40 px-4 py-3 text-xs text-orange-200">
+          {project.error.message}
+        </div>
+      )}
+
       <div className="min-h-0 flex-1">
         <section className="relative h-full min-w-0 overflow-x-hidden overflow-y-auto">
           <div

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -237,7 +237,7 @@ export function Recorder({ projectId }: { projectId: string }) {
             ref={timeline.viewportRef}
             className="pointer-events-none absolute inset-y-0 left-[15rem] right-0"
           />
-          <div className="relative min-h-full">
+          <div className="relative">
             {timeline.showPlayhead && (
               <div className="pointer-events-none absolute inset-y-0 left-[15rem] right-0 z-30 overflow-hidden">
                 <div
@@ -1374,10 +1374,7 @@ function CaptureTrackRow({
       ? "size-7 border-emerald-600 bg-emerald-700 text-white hover:bg-emerald-600"
       : "size-7 border-neutral-600 text-neutral-300 hover:bg-neutral-700";
   return (
-    <div
-      className="relative grid grid-cols-[15rem_1fr] border-b border-neutral-700"
-      style={{ height }}
-    >
+    <div className="relative grid grid-cols-[15rem_1fr]" style={{ height }}>
       <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 p-3">
         <div className="min-w-0">
           <div className="truncate text-xs font-semibold">Capture</div>
@@ -1472,7 +1469,7 @@ function CaptureTrackRow({
       {children}
       <div
         ref={resizeRef}
-        className="absolute inset-x-0 -bottom-1 z-30 h-2 cursor-ns-resize"
+        className="absolute inset-x-0 bottom-0 z-30 h-px cursor-ns-resize border-b border-neutral-700 after:absolute after:inset-x-0 after:-top-1 after:h-2"
         title="Resize Capture"
       />
     </div>

--- a/src/lib/recorder/persistence.ts
+++ b/src/lib/recorder/persistence.ts
@@ -1,5 +1,6 @@
 import { createAudioView } from "../audio-view.ts";
 import {
+  clampRecordingTrackHeight,
   WAVEFORM_POINTS_PER_SECOND,
   type PersistableRecorderRuntimeState,
   type RecorderRuntimeState,
@@ -121,7 +122,7 @@ export function deserializeRecorderRuntimeState({
       };
     }),
     recordingTrack: {
-      height: project.recordingTrack.height,
+      height: clampRecordingTrackHeight(project.recordingTrack.height),
       gain: project.recordingTrack.gain,
       muted: project.recordingTrack.muted,
       soloed: project.recordingTrack.soloed,

--- a/src/lib/recorder/persistence.ts
+++ b/src/lib/recorder/persistence.ts
@@ -1,6 +1,5 @@
 import { createAudioView } from "../audio-view.ts";
 import {
-  clampRecordingTrackHeight,
   WAVEFORM_POINTS_PER_SECOND,
   type PersistableRecorderRuntimeState,
   type RecorderRuntimeState,
@@ -122,7 +121,7 @@ export function deserializeRecorderRuntimeState({
       };
     }),
     recordingTrack: {
-      height: clampRecordingTrackHeight(project.recordingTrack.height),
+      height: project.recordingTrack.height,
       gain: project.recordingTrack.gain,
       muted: project.recordingTrack.muted,
       soloed: project.recordingTrack.soloed,

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -432,9 +432,15 @@ export class RecorderRuntime {
     const take = project.recordingTrack.takes[0];
     this.recordingTrackPlayback!.stop();
     this.recordingTrackPlayback!.setBuffer(take?.buffer);
+    // Clamp loaded external state at the runtime boundary so older projects
+    // cannot restore a Capture row too short for its current controls.
     this.store.update({
       ...project,
       position: 0,
+      recordingTrack: {
+        ...project.recordingTrack,
+        height: clampRecordingTrackHeight(project.recordingTrack.height),
+      },
     });
     this.transport!.seek(0);
     this.metronome!.setTempo(project.tempo);
@@ -586,7 +592,7 @@ function clampTrackHeight(height: number): number {
   return Math.max(MIN_TRACK_HEIGHT, Math.min(MAX_TRACK_HEIGHT, height));
 }
 
-export function clampRecordingTrackHeight(height: number): number {
+function clampRecordingTrackHeight(height: number): number {
   return Math.max(
     MIN_RECORDING_TRACK_HEIGHT,
     Math.min(MAX_TRACK_HEIGHT, height),

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -16,6 +16,7 @@ const MAX_RECORDING_SECONDS = 5 * 60;
 export const WAVEFORM_POINTS_PER_SECOND = 800;
 const DEFAULT_TRACK_HEIGHT = 96;
 const MIN_TRACK_HEIGHT = DEFAULT_TRACK_HEIGHT;
+const MIN_RECORDING_TRACK_HEIGHT = 128;
 const MAX_TRACK_HEIGHT = 300;
 
 type CaptureStatus = "disabled" | "ready" | "recording" | "processing";
@@ -296,7 +297,7 @@ export class RecorderRuntime {
     this.store.update({
       recordingTrack: {
         ...this.store.get().recordingTrack,
-        height: clampTrackHeight(height),
+        height: clampRecordingTrackHeight(height),
       },
     });
   }
@@ -573,7 +574,7 @@ function createAudioTrackState(): AudioTrackState {
 
 function createRecordingTrackState(): RecordingTrackState {
   return {
-    height: DEFAULT_TRACK_HEIGHT,
+    height: MIN_RECORDING_TRACK_HEIGHT,
     gain: 1,
     muted: false,
     soloed: false,
@@ -583,4 +584,11 @@ function createRecordingTrackState(): RecordingTrackState {
 
 function clampTrackHeight(height: number): number {
   return Math.max(MIN_TRACK_HEIGHT, Math.min(MAX_TRACK_HEIGHT, height));
+}
+
+export function clampRecordingTrackHeight(height: number): number {
+  return Math.max(
+    MIN_RECORDING_TRACK_HEIGHT,
+    Math.min(MAX_TRACK_HEIGHT, height),
+  );
 }


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/toy-midi/issues/355

The permanent input panel takes a large part of the recorder timeline for controls that are only occasionally configured.

This PR makes Capture the continuous input surface with record-enable, route, and compact meter controls, while moving detailed device, channel, level, and latency setup into a contextual Audio Input Setup dialog. It also reclaims the side-panel width for the timeline and keeps take download in Capture’s More menu.