### PR TITLE
feat: add recorder multi-take comping

### DIFF
--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -29,7 +29,7 @@ test("uploads and plays a backing track", async ({ page }) => {
   await expect(playButton).toHaveAttribute("aria-pressed", "false");
 });
 
-test("records, plays, and replaces a take", async ({ page }) => {
+test("records, plays, and manages multiple takes", async ({ page }) => {
   // The musician connects the browser input before recording is available.
   await enableInput(page);
 
@@ -67,11 +67,11 @@ test("records, plays, and replaces a take", async ({ page }) => {
     Number.parseFloat(await take.evaluate((element) => element.style.left)),
   ).toBeCloseTo(160, -2);
 
-  // The finalized take downloads as a timestamped WAV file.
+  // The resolved comp downloads as a timestamped WAV file.
   const downloadPromise = page.waitForEvent("download");
   await downloadButton.click();
   const download = await downloadPromise;
-  expect(download.suggestedFilename()).toMatch(/^toy-midi-take-1-.*\.wav$/);
+  expect(download.suggestedFilename()).toMatch(/^toy-midi-comp-.*\.wav$/);
   const downloadPath = test.info().outputPath("take.wav");
   await download.saveAs(downloadPath);
   expect(readFileSync(downloadPath).subarray(0, 4).toString()).toBe("RIFF");
@@ -89,12 +89,21 @@ test("records, plays, and replaces a take", async ({ page }) => {
   );
   await recordButton.click();
 
-  // MVP keeps one take, so the second recording replaces and repositions it.
-  await expect(take).toHaveCount(1);
-  await expect(take).toContainText("Take 1");
+  // The second recording is retained as a new source take.
+  await expect(take).toHaveCount(2);
+  await expect(take.nth(0)).toContainText("Take 1");
+  await expect(take.nth(1)).toContainText("Take 2");
   expect(
-    Number.parseFloat(await take.evaluate((element) => element.style.left)),
+    Number.parseFloat(
+      await take.nth(1).evaluate((element) => element.style.left),
+    ),
   ).toBeCloseTo(320, -2);
+
+  // Selecting and deleting a source take leaves the other take intact.
+  await take.nth(0).click();
+  await page.getByRole("button", { name: "Delete Take 1" }).click();
+  await expect(take).toHaveCount(1);
+  await expect(take).toContainText("Take 2");
 });
 
 async function seekRecorderByPixels(page: Page, pixels: number) {

--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -109,17 +109,13 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   const positionBeforeSelection = await position.textContent();
   await take.nth(0).click();
   await expect(position).toHaveText(positionBeforeSelection!);
-  await expect(
-    page.getByRole("button", { name: "Delete Take 1" }),
-  ).toBeVisible();
+  await expect(take.nth(0)).toHaveClass(/border-sky-300/);
   await page.keyboard.press("Escape");
-  await expect(
-    page.getByRole("button", { name: "Delete Take 1" }),
-  ).toBeHidden();
+  await expect(take.nth(0)).not.toHaveClass(/border-sky-300/);
 
   // Deleting a selected source take leaves the other take intact.
   await take.nth(0).click();
-  await page.getByRole("button", { name: "Delete Take 1" }).click();
+  await page.keyboard.press("Delete");
   await expect(take).toHaveCount(1);
   await expect(take).toContainText("Take 2");
 });

--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -72,12 +72,12 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
     Number.parseFloat(await take.evaluate((element) => element.style.left)),
   ).toBeCloseTo(160, -2);
 
-  // The resolved comp downloads as a timestamped WAV file.
+  // The resolved recording downloads as a timestamped WAV file.
   const downloadPromise = page.waitForEvent("download");
   await captureActions.click();
   await page.getByTestId("recorder-download-take").click();
   const download = await downloadPromise;
-  expect(download.suggestedFilename()).toMatch(/^toy-midi-comp-.*\.wav$/);
+  expect(download.suggestedFilename()).toMatch(/^toy-midi-recording-.*\.wav$/);
   const downloadPath = test.info().outputPath("take.wav");
   await download.saveAs(downloadPath);
   expect(readFileSync(downloadPath).subarray(0, 4).toString()).toBe("RIFF");

--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -39,6 +39,7 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   // Recording starts capture and rolls the stopped transport.
   const recordButton = page.getByTestId("recorder-record-button");
   const playButton = page.getByTestId("recorder-play-button");
+  const position = page.getByTestId("recorder-position");
   const captureActions = page.getByRole("button", { name: "Capture actions" });
   await captureActions.click();
   await expect(page.getByTestId("recorder-download-take")).toBeDisabled();
@@ -104,7 +105,19 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
     ),
   ).toBeCloseTo(320, -2);
 
-  // Selecting and deleting a source take leaves the other take intact.
+  // Selecting a source take does not seek, and Escape clears the selection.
+  const positionBeforeSelection = await position.textContent();
+  await take.nth(0).click();
+  await expect(position).toHaveText(positionBeforeSelection!);
+  await expect(
+    page.getByRole("button", { name: "Delete Take 1" }),
+  ).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(
+    page.getByRole("button", { name: "Delete Take 1" }),
+  ).toBeHidden();
+
+  // Deleting a selected source take leaves the other take intact.
   await take.nth(0).click();
   await page.getByRole("button", { name: "Delete Take 1" }).click();
   await expect(take).toHaveCount(1);

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -384,7 +384,9 @@ export function Recorder({ projectId }: { projectId: string }) {
               }}
             >
               <TakeTimelineLane
-                state={state}
+                captureStatus={state.captureStatus}
+                pendingTake={state.pendingTake}
+                takes={takes}
                 selectedTakeId={takeSelection.selectedId}
                 pixelsPerBeat={timeline.pixelsPerBeat}
                 beatsPerBar={timeline.beatsPerBar}
@@ -1541,33 +1543,35 @@ type RecorderTimelineClip = {
 
 function TakeTimelineLane({
   beatsPerBar,
+  captureStatus,
   emptyLabel,
   onSeek,
   onTakeDelete,
   onTakeSelect,
+  pendingTake,
   pixelsPerBeat,
   selectedTakeId,
-  state,
   subdivisionsPerBeat,
+  takes,
   tempo,
   viewportStartBeat,
   viewportWidth,
 }: {
   beatsPerBar: number;
+  captureStatus: RecorderRuntimeState["captureStatus"];
   emptyLabel: string;
   onSeek: (position: number) => void;
   onTakeDelete: (id: string) => void;
   onTakeSelect: (id: string) => void;
+  pendingTake: RecorderRuntimeState["pendingTake"];
   pixelsPerBeat: number;
   selectedTakeId?: string;
-  state: RecorderRuntimeState;
   subdivisionsPerBeat: number;
+  takes: RecorderRuntimeState["recordingTrack"]["takes"];
   tempo: number;
   viewportStartBeat: number;
   viewportWidth: number;
 }) {
-  const takes = state.recordingTrack.takes;
-  const pendingTake = state.pendingTake;
   return (
     <div
       className="relative overflow-hidden bg-neutral-900"
@@ -1628,7 +1632,7 @@ function TakeTimelineLane({
             clip={{
               duration: pendingTake.duration,
               label:
-                state.captureStatus === "processing"
+                captureStatus === "processing"
                   ? "Finalizing..."
                   : "Recording...",
               offset: pendingTake.timelineOffset,

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -384,16 +384,7 @@ export function Recorder({ projectId }: { projectId: string }) {
               }}
             >
               <TakeTimelineLane
-                takes={takes}
-                pendingTake={
-                  state.pendingTake
-                    ? {
-                        duration: state.pendingTake.duration,
-                        label: isProcessing ? "Finalizing..." : "Recording...",
-                        offset: state.pendingTake.timelineOffset,
-                      }
-                    : undefined
-                }
+                state={state}
                 selectedTakeId={takeSelection.selectedId}
                 pixelsPerBeat={timeline.pixelsPerBeat}
                 beatsPerBar={timeline.beatsPerBar}
@@ -1554,11 +1545,10 @@ function TakeTimelineLane({
   onSeek,
   onTakeDelete,
   onTakeSelect,
-  pendingTake,
   pixelsPerBeat,
   selectedTakeId,
+  state,
   subdivisionsPerBeat,
-  takes,
   tempo,
   viewportStartBeat,
   viewportWidth,
@@ -1568,15 +1558,16 @@ function TakeTimelineLane({
   onSeek: (position: number) => void;
   onTakeDelete: (id: string) => void;
   onTakeSelect: (id: string) => void;
-  pendingTake?: Omit<RecorderTimelineClip, "variant">;
   pixelsPerBeat: number;
   selectedTakeId?: string;
+  state: RecorderRuntimeState;
   subdivisionsPerBeat: number;
-  takes: RecorderRuntimeState["recordingTrack"]["takes"];
   tempo: number;
   viewportStartBeat: number;
   viewportWidth: number;
 }) {
+  const takes = state.recordingTrack.takes;
+  const pendingTake = state.pendingTake;
   return (
     <div
       className="relative overflow-hidden bg-neutral-900"
@@ -1634,7 +1625,15 @@ function TakeTimelineLane({
       {pendingTake && (
         <div>
           <TimelineClip
-            clip={{ ...pendingTake, variant: "recording" }}
+            clip={{
+              duration: pendingTake.duration,
+              label:
+                state.captureStatus === "processing"
+                  ? "Finalizing..."
+                  : "Recording...",
+              offset: pendingTake.timelineOffset,
+              variant: "recording",
+            }}
             pixelsPerBeat={pixelsPerBeat}
             viewportStartBeat={viewportStartBeat}
             tempo={tempo}

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -384,13 +384,7 @@ export function Recorder({ projectId }: { projectId: string }) {
               }}
             >
               <TakeTimelineLane
-                takes={takes.map((take) => ({
-                  id: take.id,
-                  duration: take.duration,
-                  label: `Take ${take.number}`,
-                  offset: take.timelineOffset,
-                  audioView: take.audioView,
-                }))}
+                takes={takes}
                 pendingTake={
                   state.pendingTake
                     ? {
@@ -1554,8 +1548,6 @@ type RecorderTimelineClip = {
   audioView?: AudioView;
 };
 
-type RecorderTakeClip = Omit<RecorderTimelineClip, "variant"> & { id: string };
-
 function TakeTimelineLane({
   beatsPerBar,
   emptyLabel,
@@ -1580,7 +1572,7 @@ function TakeTimelineLane({
   pixelsPerBeat: number;
   selectedTakeId?: string;
   subdivisionsPerBeat: number;
-  takes: RecorderTakeClip[];
+  takes: RecorderRuntimeState["recordingTrack"]["takes"];
   tempo: number;
   viewportStartBeat: number;
   viewportWidth: number;
@@ -1611,7 +1603,13 @@ function TakeTimelineLane({
       {takes.map((take) => (
         <div key={take.id}>
           <TimelineClip
-            clip={{ ...take, variant: "take" }}
+            clip={{
+              duration: take.duration,
+              label: `Take ${take.number}`,
+              offset: take.timelineOffset,
+              variant: "take",
+              audioView: take.audioView,
+            }}
             pixelsPerBeat={pixelsPerBeat}
             viewportStartBeat={viewportStartBeat}
             tempo={tempo}
@@ -1623,8 +1621,8 @@ function TakeTimelineLane({
             <Button
               data-testid={`recorder-delete-${take.id}`}
               className="absolute right-1 top-1 z-20 size-6 border-red-900 bg-neutral-900/90 text-red-400 hover:bg-red-950"
-              title={`Delete ${take.label}`}
-              aria-label={`Delete ${take.label}`}
+              title={`Delete Take ${take.number}`}
+              aria-label={`Delete Take ${take.number}`}
               onPointerDown={(event) => event.stopPropagation()}
               onClick={() => onTakeDelete(take.id)}
             >

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -384,15 +384,15 @@ export function Recorder({ projectId }: { projectId: string }) {
               }}
             >
               <TakeTimelineLane
-                captureStatus={state.captureStatus}
-                pendingTake={state.pendingTake}
                 takes={takes}
+                pendingTake={state.pendingTake}
+                captureStatus={state.captureStatus}
                 selectedTakeId={takeSelection.selectedId}
-                pixelsPerBeat={timeline.pixelsPerBeat}
                 beatsPerBar={timeline.beatsPerBar}
                 subdivisionsPerBeat={timeline.subdivisionsPerBeat}
-                viewportStartBeat={timeline.viewportStartBeat}
+                pixelsPerBeat={timeline.pixelsPerBeat}
                 tempo={timeline.tempo}
+                viewportStartBeat={timeline.viewportStartBeat}
                 viewportWidth={timeline.viewportWidth}
                 emptyLabel="Enable input, place the playhead, then record"
                 onSeek={(position) => runtime.seek(position)}
@@ -1542,35 +1542,35 @@ type RecorderTimelineClip = {
 };
 
 function TakeTimelineLane({
-  beatsPerBar,
-  captureStatus,
-  emptyLabel,
-  onSeek,
-  onTakeDelete,
-  onTakeSelect,
-  pendingTake,
-  pixelsPerBeat,
-  selectedTakeId,
-  subdivisionsPerBeat,
   takes,
+  pendingTake,
+  captureStatus,
+  selectedTakeId,
+  beatsPerBar,
+  subdivisionsPerBeat,
+  pixelsPerBeat,
   tempo,
   viewportStartBeat,
   viewportWidth,
+  emptyLabel,
+  onSeek,
+  onTakeSelect,
+  onTakeDelete,
 }: {
-  beatsPerBar: number;
-  captureStatus: RecorderRuntimeState["captureStatus"];
-  emptyLabel: string;
-  onSeek: (position: number) => void;
-  onTakeDelete: (id: string) => void;
-  onTakeSelect: (id: string) => void;
-  pendingTake: RecorderRuntimeState["pendingTake"];
-  pixelsPerBeat: number;
-  selectedTakeId?: string;
-  subdivisionsPerBeat: number;
   takes: RecorderRuntimeState["recordingTrack"]["takes"];
+  pendingTake: RecorderRuntimeState["pendingTake"];
+  captureStatus: RecorderRuntimeState["captureStatus"];
+  selectedTakeId?: string;
+  beatsPerBar: number;
+  subdivisionsPerBeat: number;
+  pixelsPerBeat: number;
   tempo: number;
   viewportStartBeat: number;
   viewportWidth: number;
+  emptyLabel: string;
+  onSeek: (position: number) => void;
+  onTakeSelect: (id: string) => void;
+  onTakeDelete: (id: string) => void;
 }) {
   return (
     <div

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -116,7 +116,7 @@ export function Recorder({ projectId }: { projectId: string }) {
   const project = useRecorderProject({ projectId, runtime });
   const takeSelection = useRecorderTakeSelection({
     runtime,
-    takes: state.recordingTrack.takes,
+    state,
   });
 
   const playMutation = useMutation({
@@ -461,12 +461,13 @@ type SaveStatus = "saved" | "unsaved" | "saving" | "error";
 
 function useRecorderTakeSelection({
   runtime,
-  takes,
+  state,
 }: {
   runtime: RecorderRuntime;
-  takes: RecorderRuntimeState["recordingTrack"]["takes"];
+  state: RecorderRuntimeState;
 }) {
   const [selectedId, setSelectedId] = useState<string>();
+  const takes = state.recordingTrack.takes;
 
   useEffect(() => {
     if (selectedId && !takes.some((take) => take.id === selectedId)) {

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -96,6 +96,7 @@ import { cn } from "../ui/utils";
 
 export function Recorder({ projectId }: { projectId: string }) {
   const [runtime] = useState(() => new RecorderRuntime());
+  const [selectedTakeId, setSelectedTakeId] = useState<string>();
   const state = useSyncExternalStore(
     runtime.store.subscribe,
     runtime.store.get,
@@ -143,7 +144,8 @@ export function Recorder({ projectId }: { projectId: string }) {
     },
   });
 
-  const take = state.recordingTrack.takes[0];
+  const takes = state.recordingTrack.takes;
+  const selectedTake = takes.find((take) => take.id === selectedTakeId);
   const isRecording = state.captureStatus === "recording";
   const isProcessing = state.captureStatus === "processing";
   const error =
@@ -153,6 +155,12 @@ export function Recorder({ projectId }: { projectId: string }) {
     audioTrackMutation.error ??
     playMutation.error ??
     recordMutation.error;
+
+  useEffect(() => {
+    if (selectedTakeId && !selectedTake) {
+      setSelectedTakeId(undefined);
+    }
+  }, [selectedTake, selectedTakeId]);
 
   function togglePlay() {
     if (isProcessing) {
@@ -332,10 +340,10 @@ export function Recorder({ projectId }: { projectId: string }) {
               title="Capture"
               subtitle={
                 isRecording
-                  ? `Recording · ${formatTimeWithMilliseconds(take?.duration ?? 0)}`
-                  : take
-                    ? `Take 1 · ${formatTimeWithMilliseconds(take.duration)}`
-                    : "No take"
+                  ? `Recording · ${formatTimeWithMilliseconds(state.pendingTake?.duration ?? 0)}`
+                  : takes.length > 0
+                    ? `${takes.length} ${takes.length === 1 ? "take" : "takes"}`
+                    : "No takes"
               }
               gain={state.recordingTrack.gain}
               height={state.recordingTrack.height}
@@ -352,43 +360,46 @@ export function Recorder({ projectId }: { projectId: string }) {
               action={
                 <Button
                   data-testid="recorder-download-take"
-                  disabled={!take?.buffer || isRecording || isProcessing}
+                  disabled={takes.length === 0 || isRecording || isProcessing}
                   onClick={() => {
-                    if (!take?.buffer) {
+                    const comp = runtime.renderComp();
+                    if (!comp) {
                       return;
                     }
                     downloadBlob(
-                      encodeWav(take.buffer),
+                      encodeWav(comp),
                       buildExportFileName({
-                        baseName: "toy-midi-take-1",
+                        baseName: "toy-midi-comp",
                         extension: "wav",
                       }),
                     );
                   }}
                   className="size-7 border-neutral-600 text-neutral-300 hover:bg-neutral-700"
-                  title="Download take"
-                  aria-label="Download take"
+                  title="Download comp"
+                  aria-label="Download comp"
                 >
                   <DownloadIcon className="size-3.5" />
                 </Button>
               }
             >
-              <TimelineLane
-                clip={
-                  take
+              <TakeTimelineLane
+                takes={takes.map((take) => ({
+                  id: take.id,
+                  duration: take.duration,
+                  label: `Take ${take.number}`,
+                  offset: take.timelineOffset,
+                  audioView: take.audioView,
+                }))}
+                pendingTake={
+                  state.pendingTake
                     ? {
-                        duration: take.duration,
-                        label: isRecording
-                          ? "Recording..."
-                          : isProcessing
-                            ? "Finalizing..."
-                            : "Take 1",
-                        offset: take.timelineOffset,
-                        variant: isRecording ? "recording" : "take",
-                        audioView: take.audioView,
+                        duration: state.pendingTake.duration,
+                        label: isProcessing ? "Finalizing..." : "Recording...",
+                        offset: state.pendingTake.timelineOffset,
                       }
                     : undefined
                 }
+                selectedTakeId={selectedTakeId}
                 pixelsPerBeat={timeline.pixelsPerBeat}
                 beatsPerBar={timeline.beatsPerBar}
                 subdivisionsPerBeat={timeline.subdivisionsPerBeat}
@@ -397,6 +408,13 @@ export function Recorder({ projectId }: { projectId: string }) {
                 viewportWidth={timeline.viewportWidth}
                 emptyLabel="Enable input, place the playhead, then record"
                 onSeek={(position) => runtime.seek(position)}
+                onTakeSelect={setSelectedTakeId}
+                onTakeDelete={(id) => {
+                  runtime.removeTake(id);
+                  if (selectedTake?.id === id) {
+                    setSelectedTakeId(undefined);
+                  }
+                }}
               />
             </TrackRow>
           </div>
@@ -1325,6 +1343,110 @@ type RecorderTimelineClip = {
   audioView?: AudioView;
 };
 
+type RecorderTakeClip = Omit<RecorderTimelineClip, "variant"> & { id: string };
+
+function TakeTimelineLane({
+  beatsPerBar,
+  emptyLabel,
+  onSeek,
+  onTakeDelete,
+  onTakeSelect,
+  pendingTake,
+  pixelsPerBeat,
+  selectedTakeId,
+  subdivisionsPerBeat,
+  takes,
+  tempo,
+  viewportStartBeat,
+  viewportWidth,
+}: {
+  beatsPerBar: number;
+  emptyLabel: string;
+  onSeek: (position: number) => void;
+  onTakeDelete: (id: string) => void;
+  onTakeSelect: (id: string) => void;
+  pendingTake?: Omit<RecorderTimelineClip, "variant">;
+  pixelsPerBeat: number;
+  selectedTakeId?: string;
+  subdivisionsPerBeat: number;
+  takes: RecorderTakeClip[];
+  tempo: number;
+  viewportStartBeat: number;
+  viewportWidth: number;
+}) {
+  const laneCount = takes.length + (pendingTake ? 1 : 0);
+  return (
+    <div
+      className="relative grid overflow-hidden bg-neutral-900"
+      style={{
+        gridTemplateRows: `repeat(${Math.max(1, laneCount)}, minmax(0, 1fr))`,
+        ...getTimelineGridStyle({
+          beatsPerBar,
+          pixelsPerBeat,
+          viewportStartBeat,
+          subdivisionsPerBeat,
+        }),
+      }}
+      onPointerDown={(event) => {
+        const rect = event.currentTarget.getBoundingClientRect();
+        const beat = Math.max(
+          0,
+          (event.clientX - rect.left) / pixelsPerBeat + viewportStartBeat,
+        );
+        onSeek(beatsToSeconds(beat, tempo));
+      }}
+    >
+      {laneCount === 0 && (
+        <div className="absolute inset-0 grid place-items-center text-xs text-neutral-600">
+          {emptyLabel}
+        </div>
+      )}
+      {takes.map((take) => (
+        <div
+          key={take.id}
+          className={cn(
+            "relative min-h-0 border-b border-neutral-800 last:border-b-0",
+            selectedTakeId === take.id && "bg-sky-950/30",
+          )}
+        >
+          <TimelineClip
+            clip={{ ...take, variant: "take" }}
+            pixelsPerBeat={pixelsPerBeat}
+            viewportStartBeat={viewportStartBeat}
+            tempo={tempo}
+            viewportWidth={viewportWidth}
+            onSelect={() => onTakeSelect(take.id)}
+            selected={selectedTakeId === take.id}
+          />
+          {selectedTakeId === take.id && (
+            <Button
+              data-testid={`recorder-delete-${take.id}`}
+              className="absolute right-1 top-1 z-20 size-6 border-red-900 bg-neutral-900/90 text-red-400 hover:bg-red-950"
+              title={`Delete ${take.label}`}
+              aria-label={`Delete ${take.label}`}
+              onPointerDown={(event) => event.stopPropagation()}
+              onClick={() => onTakeDelete(take.id)}
+            >
+              <Trash2Icon className="size-3" />
+            </Button>
+          )}
+        </div>
+      ))}
+      {pendingTake && (
+        <div className="relative min-h-0">
+          <TimelineClip
+            clip={{ ...pendingTake, variant: "recording" }}
+            pixelsPerBeat={pixelsPerBeat}
+            viewportStartBeat={viewportStartBeat}
+            tempo={tempo}
+            viewportWidth={viewportWidth}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
 function TimelineLane({
   beatsPerBar,
   clip,
@@ -1395,6 +1517,8 @@ function TimelineClip({
   viewportWidth,
   onClipOffsetChange,
   onClipDragEnd,
+  onSelect,
+  selected = false,
 }: {
   clip: RecorderTimelineClip;
   pixelsPerBeat: number;
@@ -1403,6 +1527,8 @@ function TimelineClip({
   viewportWidth: number;
   onClipOffsetChange?: (offset: number) => void;
   onClipDragEnd?: () => void;
+  onSelect?: () => void;
+  selected?: boolean;
 }) {
   const [isDragging, setIsDragging] = useState(false);
   const dragRef = usePointerDrag({
@@ -1454,10 +1580,18 @@ function TimelineClip({
     <div
       data-testid={`recorder-clip-${clip.variant}`}
       ref={onClipOffsetChange ? dragRef : undefined}
+      onClick={(event) => {
+        if (onSelect) {
+          event.stopPropagation();
+          onSelect();
+        }
+      }}
       className={cn(
         "absolute inset-y-1 overflow-hidden rounded-sm border text-[11px]",
         clipClass,
         onClipOffsetChange && "cursor-ew-resize select-none",
+        onSelect && "cursor-pointer",
+        selected && "border-sky-300 ring-1 ring-inset ring-sky-300",
         isDragging && "brightness-125",
       )}
       style={{

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -377,7 +377,7 @@ export function Recorder({ projectId }: { projectId: string }) {
                 downloadBlob(
                   encodeWav(comp),
                   buildExportFileName({
-                    baseName: "toy-midi-comp",
+                    baseName: "toy-midi-recording",
                     extension: "wav",
                   }),
                 );
@@ -1459,7 +1459,7 @@ function CaptureTrackRow({
                 onSelect={onTakeDownload}
               >
                 <DownloadIcon />
-                Download comp
+                Download recording
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -98,7 +98,6 @@ import { cn } from "../ui/utils";
 
 export function Recorder({ projectId }: { projectId: string }) {
   const [runtime] = useState(() => new RecorderRuntime());
-  const [selectedTakeId, setSelectedTakeId] = useState<string>();
   const [isInputSetupOpen, setIsInputSetupOpen] = useState(false);
   const state = useSyncExternalStore(
     runtime.store.subscribe,
@@ -115,6 +114,10 @@ export function Recorder({ projectId }: { projectId: string }) {
     timeSignature: state.timeSignature,
   });
   const project = useRecorderProject({ projectId, runtime });
+  const takeSelection = useRecorderTakeSelection({
+    runtime,
+    takes: state.recordingTrack.takes,
+  });
 
   const playMutation = useMutation({
     mutationFn: () => {
@@ -148,15 +151,9 @@ export function Recorder({ projectId }: { projectId: string }) {
   });
 
   const takes = state.recordingTrack.takes;
-  const selectedTake = takes.find((take) => take.id === selectedTakeId);
   const isRecording = state.captureStatus === "recording";
   const isProcessing = state.captureStatus === "processing";
 
-  useEffect(() => {
-    if (selectedTakeId && !selectedTake) {
-      setSelectedTakeId(undefined);
-    }
-  }, [selectedTake, selectedTakeId]);
   function togglePlay() {
     if (isProcessing) {
       return;
@@ -195,9 +192,9 @@ export function Recorder({ projectId }: { projectId: string }) {
     if (isShortcutTextInputTarget(event.target) || event.repeat) {
       return;
     }
-    if (matchKeyboardEvent(event, "Escape") && selectedTakeId) {
+    if (matchKeyboardEvent(event, "Escape") && takeSelection.selectedId) {
       event.preventDefault();
-      setSelectedTakeId(undefined);
+      takeSelection.clear();
     } else if (matchKeyboardEvent(event, "Space")) {
       event.preventDefault();
       togglePlay();
@@ -403,7 +400,7 @@ export function Recorder({ projectId }: { projectId: string }) {
                       }
                     : undefined
                 }
-                selectedTakeId={selectedTakeId}
+                selectedTakeId={takeSelection.selectedId}
                 pixelsPerBeat={timeline.pixelsPerBeat}
                 beatsPerBar={timeline.beatsPerBar}
                 subdivisionsPerBeat={timeline.subdivisionsPerBeat}
@@ -412,13 +409,8 @@ export function Recorder({ projectId }: { projectId: string }) {
                 viewportWidth={timeline.viewportWidth}
                 emptyLabel="Enable input, place the playhead, then record"
                 onSeek={(position) => runtime.seek(position)}
-                onTakeSelect={setSelectedTakeId}
-                onTakeDelete={(id) => {
-                  runtime.removeTake(id);
-                  if (selectedTake?.id === id) {
-                    setSelectedTakeId(undefined);
-                  }
-                }}
+                onTakeSelect={takeSelection.select}
+                onTakeDelete={takeSelection.remove}
               />
             </CaptureTrackRow>
           </div>
@@ -466,6 +458,34 @@ export function Recorder({ projectId }: { projectId: string }) {
 }
 
 type SaveStatus = "saved" | "unsaved" | "saving" | "error";
+
+function useRecorderTakeSelection({
+  runtime,
+  takes,
+}: {
+  runtime: RecorderRuntime;
+  takes: RecorderRuntimeState["recordingTrack"]["takes"];
+}) {
+  const [selectedId, setSelectedId] = useState<string>();
+
+  useEffect(() => {
+    if (selectedId && !takes.some((take) => take.id === selectedId)) {
+      setSelectedId(undefined);
+    }
+  }, [selectedId, takes]);
+
+  return {
+    clear: () => setSelectedId(undefined),
+    remove: (id: string) => {
+      runtime.removeTake(id);
+      if (selectedId === id) {
+        setSelectedId(undefined);
+      }
+    },
+    select: setSelectedId,
+    selectedId,
+  };
+}
 
 function useRecorderProject({
   projectId,

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -401,7 +401,6 @@ export function Recorder({ projectId }: { projectId: string }) {
                 tempo={timeline.tempo}
                 viewportStartBeat={timeline.viewportStartBeat}
                 viewportWidth={timeline.viewportWidth}
-                emptyLabel="Enable input, place the playhead, then record"
                 onSeek={(position) => runtime.seek(position)}
                 onTakeSelect={takeSelection.select}
               />
@@ -1558,7 +1557,6 @@ function TakeTimelineLane({
   tempo,
   viewportStartBeat,
   viewportWidth,
-  emptyLabel,
   onSeek,
   onTakeSelect,
 }: {
@@ -1572,7 +1570,6 @@ function TakeTimelineLane({
   tempo: number;
   viewportStartBeat: number;
   viewportWidth: number;
-  emptyLabel: string;
   onSeek: (position: number) => void;
   onTakeSelect: (id: string) => void;
 }) {
@@ -1596,7 +1593,7 @@ function TakeTimelineLane({
     >
       {takes.length === 0 && !pendingRecording && (
         <div className="absolute inset-0 grid place-items-center text-xs text-neutral-600">
-          {emptyLabel}
+          Enable input, place the playhead, then record
         </div>
       )}
       {takes.map((take) => (

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -195,7 +195,10 @@ export function Recorder({ projectId }: { projectId: string }) {
     if (isShortcutTextInputTarget(event.target) || event.repeat) {
       return;
     }
-    if (matchKeyboardEvent(event, "Space")) {
+    if (matchKeyboardEvent(event, "Escape") && selectedTakeId) {
+      event.preventDefault();
+      setSelectedTakeId(undefined);
+    } else if (matchKeyboardEvent(event, "Space")) {
       event.preventDefault();
       togglePlay();
     } else if (matchKeyboardEvent(event, "R")) {
@@ -1757,6 +1760,11 @@ function TimelineClip({
     <div
       data-testid={`recorder-clip-${clip.variant}`}
       ref={onClipOffsetChange ? dragRef : undefined}
+      onPointerDown={(event) => {
+        if (onSelect) {
+          event.stopPropagation();
+        }
+      }}
       onClick={(event) => {
         if (onSelect) {
           event.stopPropagation();

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -338,7 +338,7 @@ export function Recorder({ projectId }: { projectId: string }) {
                 isProcessing
                   ? "Finalizing take…"
                   : isRecording
-                    ? `Recording · ${formatTimeWithMilliseconds(state.pendingTake?.duration ?? 0)}`
+                    ? `Recording · ${formatTimeWithMilliseconds(state.pendingRecording?.duration ?? 0)}`
                     : takes.length > 0
                       ? `${takes.length} ${takes.length === 1 ? "take" : "takes"}`
                       : "No takes"
@@ -385,7 +385,7 @@ export function Recorder({ projectId }: { projectId: string }) {
             >
               <TakeTimelineLane
                 takes={takes}
-                pendingTake={state.pendingTake}
+                pendingRecording={state.pendingRecording}
                 captureStatus={state.captureStatus}
                 selectedTakeId={takeSelection.selectedId}
                 beatsPerBar={timeline.beatsPerBar}
@@ -1543,7 +1543,7 @@ type RecorderTimelineClip = {
 
 function TakeTimelineLane({
   takes,
-  pendingTake,
+  pendingRecording,
   captureStatus,
   selectedTakeId,
   beatsPerBar,
@@ -1558,7 +1558,7 @@ function TakeTimelineLane({
   onTakeDelete,
 }: {
   takes: RecorderRuntimeState["recordingTrack"]["takes"];
-  pendingTake: RecorderRuntimeState["pendingTake"];
+  pendingRecording: RecorderRuntimeState["pendingRecording"];
   captureStatus: RecorderRuntimeState["captureStatus"];
   selectedTakeId?: string;
   beatsPerBar: number;
@@ -1590,7 +1590,7 @@ function TakeTimelineLane({
         onSeek(beatsToSeconds(beat, tempo));
       }}
     >
-      {takes.length === 0 && !pendingTake && (
+      {takes.length === 0 && !pendingRecording && (
         <div className="absolute inset-0 grid place-items-center text-xs text-neutral-600">
           {emptyLabel}
         </div>
@@ -1626,16 +1626,16 @@ function TakeTimelineLane({
           )}
         </div>
       ))}
-      {pendingTake && (
+      {pendingRecording && (
         <div>
           <TimelineClip
             clip={{
-              duration: pendingTake.duration,
+              duration: pendingRecording.duration,
               label:
                 captureStatus === "processing"
                   ? "Finalizing..."
                   : "Recording...",
-              offset: pendingTake.timelineOffset,
+              offset: pendingRecording.timelineOffset,
               variant: "recording",
             }}
             pixelsPerBeat={pixelsPerBeat}

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -195,6 +195,13 @@ export function Recorder({ projectId }: { projectId: string }) {
     if (matchKeyboardEvent(event, "Escape") && takeSelection.selectedId) {
       event.preventDefault();
       takeSelection.clear();
+    } else if (
+      takeSelection.selectedId &&
+      (matchKeyboardEvent(event, "Delete") ||
+        matchKeyboardEvent(event, "Backspace"))
+    ) {
+      event.preventDefault();
+      takeSelection.remove(takeSelection.selectedId);
     } else if (matchKeyboardEvent(event, "Space")) {
       event.preventDefault();
       togglePlay();
@@ -397,7 +404,6 @@ export function Recorder({ projectId }: { projectId: string }) {
                 emptyLabel="Enable input, place the playhead, then record"
                 onSeek={(position) => runtime.seek(position)}
                 onTakeSelect={takeSelection.select}
-                onTakeDelete={takeSelection.remove}
               />
             </CaptureTrackRow>
           </div>
@@ -1555,7 +1561,6 @@ function TakeTimelineLane({
   emptyLabel,
   onSeek,
   onTakeSelect,
-  onTakeDelete,
 }: {
   takes: RecorderRuntimeState["recordingTrack"]["takes"];
   pendingRecording: RecorderRuntimeState["pendingRecording"];
@@ -1570,7 +1575,6 @@ function TakeTimelineLane({
   emptyLabel: string;
   onSeek: (position: number) => void;
   onTakeSelect: (id: string) => void;
-  onTakeDelete: (id: string) => void;
 }) {
   return (
     <div
@@ -1612,18 +1616,6 @@ function TakeTimelineLane({
             onSelect={() => onTakeSelect(take.id)}
             selected={selectedTakeId === take.id}
           />
-          {selectedTakeId === take.id && (
-            <Button
-              data-testid={`recorder-delete-${take.id}`}
-              className="absolute right-1 top-1 z-20 size-6 border-red-900 bg-neutral-900/90 text-red-400 hover:bg-red-950"
-              title={`Delete Take ${take.number}`}
-              aria-label={`Delete Take ${take.number}`}
-              onPointerDown={(event) => event.stopPropagation()}
-              onClick={() => onTakeDelete(take.id)}
-            >
-              <Trash2Icon className="size-3" />
-            </Button>
-          )}
         </div>
       ))}
       {pendingRecording && (

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1374,19 +1374,15 @@ function TakeTimelineLane({
   viewportStartBeat: number;
   viewportWidth: number;
 }) {
-  const laneCount = takes.length + (pendingTake ? 1 : 0);
   return (
     <div
-      className="relative grid overflow-hidden bg-neutral-900"
-      style={{
-        gridTemplateRows: `repeat(${Math.max(1, laneCount)}, minmax(0, 1fr))`,
-        ...getTimelineGridStyle({
-          beatsPerBar,
-          pixelsPerBeat,
-          viewportStartBeat,
-          subdivisionsPerBeat,
-        }),
-      }}
+      className="relative overflow-hidden bg-neutral-900"
+      style={getTimelineGridStyle({
+        beatsPerBar,
+        pixelsPerBeat,
+        viewportStartBeat,
+        subdivisionsPerBeat,
+      })}
       onPointerDown={(event) => {
         const rect = event.currentTarget.getBoundingClientRect();
         const beat = Math.max(
@@ -1396,19 +1392,13 @@ function TakeTimelineLane({
         onSeek(beatsToSeconds(beat, tempo));
       }}
     >
-      {laneCount === 0 && (
+      {takes.length === 0 && !pendingTake && (
         <div className="absolute inset-0 grid place-items-center text-xs text-neutral-600">
           {emptyLabel}
         </div>
       )}
       {takes.map((take) => (
-        <div
-          key={take.id}
-          className={cn(
-            "relative min-h-0 border-b border-neutral-800 last:border-b-0",
-            selectedTakeId === take.id && "bg-sky-950/30",
-          )}
-        >
+        <div key={take.id}>
           <TimelineClip
             clip={{ ...take, variant: "take" }}
             pixelsPerBeat={pixelsPerBeat}
@@ -1433,7 +1423,7 @@ function TakeTimelineLane({
         </div>
       ))}
       {pendingTake && (
-        <div className="relative min-h-0">
+        <div>
           <TimelineClip
             clip={{ ...pendingTake, variant: "recording" }}
             pixelsPerBeat={pixelsPerBeat}

--- a/src/lib/recorder/audio-buffer-playback.ts
+++ b/src/lib/recorder/audio-buffer-playback.ts
@@ -10,11 +10,8 @@ export class AudioBufferPlayback implements TransportParticipant {
   private buffer?: AudioBuffer;
   private source?: AudioBufferSourceNode;
   /** Transport timeline time corresponding to source-buffer time zero. */
-  private timelineOffset = 0;
-  /** Time within the source buffer where this playback region begins. */
-  private sourceOffset = 0;
-  /** Length of this playback region in seconds; defaults to the remaining buffer. */
-  private duration?: number;
+  private bufferTimelineOffset = 0;
+  private timelineRange?: { start: number; end: number };
 
   constructor({
     transport,
@@ -41,19 +38,12 @@ export class AudioBufferPlayback implements TransportParticipant {
     );
   }
 
-  setTimelineOffset(offset: number): void {
-    this.timelineOffset = offset;
+  setBufferTimelineOffset(offset: number): void {
+    this.bufferTimelineOffset = offset;
   }
 
-  setSourceRange({
-    sourceOffset,
-    duration,
-  }: {
-    sourceOffset: number;
-    duration: number;
-  }): void {
-    this.sourceOffset = sourceOffset;
-    this.duration = duration;
+  setTimelineRange(range: { start: number; end: number }): void {
+    this.timelineRange = range;
   }
 
   /**
@@ -69,11 +59,15 @@ export class AudioBufferPlayback implements TransportParticipant {
       return;
     }
     const playbackAnchor = this.transport.playbackAnchor!;
-    const regionTimelineOffset = this.timelineOffset + this.sourceOffset;
-    const elapsed = Math.max(0, playbackAnchor.position - regionTimelineOffset);
+    const timelineStart =
+      this.timelineRange?.start ?? this.bufferTimelineOffset;
+    const timelineEnd =
+      this.timelineRange?.end ?? this.bufferTimelineOffset + buffer.duration;
+    const sourceOffset = timelineStart - this.bufferTimelineOffset;
+    const elapsed = Math.max(0, playbackAnchor.position - timelineStart);
     const duration = Math.min(
-      this.duration ?? buffer.duration - this.sourceOffset,
-      buffer.duration - this.sourceOffset,
+      timelineEnd - timelineStart,
+      buffer.duration - sourceOffset,
     );
     if (elapsed >= duration) {
       return;
@@ -83,8 +77,8 @@ export class AudioBufferPlayback implements TransportParticipant {
     source.connect(this.gain);
     source.start(
       playbackAnchor.contextTime +
-        Math.max(0, regionTimelineOffset - playbackAnchor.position),
-      this.sourceOffset + elapsed,
+        Math.max(0, timelineStart - playbackAnchor.position),
+      sourceOffset + elapsed,
       duration - elapsed,
     );
     this.source = source;

--- a/src/lib/recorder/audio-buffer-playback.ts
+++ b/src/lib/recorder/audio-buffer-playback.ts
@@ -10,6 +10,8 @@ export class AudioBufferPlayback implements TransportParticipant {
   private buffer?: AudioBuffer;
   private source?: AudioBufferSourceNode;
   private timelineOffset = 0;
+  private sourceOffset = 0;
+  private duration?: number;
 
   constructor({
     transport,
@@ -40,6 +42,17 @@ export class AudioBufferPlayback implements TransportParticipant {
     this.timelineOffset = offset;
   }
 
+  setSourceRange({
+    sourceOffset,
+    duration,
+  }: {
+    sourceOffset: number;
+    duration?: number;
+  }): void {
+    this.sourceOffset = sourceOffset;
+    this.duration = duration;
+  }
+
   /**
    * Starts this buffer from the transport's shared context and timeline anchor.
    *
@@ -53,11 +66,12 @@ export class AudioBufferPlayback implements TransportParticipant {
       return;
     }
     const playbackAnchor = this.transport.playbackAnchor!;
-    const bufferOffset = Math.max(
-      0,
-      playbackAnchor.position - this.timelineOffset,
+    const elapsed = Math.max(0, playbackAnchor.position - this.timelineOffset);
+    const duration = Math.min(
+      this.duration ?? buffer.duration - this.sourceOffset,
+      buffer.duration - this.sourceOffset,
     );
-    if (bufferOffset >= buffer.duration) {
+    if (elapsed >= duration) {
       return;
     }
     const source = this.transport.context.createBufferSource();
@@ -66,7 +80,8 @@ export class AudioBufferPlayback implements TransportParticipant {
     source.start(
       playbackAnchor.contextTime +
         Math.max(0, this.timelineOffset - playbackAnchor.position),
-      bufferOffset,
+      this.sourceOffset + elapsed,
+      duration - elapsed,
     );
     this.source = source;
   }

--- a/src/lib/recorder/audio-buffer-playback.ts
+++ b/src/lib/recorder/audio-buffer-playback.ts
@@ -9,8 +9,11 @@ export class AudioBufferPlayback implements TransportParticipant {
   private readonly unregister: () => void;
   private buffer?: AudioBuffer;
   private source?: AudioBufferSourceNode;
+  /** Transport timeline time where this playback region begins. */
   private timelineOffset = 0;
+  /** Time within the source buffer where this playback region begins. */
   private sourceOffset = 0;
+  /** Length of this playback region in seconds; defaults to the remaining buffer. */
   private duration?: number;
 
   constructor({

--- a/src/lib/recorder/audio-buffer-playback.ts
+++ b/src/lib/recorder/audio-buffer-playback.ts
@@ -65,10 +65,7 @@ export class AudioBufferPlayback implements TransportParticipant {
       this.timelineRange?.end ?? this.bufferTimelineOffset + buffer.duration;
     const sourceOffset = timelineStart - this.bufferTimelineOffset;
     const elapsed = Math.max(0, playbackAnchor.position - timelineStart);
-    const duration = Math.min(
-      timelineEnd - timelineStart,
-      buffer.duration - sourceOffset,
-    );
+    const duration = timelineEnd - timelineStart;
     if (elapsed >= duration) {
       return;
     }

--- a/src/lib/recorder/audio-buffer-playback.ts
+++ b/src/lib/recorder/audio-buffer-playback.ts
@@ -50,7 +50,7 @@ export class AudioBufferPlayback implements TransportParticipant {
     duration,
   }: {
     sourceOffset: number;
-    duration?: number;
+    duration: number;
   }): void {
     this.sourceOffset = sourceOffset;
     this.duration = duration;

--- a/src/lib/recorder/audio-buffer-playback.ts
+++ b/src/lib/recorder/audio-buffer-playback.ts
@@ -63,7 +63,6 @@ export class AudioBufferPlayback implements TransportParticipant {
       this.timelineRange?.start ?? this.bufferTimelineOffset;
     const timelineEnd =
       this.timelineRange?.end ?? this.bufferTimelineOffset + buffer.duration;
-    const sourceOffset = timelineStart - this.bufferTimelineOffset;
     const elapsed = Math.max(0, playbackAnchor.position - timelineStart);
     const duration = timelineEnd - timelineStart;
     if (elapsed >= duration) {
@@ -75,7 +74,7 @@ export class AudioBufferPlayback implements TransportParticipant {
     source.start(
       playbackAnchor.contextTime +
         Math.max(0, timelineStart - playbackAnchor.position),
-      sourceOffset + elapsed,
+      timelineStart - this.bufferTimelineOffset + elapsed,
       duration - elapsed,
     );
     this.source = source;

--- a/src/lib/recorder/audio-buffer-playback.ts
+++ b/src/lib/recorder/audio-buffer-playback.ts
@@ -9,7 +9,7 @@ export class AudioBufferPlayback implements TransportParticipant {
   private readonly unregister: () => void;
   private buffer?: AudioBuffer;
   private source?: AudioBufferSourceNode;
-  /** Transport timeline time where this playback region begins. */
+  /** Transport timeline time corresponding to source-buffer time zero. */
   private timelineOffset = 0;
   /** Time within the source buffer where this playback region begins. */
   private sourceOffset = 0;
@@ -69,7 +69,8 @@ export class AudioBufferPlayback implements TransportParticipant {
       return;
     }
     const playbackAnchor = this.transport.playbackAnchor!;
-    const elapsed = Math.max(0, playbackAnchor.position - this.timelineOffset);
+    const regionTimelineOffset = this.timelineOffset + this.sourceOffset;
+    const elapsed = Math.max(0, playbackAnchor.position - regionTimelineOffset);
     const duration = Math.min(
       this.duration ?? buffer.duration - this.sourceOffset,
       buffer.duration - this.sourceOffset,
@@ -82,7 +83,7 @@ export class AudioBufferPlayback implements TransportParticipant {
     source.connect(this.gain);
     source.start(
       playbackAnchor.contextTime +
-        Math.max(0, this.timelineOffset - playbackAnchor.position),
+        Math.max(0, regionTimelineOffset - playbackAnchor.position),
       this.sourceOffset + elapsed,
       duration - elapsed,
     );

--- a/src/lib/recorder/persistence.ts
+++ b/src/lib/recorder/persistence.ts
@@ -14,6 +14,7 @@ export interface SerializedRecorderRuntimeState {
     muted: boolean;
     soloed: boolean;
     takes: SerializedTakeState[];
+    nextTakeNumber?: number;
   };
   latencyCompensation: number;
   tempo: number;
@@ -37,6 +38,8 @@ interface SerializedAudioTrackState {
 }
 
 interface SerializedTakeState {
+  id?: string;
+  number?: number;
   timelineOffset: number;
   pcm: RecorderPcm;
 }
@@ -70,11 +73,14 @@ export function serializeRecorderRuntimeState(
       gain: state.recordingTrack.gain,
       muted: state.recordingTrack.muted,
       soloed: state.recordingTrack.soloed,
+      nextTakeNumber: state.recordingTrack.nextTakeNumber,
       takes: state.recordingTrack.takes.map((take) => {
         if (!take.buffer) {
           throw new Error("Recording take has no loaded buffer.");
         }
         return {
+          id: take.id,
+          number: take.number,
           timelineOffset: take.timelineOffset,
           pcm: serializeAudioBuffer(take.buffer),
         };
@@ -125,9 +131,14 @@ export function deserializeRecorderRuntimeState({
       gain: project.recordingTrack.gain,
       muted: project.recordingTrack.muted,
       soloed: project.recordingTrack.soloed,
-      takes: project.recordingTrack.takes.map((take) => {
+      nextTakeNumber:
+        project.recordingTrack.nextTakeNumber ??
+        project.recordingTrack.takes.length + 1,
+      takes: project.recordingTrack.takes.map((take, index) => {
         const buffer = deserializeAudioBuffer(context, take.pcm);
         return {
+          id: take.id ?? crypto.randomUUID(),
+          number: take.number ?? index + 1,
           duration: buffer.duration,
           timelineOffset: take.timelineOffset,
           buffer,

--- a/src/lib/recorder/persistence.ts
+++ b/src/lib/recorder/persistence.ts
@@ -14,6 +14,7 @@ export interface SerializedRecorderRuntimeState {
     muted: boolean;
     soloed: boolean;
     takes: SerializedTakeState[];
+    // Optional for recorder projects saved before multi-take support.
     nextTakeNumber?: number;
   };
   latencyCompensation: number;
@@ -38,6 +39,7 @@ interface SerializedAudioTrackState {
 }
 
 interface SerializedTakeState {
+  // Optional for recorder projects saved before multi-take support.
   id?: string;
   number?: number;
   timelineOffset: number;

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -586,7 +586,10 @@ export class RecorderRuntime {
     }
     const takes = this.store.get().recordingTrack.takes;
     this.takeRegions = deriveTakeRegions(takes);
-    this.disposeRecordingTrackPlaybacks();
+    for (const playback of this.recordingTrackPlaybacks) {
+      playback.dispose();
+    }
+    this.recordingTrackPlaybacks = [];
     for (const region of this.takeRegions) {
       const take = takes.find((entry) => entry.id === region.takeId);
       if (!take?.buffer) {
@@ -608,13 +611,6 @@ export class RecorderRuntime {
     if (wasPlaying) {
       this.transport!.play();
     }
-  }
-
-  private disposeRecordingTrackPlaybacks(): void {
-    for (const playback of this.recordingTrackPlaybacks) {
-      playback.dispose();
-    }
-    this.recordingTrackPlaybacks = [];
   }
 }
 

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -568,6 +568,10 @@ export class RecorderRuntime {
   }
 
   removeTake(id: string): void {
+    const wasPlaying = this.store.get().isPlaying;
+    if (wasPlaying) {
+      this.pause();
+    }
     const recordingTrack = this.store.get().recordingTrack;
     this.store.update({
       recordingTrack: {
@@ -576,14 +580,13 @@ export class RecorderRuntime {
       },
     });
     this.syncTakeRegions();
+    if (wasPlaying) {
+      this.transport!.play();
+    }
   }
 
   private syncTakeRegions(): void {
     const context = this.ensureContext();
-    const wasPlaying = this.store.get().isPlaying;
-    if (wasPlaying) {
-      this.pause();
-    }
     const takes = this.store.get().recordingTrack.takes;
     this.takeRegions = deriveTakeRegions(takes);
     for (const playback of this.recordingTrackPlaybacks) {
@@ -608,9 +611,6 @@ export class RecorderRuntime {
       this.recordingTrackPlaybacks.push(playback);
     }
     this.syncTrackMix();
-    if (wasPlaying) {
-      this.transport!.play();
-    }
   }
 }
 

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -393,10 +393,6 @@ export class RecorderRuntime {
     this.store.update({ title });
   }
 
-  serializeProject(): SerializedRecorderRuntimeState {
-    return serializeRecorderRuntimeState(this.store.get());
-  }
-
   renderComp(): AudioBuffer | undefined {
     const context = this.ensureContext();
     const takes = this.store.get().recordingTrack.takes;
@@ -436,6 +432,10 @@ export class RecorderRuntime {
       }
     }
     return buffer;
+  }
+
+  serializeProject(): SerializedRecorderRuntimeState {
+    return serializeRecorderRuntimeState(this.store.get());
   }
 
   deserializeProject(project: SerializedRecorderRuntimeState): void {

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -11,7 +11,7 @@ import {
 } from "./persistence.ts";
 import { ActiveRecording } from "./recording.ts";
 import { renderTakeComp } from "./take-comp.ts";
-import { deriveTakeRegions } from "./take-regions.ts";
+import { deriveTakeRegions, type TakeRegion } from "./take-regions.ts";
 import { AudioContextTransport } from "./transport.ts";
 
 const MAX_RECORDING_SECONDS = 5 * 60;
@@ -114,6 +114,7 @@ export class RecorderRuntime {
   captureInput?: CaptureInput;
   private audioTrackPlaybacks = new Map<string, AudioBufferPlayback>();
   private recordingTrackPlaybacks: AudioBufferPlayback[] = [];
+  private takeRegions: TakeRegion[] = [];
   private activeRecording?: {
     id: string;
     number: number;
@@ -397,6 +398,7 @@ export class RecorderRuntime {
   renderComp(): AudioBuffer | undefined {
     return renderTakeComp({
       context: this.ensureContext(),
+      regions: this.takeRegions,
       takes: this.store.get().recordingTrack.takes,
     });
   }
@@ -456,7 +458,7 @@ export class RecorderRuntime {
     this.transport!.seek(0);
     this.metronome!.setTempo(project.tempo);
     this.metronome!.setTimeSignature(project.timeSignature);
-    this.syncRecordingTrackPlaybacks();
+    this.syncTakeRegions();
     this.syncTrackMix();
   }
 
@@ -558,7 +560,7 @@ export class RecorderRuntime {
         ],
       },
     });
-    this.syncRecordingTrackPlaybacks();
+    this.syncTakeRegions();
   }
 
   private closeInput(): void {
@@ -575,18 +577,19 @@ export class RecorderRuntime {
           .recordingTrack.takes.filter((take) => take.id !== id),
       },
     });
-    this.syncRecordingTrackPlaybacks();
+    this.syncTakeRegions();
   }
 
-  private syncRecordingTrackPlaybacks(): void {
+  private syncTakeRegions(): void {
     const context = this.ensureContext();
     const wasPlaying = this.store.get().isPlaying;
     if (wasPlaying) {
       this.pause();
     }
     const takes = this.store.get().recordingTrack.takes;
+    this.takeRegions = deriveTakeRegions(takes);
     this.disposeRecordingTrackPlaybacks();
-    for (const region of deriveTakeRegions(takes)) {
+    for (const region of this.takeRegions) {
       const take = takes.find((entry) => entry.id === region.takeId);
       if (!take?.buffer) {
         continue;

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -333,6 +333,9 @@ export class RecorderRuntime {
     if (!this.store.get().isPlaying) {
       await this.play();
     }
+    for (const playback of this.recordingTrackPlaybacks) {
+      playback.setGain(0);
+    }
     // Trim samples captured during playback lead time.
     const playbackStartFrame =
       this.transport!.playbackAnchor!.contextTime * context.sampleRate;
@@ -554,6 +557,7 @@ export class RecorderRuntime {
     if (!samples) {
       this.activeRecording = undefined;
       this.store.update({ captureStatus: "ready", pendingTake: undefined });
+      this.syncTrackMix();
       return;
     }
     const takeBuffer = context.createBuffer(

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -11,7 +11,8 @@ import {
 } from "./persistence.ts";
 import { ActiveRecording } from "./recording.ts";
 import { renderTakeComp } from "./take-comp.ts";
-import { deriveTakeRegions, type TakeRegion } from "./take-regions.ts";
+import { deriveTakeRegions } from "./take-regions.ts";
+import type { TakeRegion, TakeState } from "./take.ts";
 import { AudioContextTransport } from "./transport.ts";
 
 const MAX_RECORDING_SECONDS = 5 * 60;
@@ -44,15 +45,6 @@ interface RecordingTrackState {
   soloed: boolean;
   takes: TakeState[];
   nextTakeNumber: number;
-}
-
-interface TakeState {
-  id: string;
-  number: number;
-  duration: number;
-  timelineOffset: number;
-  buffer?: AudioBuffer;
-  audioView?: AudioView;
 }
 
 interface PendingRecordingState extends Pick<

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -593,9 +593,9 @@ export class RecorderRuntime {
         output: context.destination,
       });
       playback.setBuffer(take.buffer);
-      playback.setTimelineOffset(region.timelineOffset);
+      playback.setTimelineOffset(take.timelineOffset);
       playback.setSourceRange({
-        sourceOffset: region.sourceOffset,
+        sourceOffset: region.timelineOffset - take.timelineOffset,
         duration: region.duration,
       });
       this.recordingTrackPlaybacks.push(playback);

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -10,6 +10,7 @@ import {
   serializeRecorderRuntimeState,
 } from "./persistence.ts";
 import { ActiveRecording } from "./recording.ts";
+import { deriveTakeRegions } from "./take-regions.ts";
 import { AudioContextTransport } from "./transport.ts";
 
 const MAX_RECORDING_SECONDS = 5 * 60;
@@ -40,9 +41,12 @@ interface RecordingTrackState {
   muted: boolean;
   soloed: boolean;
   takes: TakeState[];
+  nextTakeNumber: number;
 }
 
 interface TakeState {
+  id: string;
+  number: number;
   duration: number;
   timelineOffset: number;
   buffer?: AudioBuffer;
@@ -60,6 +64,10 @@ export interface RecorderRuntimeState {
   // Tracks
   audioTracks: AudioTrackState[];
   recordingTrack: RecordingTrackState;
+  pendingTake?: Pick<
+    TakeState,
+    "id" | "number" | "duration" | "timelineOffset"
+  >;
   // Capture
   captureStatus: CaptureStatus;
   inputChannelCount: number;
@@ -103,8 +111,13 @@ export class RecorderRuntime {
   private transport?: AudioContextTransport;
   captureInput?: CaptureInput;
   private audioTrackPlaybacks = new Map<string, AudioBufferPlayback>();
-  private recordingTrackPlayback?: AudioBufferPlayback;
-  private activeRecording?: ActiveRecording;
+  private recordingTrackPlaybacks: AudioBufferPlayback[] = [];
+  private activeRecording?: {
+    id: string;
+    number: number;
+    timelineOffset: number;
+    recording: ActiveRecording;
+  };
   private metronome?: RecorderMetronome;
 
   async startInput({
@@ -127,26 +140,19 @@ export class RecorderRuntime {
             if (!activeRecording) {
               break;
             }
-            activeRecording.append(message);
-            const recordingTrack = this.store.get().recordingTrack;
-            const take = recordingTrack.takes[0];
-            if (!take) {
-              throw new Error("Recording take state is missing.");
-            }
+            activeRecording.recording.append(message);
             this.store.update({
-              recordingTrack: {
-                ...recordingTrack,
-                takes: [
-                  {
-                    ...take,
-                    duration:
-                      activeRecording.getDurationFrames() / context.sampleRate,
-                  },
-                ],
+              pendingTake: {
+                id: activeRecording.id,
+                number: activeRecording.number,
+                duration:
+                  activeRecording.recording.getDurationFrames() /
+                  context.sampleRate,
+                timelineOffset: activeRecording.timelineOffset,
               },
             });
             if (
-              activeRecording.getDurationFrames() >=
+              activeRecording.recording.getDurationFrames() >=
                 context.sampleRate * MAX_RECORDING_SECONDS &&
               this.store.get().captureStatus === "recording"
             ) {
@@ -304,8 +310,6 @@ export class RecorderRuntime {
   async play(): Promise<void> {
     const context = this.ensureContext();
     await context.resume();
-    const take = this.store.get().recordingTrack.takes[0];
-    this.recordingTrackPlayback!.setTimelineOffset(take?.timelineOffset ?? 0);
     this.transport!.play();
   }
 
@@ -328,27 +332,25 @@ export class RecorderRuntime {
     if (!this.store.get().isPlaying) {
       await this.play();
     }
-    this.clearTake();
     // Trim samples captured during playback lead time.
     const playbackStartFrame =
       this.transport!.playbackAnchor!.contextTime * context.sampleRate;
     const startFrame = Math.max(captureStartFrame, playbackStartFrame);
-    this.activeRecording = new ActiveRecording(startFrame);
     const timelineOffset =
       this.transport!.getPlaybackPositionByContextTime(
         startFrame / context.sampleRate,
       ) - this.store.get().latencyCompensation;
+    const id = crypto.randomUUID();
+    const number = this.store.get().recordingTrack.nextTakeNumber;
+    this.activeRecording = {
+      id,
+      number,
+      timelineOffset,
+      recording: new ActiveRecording(startFrame),
+    };
     this.store.update({
       captureStatus: "recording",
-      recordingTrack: {
-        ...this.store.get().recordingTrack,
-        takes: [
-          {
-            duration: 0,
-            timelineOffset,
-          },
-        ],
-      },
+      pendingTake: { id, number, duration: 0, timelineOffset },
     });
   }
 
@@ -391,6 +393,47 @@ export class RecorderRuntime {
     return serializeRecorderRuntimeState(this.store.get());
   }
 
+  renderComp(): AudioBuffer | undefined {
+    const context = this.ensureContext();
+    const takes = this.store.get().recordingTrack.takes;
+    const regions = deriveTakeRegions(takes);
+    if (regions.length === 0) {
+      return undefined;
+    }
+    const timelineOffset = Math.min(0, regions[0]!.timelineOffset);
+    const timelineEnd = Math.max(
+      ...regions.map((region) => region.timelineOffset + region.duration),
+    );
+    const sampleRate = context.sampleRate;
+    const buffer = context.createBuffer(
+      1,
+      Math.ceil((timelineEnd - timelineOffset) * sampleRate),
+      sampleRate,
+    );
+    const output = buffer.getChannelData(0);
+    for (const region of regions) {
+      const take = takes.find((entry) => entry.id === region.takeId);
+      if (!take?.buffer) {
+        continue;
+      }
+      const source = take.buffer.getChannelData(0);
+      const outputStart = Math.round(
+        (region.timelineOffset - timelineOffset) * sampleRate,
+      );
+      const outputLength = Math.round(region.duration * sampleRate);
+      for (let index = 0; index < outputLength; index++) {
+        const sourcePosition =
+          (region.sourceOffset + index / sampleRate) * take.buffer.sampleRate;
+        const sourceIndex = Math.floor(sourcePosition);
+        const fraction = sourcePosition - sourceIndex;
+        output[outputStart + index] =
+          (source[sourceIndex] ?? 0) * (1 - fraction) +
+          (source[sourceIndex + 1] ?? source[sourceIndex] ?? 0) * fraction;
+      }
+    }
+    return buffer;
+  }
+
   deserializeProject(project: SerializedRecorderRuntimeState): void {
     this.replacePersistableState(
       deserializeRecorderRuntimeState({
@@ -428,9 +471,7 @@ export class RecorderRuntime {
       playback.setTimelineOffset(track.timelineOffset);
       this.audioTrackPlaybacks.set(track.id, playback);
     }
-    const take = project.recordingTrack.takes[0];
-    this.recordingTrackPlayback!.stop();
-    this.recordingTrackPlayback!.setBuffer(take?.buffer);
+    this.disposeRecordingTrackPlaybacks();
     this.store.update({
       ...project,
       position: 0,
@@ -438,6 +479,7 @@ export class RecorderRuntime {
     this.transport!.seek(0);
     this.metronome!.setTempo(project.tempo);
     this.metronome!.setTimeSignature(project.timeSignature);
+    this.syncRecordingTrackPlaybacks();
     this.syncTrackMix();
   }
 
@@ -461,11 +503,6 @@ export class RecorderRuntime {
     if (!this.context) {
       this.context = new AudioContext();
       this.transport = new AudioContextTransport(this.context);
-      this.recordingTrackPlayback = new AudioBufferPlayback({
-        transport: this.transport,
-        output: this.context.destination,
-      });
-      this.syncTrackMix();
       this.metronome = new RecorderMetronome(this.transport);
       this.metronome.setGain(
         this.store.get().metronomeEnabled ? METRONOME_GAIN : 0,
@@ -491,11 +528,13 @@ export class RecorderRuntime {
           track.muted || (anyTrackSoloed && !track.soloed) ? 0 : track.gain,
         );
     }
-    this.recordingTrackPlayback?.setGain(
+    const recordingGain =
       recordingTrack.muted || (anyTrackSoloed && !recordingTrack.soloed)
         ? 0
-        : recordingTrack.gain,
-    );
+        : recordingTrack.gain;
+    for (const playback of this.recordingTrackPlaybacks) {
+      playback.setGain(recordingGain);
+    }
   }
 
   private finishRecording(stopFrame: number): void {
@@ -504,11 +543,10 @@ export class RecorderRuntime {
     if (!context || !activeRecording) {
       throw new Error("Recording state is incomplete.");
     }
-    const samples = activeRecording.finish(stopFrame);
+    const samples = activeRecording.recording.finish(stopFrame);
     if (!samples) {
       this.activeRecording = undefined;
-      this.clearTake();
-      this.store.update({ captureStatus: "ready" });
+      this.store.update({ captureStatus: "ready", pendingTake: undefined });
       return;
     }
     const takeBuffer = context.createBuffer(
@@ -517,21 +555,22 @@ export class RecorderRuntime {
       context.sampleRate,
     );
     takeBuffer.getChannelData(0).set(samples);
-    this.recordingTrackPlayback!.setBuffer(takeBuffer);
     this.activeRecording = undefined;
-    const take = this.store.get().recordingTrack.takes[0];
-    if (!take) {
-      throw new Error("Recording take state is missing.");
-    }
+    const recordingTrack = this.store.get().recordingTrack;
     this.store.update({
       captureStatus: "ready",
+      pendingTake: undefined,
       recordingTrack: {
-        ...this.store.get().recordingTrack,
+        ...recordingTrack,
+        nextTakeNumber: recordingTrack.nextTakeNumber + 1,
         takes: [
+          ...recordingTrack.takes,
           {
-            ...take,
+            id: activeRecording.id,
+            number: activeRecording.number,
             buffer: takeBuffer,
             duration: takeBuffer.duration,
+            timelineOffset: activeRecording.timelineOffset,
             audioView: createAudioView(
               samples,
               context.sampleRate,
@@ -541,6 +580,7 @@ export class RecorderRuntime {
         ],
       },
     });
+    this.syncRecordingTrackPlaybacks();
   }
 
   private closeInput(): void {
@@ -548,15 +588,54 @@ export class RecorderRuntime {
     this.captureInput = undefined;
   }
 
-  private clearTake(): void {
-    this.recordingTrackPlayback?.stop();
-    this.recordingTrackPlayback?.setBuffer(undefined);
+  removeTake(id: string): void {
     this.store.update({
       recordingTrack: {
         ...this.store.get().recordingTrack,
-        takes: [],
+        takes: this.store
+          .get()
+          .recordingTrack.takes.filter((take) => take.id !== id),
       },
     });
+    this.syncRecordingTrackPlaybacks();
+  }
+
+  private syncRecordingTrackPlaybacks(): void {
+    const context = this.ensureContext();
+    const wasPlaying = this.store.get().isPlaying;
+    if (wasPlaying) {
+      this.pause();
+    }
+    const takes = this.store.get().recordingTrack.takes;
+    this.disposeRecordingTrackPlaybacks();
+    for (const region of deriveTakeRegions(takes)) {
+      const take = takes.find((entry) => entry.id === region.takeId);
+      if (!take?.buffer) {
+        continue;
+      }
+      const playback = new AudioBufferPlayback({
+        transport: this.transport!,
+        output: context.destination,
+      });
+      playback.setBuffer(take.buffer);
+      playback.setTimelineOffset(region.timelineOffset);
+      playback.setSourceRange({
+        sourceOffset: region.sourceOffset,
+        duration: region.duration,
+      });
+      this.recordingTrackPlaybacks.push(playback);
+    }
+    this.syncTrackMix();
+    if (wasPlaying) {
+      this.transport!.play();
+    }
+  }
+
+  private disposeRecordingTrackPlaybacks(): void {
+    for (const playback of this.recordingTrackPlaybacks) {
+      playback.dispose();
+    }
+    this.recordingTrackPlaybacks = [];
   }
 }
 
@@ -578,6 +657,7 @@ function createRecordingTrackState(): RecordingTrackState {
     muted: false,
     soloed: false,
     takes: [],
+    nextTakeNumber: 1,
   };
 }
 

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -10,6 +10,7 @@ import {
   serializeRecorderRuntimeState,
 } from "./persistence.ts";
 import { ActiveRecording } from "./recording.ts";
+import { renderTakeComp } from "./take-comp.ts";
 import { deriveTakeRegions } from "./take-regions.ts";
 import { AudioContextTransport } from "./transport.ts";
 
@@ -394,44 +395,10 @@ export class RecorderRuntime {
   }
 
   renderComp(): AudioBuffer | undefined {
-    const context = this.ensureContext();
-    const takes = this.store.get().recordingTrack.takes;
-    const regions = deriveTakeRegions(takes);
-    if (regions.length === 0) {
-      return undefined;
-    }
-    const timelineOffset = Math.min(0, regions[0]!.timelineOffset);
-    const timelineEnd = Math.max(
-      ...regions.map((region) => region.timelineOffset + region.duration),
-    );
-    const sampleRate = context.sampleRate;
-    const buffer = context.createBuffer(
-      1,
-      Math.ceil((timelineEnd - timelineOffset) * sampleRate),
-      sampleRate,
-    );
-    const output = buffer.getChannelData(0);
-    for (const region of regions) {
-      const take = takes.find((entry) => entry.id === region.takeId);
-      if (!take?.buffer) {
-        continue;
-      }
-      const source = take.buffer.getChannelData(0);
-      const outputStart = Math.round(
-        (region.timelineOffset - timelineOffset) * sampleRate,
-      );
-      const outputLength = Math.round(region.duration * sampleRate);
-      for (let index = 0; index < outputLength; index++) {
-        const sourcePosition =
-          (region.sourceOffset + index / sampleRate) * take.buffer.sampleRate;
-        const sourceIndex = Math.floor(sourcePosition);
-        const fraction = sourcePosition - sourceIndex;
-        output[outputStart + index] =
-          (source[sourceIndex] ?? 0) * (1 - fraction) +
-          (source[sourceIndex + 1] ?? source[sourceIndex] ?? 0) * fraction;
-      }
-    }
-    return buffer;
+    return renderTakeComp({
+      context: this.ensureContext(),
+      takes: this.store.get().recordingTrack.takes,
+    });
   }
 
   serializeProject(): SerializedRecorderRuntimeState {

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -444,7 +444,6 @@ export class RecorderRuntime {
       playback.setTimelineOffset(track.timelineOffset);
       this.audioTrackPlaybacks.set(track.id, playback);
     }
-    this.disposeRecordingTrackPlaybacks();
     // Clamp loaded external state at the runtime boundary so older projects
     // cannot restore a Capture row too short for its current controls.
     this.store.update({

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -569,12 +569,11 @@ export class RecorderRuntime {
   }
 
   removeTake(id: string): void {
+    const recordingTrack = this.store.get().recordingTrack;
     this.store.update({
       recordingTrack: {
-        ...this.store.get().recordingTrack,
-        takes: this.store
-          .get()
-          .recordingTrack.takes.filter((take) => take.id !== id),
+        ...recordingTrack,
+        takes: recordingTrack.takes.filter((take) => take.id !== id),
       },
     });
     this.syncTakeRegions();

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -55,6 +55,13 @@ interface TakeState {
   audioView?: AudioView;
 }
 
+interface PendingRecordingState extends Pick<
+  TakeState,
+  "id" | "number" | "duration" | "timelineOffset"
+> {
+  recording: ActiveRecording;
+}
+
 export interface RecorderRuntimeState {
   title: string;
   // Transport
@@ -66,10 +73,7 @@ export interface RecorderRuntimeState {
   // Tracks
   audioTracks: AudioTrackState[];
   recordingTrack: RecordingTrackState;
-  pendingTake?: Pick<
-    TakeState,
-    "id" | "number" | "duration" | "timelineOffset"
-  >;
+  pendingRecording?: PendingRecordingState;
   // Capture
   captureStatus: CaptureStatus;
   inputChannelCount: number;
@@ -115,12 +119,6 @@ export class RecorderRuntime {
   private audioTrackPlaybacks = new Map<string, AudioBufferPlayback>();
   private recordingTrackPlaybacks: AudioBufferPlayback[] = [];
   private takeRegions: TakeRegion[] = [];
-  private activeRecording?: {
-    id: string;
-    number: number;
-    timelineOffset: number;
-    recording: ActiveRecording;
-  };
   private metronome?: RecorderMetronome;
 
   async startInput({
@@ -137,25 +135,23 @@ export class RecorderRuntime {
       onNotification: (message) => {
         switch (message.type) {
           case "samples": {
-            const activeRecording = this.activeRecording;
+            const pendingRecording = this.store.get().pendingRecording;
             // Batched samples can arrive after stop is requested. Keep accepting
             // them until the render thread confirms its boundary.
-            if (!activeRecording) {
+            if (!pendingRecording) {
               break;
             }
-            activeRecording.recording.append(message);
+            pendingRecording.recording.append(message);
             this.store.update({
-              pendingTake: {
-                id: activeRecording.id,
-                number: activeRecording.number,
+              pendingRecording: {
+                ...pendingRecording,
                 duration:
-                  activeRecording.recording.getDurationFrames() /
+                  pendingRecording.recording.getDurationFrames() /
                   context.sampleRate,
-                timelineOffset: activeRecording.timelineOffset,
               },
             });
             if (
-              activeRecording.recording.getDurationFrames() >=
+              pendingRecording.recording.getDurationFrames() >=
                 context.sampleRate * MAX_RECORDING_SECONDS &&
               this.store.get().captureStatus === "recording"
             ) {
@@ -348,15 +344,16 @@ export class RecorderRuntime {
       ) - this.store.get().latencyCompensation;
     const id = crypto.randomUUID();
     const number = this.store.get().recordingTrack.nextTakeNumber;
-    this.activeRecording = {
+    const pendingRecording: PendingRecordingState = {
       id,
       number,
+      duration: 0,
       timelineOffset,
       recording: new ActiveRecording(startFrame),
     };
     this.store.update({
       captureStatus: "recording",
-      pendingTake: { id, number, duration: 0, timelineOffset },
+      pendingRecording,
     });
   }
 
@@ -517,14 +514,16 @@ export class RecorderRuntime {
 
   private finishRecording(stopFrame: number): void {
     const context = this.context;
-    const activeRecording = this.activeRecording;
-    if (!context || !activeRecording) {
+    const pendingRecording = this.store.get().pendingRecording;
+    if (!context || !pendingRecording) {
       throw new Error("Recording state is incomplete.");
     }
-    const samples = activeRecording.recording.finish(stopFrame);
+    const samples = pendingRecording.recording.finish(stopFrame);
     if (!samples) {
-      this.activeRecording = undefined;
-      this.store.update({ captureStatus: "ready", pendingTake: undefined });
+      this.store.update({
+        captureStatus: "ready",
+        pendingRecording: undefined,
+      });
       this.syncTrackMix();
       return;
     }
@@ -534,22 +533,21 @@ export class RecorderRuntime {
       context.sampleRate,
     );
     takeBuffer.getChannelData(0).set(samples);
-    this.activeRecording = undefined;
     const recordingTrack = this.store.get().recordingTrack;
     this.store.update({
       captureStatus: "ready",
-      pendingTake: undefined,
+      pendingRecording: undefined,
       recordingTrack: {
         ...recordingTrack,
         nextTakeNumber: recordingTrack.nextTakeNumber + 1,
         takes: [
           ...recordingTrack.takes,
           {
-            id: activeRecording.id,
-            number: activeRecording.number,
+            id: pendingRecording.id,
+            number: pendingRecording.number,
             buffer: takeBuffer,
             duration: takeBuffer.duration,
-            timelineOffset: activeRecording.timelineOffset,
+            timelineOffset: pendingRecording.timelineOffset,
             audioView: createAudioView(
               samples,
               context.sampleRate,

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -221,7 +221,7 @@ export class RecorderRuntime {
   }
 
   setAudioTrackOffset(id: string, timelineOffset: number): void {
-    this.getAudioTrackPlayback(id).setTimelineOffset(timelineOffset);
+    this.getAudioTrackPlayback(id).setBufferTimelineOffset(timelineOffset);
     this.updateAudioTrack(id, (track) => ({
       ...track,
       timelineOffset,
@@ -274,7 +274,7 @@ export class RecorderRuntime {
       if (!track) {
         throw new Error("Audio track state is missing.");
       }
-      playback.setTimelineOffset(track.timelineOffset);
+      playback.setBufferTimelineOffset(track.timelineOffset);
       this.audioTrackPlaybacks.set(id, playback);
       this.syncTrackMix();
     }
@@ -430,7 +430,7 @@ export class RecorderRuntime {
         output: context.destination,
       });
       playback.setBuffer(buffer);
-      playback.setTimelineOffset(track.timelineOffset);
+      playback.setBufferTimelineOffset(track.timelineOffset);
       this.audioTrackPlaybacks.set(track.id, playback);
     }
     // Clamp loaded external state at the runtime boundary so older projects
@@ -593,10 +593,10 @@ export class RecorderRuntime {
         output: context.destination,
       });
       playback.setBuffer(take.buffer);
-      playback.setTimelineOffset(take.timelineOffset);
-      playback.setSourceRange({
-        sourceOffset: region.timelineOffset - take.timelineOffset,
-        duration: region.duration,
+      playback.setBufferTimelineOffset(take.timelineOffset);
+      playback.setTimelineRange({
+        start: region.timelineStart,
+        end: region.timelineEnd,
       });
       this.recordingTrackPlaybacks.push(playback);
     }

--- a/src/lib/recorder/take-comp.test.ts
+++ b/src/lib/recorder/take-comp.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { renderTakeComp } from "./take-comp.ts";
 import { deriveTakeRegions } from "./take-regions.ts";
+import type { TakeState } from "./take.ts";
 
 describe(renderTakeComp, () => {
   it("renders newer overlapping samples over an older take", () => {
@@ -8,17 +9,19 @@ describe(renderTakeComp, () => {
     const takes = [
       {
         id: "old",
+        number: 1,
         timelineOffset: 0,
         duration: 2,
         buffer: createBuffer({ sampleRate: 4, samples: Array(8).fill(1) }),
       },
       {
         id: "new",
+        number: 2,
         timelineOffset: 0.75,
         duration: 0.5,
         buffer: createBuffer({ sampleRate: 4, samples: [2, 2] }),
       },
-    ];
+    ] satisfies TakeState[];
     const result = renderTakeComp({
       context,
       regions: deriveTakeRegions(takes),
@@ -34,11 +37,12 @@ describe(renderTakeComp, () => {
     const takes = [
       {
         id: "take",
+        number: 1,
         timelineOffset: 0,
         duration: 1,
         buffer: createBuffer({ sampleRate: 2, samples: [0, 1] }),
       },
-    ];
+    ] satisfies TakeState[];
     const result = renderTakeComp({
       context: createContext(4),
       regions: deriveTakeRegions(takes),
@@ -52,11 +56,12 @@ describe(renderTakeComp, () => {
     const takes = [
       {
         id: "take",
+        number: 1,
         timelineOffset: 1,
         duration: 1,
         buffer: createBuffer({ sampleRate: 2, samples: [1, 1] }),
       },
-    ];
+    ] satisfies TakeState[];
     const result = renderTakeComp({
       context: createContext(2),
       regions: deriveTakeRegions(takes),

--- a/src/lib/recorder/take-comp.test.ts
+++ b/src/lib/recorder/take-comp.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { renderTakeComp } from "./take-comp.ts";
+
+describe(renderTakeComp, () => {
+  it("renders newer overlapping samples over an older take", () => {
+    const context = createContext(4);
+    const result = renderTakeComp({
+      context,
+      takes: [
+        {
+          id: "old",
+          timelineOffset: 0,
+          duration: 2,
+          buffer: createBuffer({ sampleRate: 4, samples: Array(8).fill(1) }),
+        },
+        {
+          id: "new",
+          timelineOffset: 0.75,
+          duration: 0.5,
+          buffer: createBuffer({ sampleRate: 4, samples: [2, 2] }),
+        },
+      ],
+    });
+
+    expect(Array.from(result!.getChannelData(0))).toEqual([
+      1, 1, 1, 2, 2, 1, 1, 1,
+    ]);
+  });
+
+  it("resamples take audio to the context sample rate", () => {
+    const result = renderTakeComp({
+      context: createContext(4),
+      takes: [
+        {
+          id: "take",
+          timelineOffset: 0,
+          duration: 1,
+          buffer: createBuffer({ sampleRate: 2, samples: [0, 1] }),
+        },
+      ],
+    });
+
+    expect(Array.from(result!.getChannelData(0))).toEqual([0, 0.5, 1, 1]);
+  });
+
+  it("includes silence before a positive timeline offset", () => {
+    const result = renderTakeComp({
+      context: createContext(2),
+      takes: [
+        {
+          id: "take",
+          timelineOffset: 1,
+          duration: 1,
+          buffer: createBuffer({ sampleRate: 2, samples: [1, 1] }),
+        },
+      ],
+    });
+
+    expect(Array.from(result!.getChannelData(0))).toEqual([0, 0, 1, 1]);
+  });
+});
+
+function createContext(sampleRate: number): BaseAudioContext {
+  return {
+    sampleRate,
+    createBuffer: (_channels, length, nextSampleRate) =>
+      createBuffer({
+        sampleRate: nextSampleRate,
+        samples: Array(length).fill(0),
+      }),
+  } as BaseAudioContext;
+}
+
+function createBuffer({
+  sampleRate,
+  samples,
+}: {
+  sampleRate: number;
+  samples: number[];
+}): AudioBuffer {
+  const data = Float32Array.from(samples);
+  return {
+    duration: data.length / sampleRate,
+    length: data.length,
+    numberOfChannels: 1,
+    sampleRate,
+    getChannelData: () => data,
+  } as unknown as AudioBuffer;
+}

--- a/src/lib/recorder/take-comp.test.ts
+++ b/src/lib/recorder/take-comp.test.ts
@@ -1,25 +1,28 @@
 import { describe, expect, it } from "vitest";
 import { renderTakeComp } from "./take-comp.ts";
+import { deriveTakeRegions } from "./take-regions.ts";
 
 describe(renderTakeComp, () => {
   it("renders newer overlapping samples over an older take", () => {
     const context = createContext(4);
+    const takes = [
+      {
+        id: "old",
+        timelineOffset: 0,
+        duration: 2,
+        buffer: createBuffer({ sampleRate: 4, samples: Array(8).fill(1) }),
+      },
+      {
+        id: "new",
+        timelineOffset: 0.75,
+        duration: 0.5,
+        buffer: createBuffer({ sampleRate: 4, samples: [2, 2] }),
+      },
+    ];
     const result = renderTakeComp({
       context,
-      takes: [
-        {
-          id: "old",
-          timelineOffset: 0,
-          duration: 2,
-          buffer: createBuffer({ sampleRate: 4, samples: Array(8).fill(1) }),
-        },
-        {
-          id: "new",
-          timelineOffset: 0.75,
-          duration: 0.5,
-          buffer: createBuffer({ sampleRate: 4, samples: [2, 2] }),
-        },
-      ],
+      regions: deriveTakeRegions(takes),
+      takes,
     });
 
     expect(Array.from(result!.getChannelData(0))).toEqual([
@@ -28,32 +31,36 @@ describe(renderTakeComp, () => {
   });
 
   it("resamples take audio to the context sample rate", () => {
+    const takes = [
+      {
+        id: "take",
+        timelineOffset: 0,
+        duration: 1,
+        buffer: createBuffer({ sampleRate: 2, samples: [0, 1] }),
+      },
+    ];
     const result = renderTakeComp({
       context: createContext(4),
-      takes: [
-        {
-          id: "take",
-          timelineOffset: 0,
-          duration: 1,
-          buffer: createBuffer({ sampleRate: 2, samples: [0, 1] }),
-        },
-      ],
+      regions: deriveTakeRegions(takes),
+      takes,
     });
 
     expect(Array.from(result!.getChannelData(0))).toEqual([0, 0.5, 1, 1]);
   });
 
   it("includes silence before a positive timeline offset", () => {
+    const takes = [
+      {
+        id: "take",
+        timelineOffset: 1,
+        duration: 1,
+        buffer: createBuffer({ sampleRate: 2, samples: [1, 1] }),
+      },
+    ];
     const result = renderTakeComp({
       context: createContext(2),
-      takes: [
-        {
-          id: "take",
-          timelineOffset: 1,
-          duration: 1,
-          buffer: createBuffer({ sampleRate: 2, samples: [1, 1] }),
-        },
-      ],
+      regions: deriveTakeRegions(takes),
+      takes,
     });
 
     expect(Array.from(result!.getChannelData(0))).toEqual([0, 0, 1, 1]);

--- a/src/lib/recorder/take-comp.test.ts
+++ b/src/lib/recorder/take-comp.test.ts
@@ -6,7 +6,7 @@ import type { TakeState } from "./take.ts";
 describe(renderTakeComp, () => {
   it("renders newer overlapping samples over an older take", () => {
     const context = createContext(4);
-    const takes = [
+    const takes: TakeState[] = [
       {
         id: "old",
         number: 1,
@@ -21,7 +21,7 @@ describe(renderTakeComp, () => {
         duration: 0.5,
         buffer: createBuffer({ sampleRate: 4, samples: [2, 2] }),
       },
-    ] satisfies TakeState[];
+    ];
     const result = renderTakeComp({
       context,
       regions: deriveTakeRegions(takes),
@@ -34,7 +34,7 @@ describe(renderTakeComp, () => {
   });
 
   it("resamples take audio to the context sample rate", () => {
-    const takes = [
+    const takes: TakeState[] = [
       {
         id: "take",
         number: 1,
@@ -42,7 +42,7 @@ describe(renderTakeComp, () => {
         duration: 1,
         buffer: createBuffer({ sampleRate: 2, samples: [0, 1] }),
       },
-    ] satisfies TakeState[];
+    ];
     const result = renderTakeComp({
       context: createContext(4),
       regions: deriveTakeRegions(takes),
@@ -53,7 +53,7 @@ describe(renderTakeComp, () => {
   });
 
   it("includes silence before a positive timeline offset", () => {
-    const takes = [
+    const takes: TakeState[] = [
       {
         id: "take",
         number: 1,
@@ -61,7 +61,7 @@ describe(renderTakeComp, () => {
         duration: 1,
         buffer: createBuffer({ sampleRate: 2, samples: [1, 1] }),
       },
-    ] satisfies TakeState[];
+    ];
     const result = renderTakeComp({
       context: createContext(2),
       regions: deriveTakeRegions(takes),

--- a/src/lib/recorder/take-comp.ts
+++ b/src/lib/recorder/take-comp.ts
@@ -31,15 +31,14 @@ export function renderTakeComp({
       continue;
     }
     const source = take.buffer.getChannelData(0);
+    const sourceOffset = region.timelineOffset - take.timelineOffset;
     // Convert the region's timeline placement to an output frame relative to
     // the earliest exported timeline position.
     const outputStart = Math.round(
       (region.timelineOffset - timelineOffset) * sampleRate,
     );
     const outputLength = Math.round(region.duration * sampleRate);
-    const sourceStart = Math.round(
-      region.sourceOffset * take.buffer.sampleRate,
-    );
+    const sourceStart = Math.round(sourceOffset * take.buffer.sampleRate);
     if (take.buffer.sampleRate === sampleRate) {
       output.set(
         source.subarray(sourceStart, sourceStart + outputLength),
@@ -51,7 +50,7 @@ export function renderTakeComp({
     // Linearly interpolate those as a compatibility fallback.
     for (let index = 0; index < outputLength; index++) {
       const sourcePosition =
-        (region.sourceOffset + index / sampleRate) * take.buffer.sampleRate;
+        (sourceOffset + index / sampleRate) * take.buffer.sampleRate;
       const sourceIndex = Math.floor(sourcePosition);
       const fraction = sourcePosition - sourceIndex;
       output[outputStart + index] =

--- a/src/lib/recorder/take-comp.ts
+++ b/src/lib/recorder/take-comp.ts
@@ -1,4 +1,4 @@
-import { deriveTakeRegions, type TakeRange } from "./take-regions.ts";
+import type { TakeRange, TakeRegion } from "./take-regions.ts";
 
 interface TakeWithBuffer extends TakeRange {
   buffer?: AudioBuffer;
@@ -6,12 +6,13 @@ interface TakeWithBuffer extends TakeRange {
 
 export function renderTakeComp({
   context,
+  regions,
   takes,
 }: {
   context: BaseAudioContext;
+  regions: readonly TakeRegion[];
   takes: readonly TakeWithBuffer[];
 }): AudioBuffer | undefined {
-  const regions = deriveTakeRegions(takes);
   if (regions.length === 0) {
     return undefined;
   }

--- a/src/lib/recorder/take-comp.ts
+++ b/src/lib/recorder/take-comp.ts
@@ -37,9 +37,19 @@ export function renderTakeComp({
       (region.timelineOffset - timelineOffset) * sampleRate,
     );
     const outputLength = Math.round(region.duration * sampleRate);
+    const sourceStart = Math.round(
+      region.sourceOffset * take.buffer.sampleRate,
+    );
+    if (take.buffer.sampleRate === sampleRate) {
+      output.set(
+        source.subarray(sourceStart, sourceStart + outputLength),
+        outputStart,
+      );
+      continue;
+    }
+    // Persisted takes may come from a context with another sample rate.
+    // Linearly interpolate those as a compatibility fallback.
     for (let index = 0; index < outputLength; index++) {
-      // Map each output frame back into the source buffer. The source may use a
-      // different sample rate, so interpolate between its neighboring frames.
       const sourcePosition =
         (region.sourceOffset + index / sampleRate) * take.buffer.sampleRate;
       const sourceIndex = Math.floor(sourcePosition);

--- a/src/lib/recorder/take-comp.ts
+++ b/src/lib/recorder/take-comp.ts
@@ -14,10 +14,8 @@ export function renderTakeComp({
   }
   // Keep timeline zero in the export so positive-offset recordings retain
   // their leading silence. Negative latency-compensated offsets extend it left.
-  const timelineOffset = Math.min(0, regions[0]!.timelineOffset);
-  const timelineEnd = Math.max(
-    ...regions.map((region) => region.timelineOffset + region.duration),
-  );
+  const timelineOffset = Math.min(0, regions[0]!.timelineStart);
+  const timelineEnd = Math.max(...regions.map((region) => region.timelineEnd));
   const sampleRate = context.sampleRate;
   const buffer = context.createBuffer(
     1,
@@ -31,13 +29,15 @@ export function renderTakeComp({
       continue;
     }
     const source = take.buffer.getChannelData(0);
-    const sourceOffset = region.timelineOffset - take.timelineOffset;
+    const sourceOffset = region.timelineStart - take.timelineOffset;
     // Convert the region's timeline placement to an output frame relative to
     // the earliest exported timeline position.
     const outputStart = Math.round(
-      (region.timelineOffset - timelineOffset) * sampleRate,
+      (region.timelineStart - timelineOffset) * sampleRate,
     );
-    const outputLength = Math.round(region.duration * sampleRate);
+    const outputLength = Math.round(
+      (region.timelineEnd - region.timelineStart) * sampleRate,
+    );
     const sourceStart = Math.round(sourceOffset * take.buffer.sampleRate);
     if (take.buffer.sampleRate === sampleRate) {
       output.set(

--- a/src/lib/recorder/take-comp.ts
+++ b/src/lib/recorder/take-comp.ts
@@ -1,0 +1,50 @@
+import { deriveTakeRegions, type TakeRange } from "./take-regions.ts";
+
+interface TakeWithBuffer extends TakeRange {
+  buffer?: AudioBuffer;
+}
+
+export function renderTakeComp({
+  context,
+  takes,
+}: {
+  context: BaseAudioContext;
+  takes: readonly TakeWithBuffer[];
+}): AudioBuffer | undefined {
+  const regions = deriveTakeRegions(takes);
+  if (regions.length === 0) {
+    return undefined;
+  }
+  const timelineOffset = Math.min(0, regions[0]!.timelineOffset);
+  const timelineEnd = Math.max(
+    ...regions.map((region) => region.timelineOffset + region.duration),
+  );
+  const sampleRate = context.sampleRate;
+  const buffer = context.createBuffer(
+    1,
+    Math.ceil((timelineEnd - timelineOffset) * sampleRate),
+    sampleRate,
+  );
+  const output = buffer.getChannelData(0);
+  for (const region of regions) {
+    const take = takes.find((entry) => entry.id === region.takeId);
+    if (!take?.buffer) {
+      continue;
+    }
+    const source = take.buffer.getChannelData(0);
+    const outputStart = Math.round(
+      (region.timelineOffset - timelineOffset) * sampleRate,
+    );
+    const outputLength = Math.round(region.duration * sampleRate);
+    for (let index = 0; index < outputLength; index++) {
+      const sourcePosition =
+        (region.sourceOffset + index / sampleRate) * take.buffer.sampleRate;
+      const sourceIndex = Math.floor(sourcePosition);
+      const fraction = sourcePosition - sourceIndex;
+      output[outputStart + index] =
+        (source[sourceIndex] ?? 0) * (1 - fraction) +
+        (source[sourceIndex + 1] ?? source[sourceIndex] ?? 0) * fraction;
+    }
+  }
+  return buffer;
+}

--- a/src/lib/recorder/take-comp.ts
+++ b/src/lib/recorder/take-comp.ts
@@ -1,8 +1,4 @@
-import type { TakeRange, TakeRegion } from "./take-regions.ts";
-
-interface TakeWithBuffer extends TakeRange {
-  buffer?: AudioBuffer;
-}
+import type { TakeRegion, TakeState } from "./take.ts";
 
 export function renderTakeComp({
   context,
@@ -11,7 +7,7 @@ export function renderTakeComp({
 }: {
   context: BaseAudioContext;
   regions: readonly TakeRegion[];
-  takes: readonly TakeWithBuffer[];
+  takes: readonly TakeState[];
 }): AudioBuffer | undefined {
   if (regions.length === 0) {
     return undefined;

--- a/src/lib/recorder/take-comp.ts
+++ b/src/lib/recorder/take-comp.ts
@@ -12,6 +12,8 @@ export function renderTakeComp({
   if (regions.length === 0) {
     return undefined;
   }
+  // Keep timeline zero in the export so positive-offset recordings retain
+  // their leading silence. Negative latency-compensated offsets extend it left.
   const timelineOffset = Math.min(0, regions[0]!.timelineOffset);
   const timelineEnd = Math.max(
     ...regions.map((region) => region.timelineOffset + region.duration),
@@ -29,11 +31,15 @@ export function renderTakeComp({
       continue;
     }
     const source = take.buffer.getChannelData(0);
+    // Convert the region's timeline placement to an output frame relative to
+    // the earliest exported timeline position.
     const outputStart = Math.round(
       (region.timelineOffset - timelineOffset) * sampleRate,
     );
     const outputLength = Math.round(region.duration * sampleRate);
     for (let index = 0; index < outputLength; index++) {
+      // Map each output frame back into the source buffer. The source may use a
+      // different sample rate, so interpolate between its neighboring frames.
       const sourcePosition =
         (region.sourceOffset + index / sampleRate) * take.buffer.sampleRate;
       const sourceIndex = Math.floor(sourcePosition);

--- a/src/lib/recorder/take-regions.test.ts
+++ b/src/lib/recorder/take-regions.test.ts
@@ -9,44 +9,44 @@ describe(deriveTakeRegions, () => {
     ).toEqual([
       {
         takeId: "second",
-        timelineOffset: 0,
-        duration: 2,
+        timelineStart: 0,
+        timelineEnd: 2,
       },
       {
         takeId: "first",
-        timelineOffset: 4,
-        duration: 2,
+        timelineStart: 4,
+        timelineEnd: 6,
       },
     ]);
   });
 
   it("lets a newer take replace the end of an older take", () => {
     expect(deriveTakeRegions([take("old", 0, 5), take("new", 3, 4)])).toEqual([
-      { takeId: "old", timelineOffset: 0, duration: 3 },
-      { takeId: "new", timelineOffset: 3, duration: 4 },
+      { takeId: "old", timelineStart: 0, timelineEnd: 3 },
+      { takeId: "new", timelineStart: 3, timelineEnd: 7 },
     ]);
   });
 
   it("splits an older take around a contained newer take", () => {
     expect(deriveTakeRegions([take("old", 0, 10), take("new", 3, 4)])).toEqual([
-      { takeId: "old", timelineOffset: 0, duration: 3 },
-      { takeId: "new", timelineOffset: 3, duration: 4 },
-      { takeId: "old", timelineOffset: 7, duration: 3 },
+      { takeId: "old", timelineStart: 0, timelineEnd: 3 },
+      { takeId: "new", timelineStart: 3, timelineEnd: 7 },
+      { takeId: "old", timelineStart: 7, timelineEnd: 10 },
     ]);
   });
 
   it("uses the newest take for equal ranges", () => {
     expect(deriveTakeRegions([take("old", 1, 4), take("new", 1, 4)])).toEqual([
-      { takeId: "new", timelineOffset: 1, duration: 4 },
+      { takeId: "new", timelineStart: 1, timelineEnd: 5 },
     ]);
   });
 
   it("preserves negative timeline offsets", () => {
     expect(deriveTakeRegions([take("old", -4, 6), take("new", -2, 3)])).toEqual(
       [
-        { takeId: "old", timelineOffset: -4, duration: 2 },
-        { takeId: "new", timelineOffset: -2, duration: 3 },
-        { takeId: "old", timelineOffset: 1, duration: 1 },
+        { takeId: "old", timelineStart: -4, timelineEnd: -2 },
+        { takeId: "new", timelineStart: -2, timelineEnd: 1 },
+        { takeId: "old", timelineStart: 1, timelineEnd: 2 },
       ],
     );
   });

--- a/src/lib/recorder/take-regions.test.ts
+++ b/src/lib/recorder/take-regions.test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { deriveTakeRegions } from "./take-regions.ts";
+import type { TakeState } from "./take.ts";
 
 describe(deriveTakeRegions, () => {
   it("keeps disjoint takes in timeline order", () => {
     expect(
-      deriveTakeRegions([
-        { id: "first", timelineOffset: 4, duration: 2 },
-        { id: "second", timelineOffset: 0, duration: 2 },
-      ]),
+      deriveTakeRegions([take("first", 4, 2), take("second", 0, 2)]),
     ).toEqual([
       {
         takeId: "second",
@@ -25,24 +23,14 @@ describe(deriveTakeRegions, () => {
   });
 
   it("lets a newer take replace the end of an older take", () => {
-    expect(
-      deriveTakeRegions([
-        { id: "old", timelineOffset: 0, duration: 5 },
-        { id: "new", timelineOffset: 3, duration: 4 },
-      ]),
-    ).toEqual([
+    expect(deriveTakeRegions([take("old", 0, 5), take("new", 3, 4)])).toEqual([
       { takeId: "old", timelineOffset: 0, sourceOffset: 0, duration: 3 },
       { takeId: "new", timelineOffset: 3, sourceOffset: 0, duration: 4 },
     ]);
   });
 
   it("splits an older take around a contained newer take", () => {
-    expect(
-      deriveTakeRegions([
-        { id: "old", timelineOffset: 0, duration: 10 },
-        { id: "new", timelineOffset: 3, duration: 4 },
-      ]),
-    ).toEqual([
+    expect(deriveTakeRegions([take("old", 0, 10), take("new", 3, 4)])).toEqual([
       { takeId: "old", timelineOffset: 0, sourceOffset: 0, duration: 3 },
       { takeId: "new", timelineOffset: 3, sourceOffset: 0, duration: 4 },
       { takeId: "old", timelineOffset: 7, sourceOffset: 7, duration: 3 },
@@ -50,26 +38,22 @@ describe(deriveTakeRegions, () => {
   });
 
   it("uses the newest take for equal ranges", () => {
-    expect(
-      deriveTakeRegions([
-        { id: "old", timelineOffset: 1, duration: 4 },
-        { id: "new", timelineOffset: 1, duration: 4 },
-      ]),
-    ).toEqual([
+    expect(deriveTakeRegions([take("old", 1, 4), take("new", 1, 4)])).toEqual([
       { takeId: "new", timelineOffset: 1, sourceOffset: 0, duration: 4 },
     ]);
   });
 
   it("preserves negative timeline offsets", () => {
-    expect(
-      deriveTakeRegions([
-        { id: "old", timelineOffset: -4, duration: 6 },
-        { id: "new", timelineOffset: -2, duration: 3 },
-      ]),
-    ).toEqual([
-      { takeId: "old", timelineOffset: -4, sourceOffset: 0, duration: 2 },
-      { takeId: "new", timelineOffset: -2, sourceOffset: 0, duration: 3 },
-      { takeId: "old", timelineOffset: 1, sourceOffset: 5, duration: 1 },
-    ]);
+    expect(deriveTakeRegions([take("old", -4, 6), take("new", -2, 3)])).toEqual(
+      [
+        { takeId: "old", timelineOffset: -4, sourceOffset: 0, duration: 2 },
+        { takeId: "new", timelineOffset: -2, sourceOffset: 0, duration: 3 },
+        { takeId: "old", timelineOffset: 1, sourceOffset: 5, duration: 1 },
+      ],
+    );
   });
 });
+
+function take(id: string, timelineOffset: number, duration: number): TakeState {
+  return { id, number: 1, timelineOffset, duration };
+}

--- a/src/lib/recorder/take-regions.test.ts
+++ b/src/lib/recorder/take-regions.test.ts
@@ -10,13 +10,11 @@ describe(deriveTakeRegions, () => {
       {
         takeId: "second",
         timelineOffset: 0,
-        sourceOffset: 0,
         duration: 2,
       },
       {
         takeId: "first",
         timelineOffset: 4,
-        sourceOffset: 0,
         duration: 2,
       },
     ]);
@@ -24,31 +22,31 @@ describe(deriveTakeRegions, () => {
 
   it("lets a newer take replace the end of an older take", () => {
     expect(deriveTakeRegions([take("old", 0, 5), take("new", 3, 4)])).toEqual([
-      { takeId: "old", timelineOffset: 0, sourceOffset: 0, duration: 3 },
-      { takeId: "new", timelineOffset: 3, sourceOffset: 0, duration: 4 },
+      { takeId: "old", timelineOffset: 0, duration: 3 },
+      { takeId: "new", timelineOffset: 3, duration: 4 },
     ]);
   });
 
   it("splits an older take around a contained newer take", () => {
     expect(deriveTakeRegions([take("old", 0, 10), take("new", 3, 4)])).toEqual([
-      { takeId: "old", timelineOffset: 0, sourceOffset: 0, duration: 3 },
-      { takeId: "new", timelineOffset: 3, sourceOffset: 0, duration: 4 },
-      { takeId: "old", timelineOffset: 7, sourceOffset: 7, duration: 3 },
+      { takeId: "old", timelineOffset: 0, duration: 3 },
+      { takeId: "new", timelineOffset: 3, duration: 4 },
+      { takeId: "old", timelineOffset: 7, duration: 3 },
     ]);
   });
 
   it("uses the newest take for equal ranges", () => {
     expect(deriveTakeRegions([take("old", 1, 4), take("new", 1, 4)])).toEqual([
-      { takeId: "new", timelineOffset: 1, sourceOffset: 0, duration: 4 },
+      { takeId: "new", timelineOffset: 1, duration: 4 },
     ]);
   });
 
   it("preserves negative timeline offsets", () => {
     expect(deriveTakeRegions([take("old", -4, 6), take("new", -2, 3)])).toEqual(
       [
-        { takeId: "old", timelineOffset: -4, sourceOffset: 0, duration: 2 },
-        { takeId: "new", timelineOffset: -2, sourceOffset: 0, duration: 3 },
-        { takeId: "old", timelineOffset: 1, sourceOffset: 5, duration: 1 },
+        { takeId: "old", timelineOffset: -4, duration: 2 },
+        { takeId: "new", timelineOffset: -2, duration: 3 },
+        { takeId: "old", timelineOffset: 1, duration: 1 },
       ],
     );
   });

--- a/src/lib/recorder/take-regions.test.ts
+++ b/src/lib/recorder/take-regions.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { deriveTakeRegions } from "./take-regions.ts";
+
+describe(deriveTakeRegions, () => {
+  it("keeps disjoint takes in timeline order", () => {
+    expect(
+      deriveTakeRegions([
+        { id: "first", timelineOffset: 4, duration: 2 },
+        { id: "second", timelineOffset: 0, duration: 2 },
+      ]),
+    ).toEqual([
+      {
+        takeId: "second",
+        timelineOffset: 0,
+        sourceOffset: 0,
+        duration: 2,
+      },
+      {
+        takeId: "first",
+        timelineOffset: 4,
+        sourceOffset: 0,
+        duration: 2,
+      },
+    ]);
+  });
+
+  it("lets a newer take replace the end of an older take", () => {
+    expect(
+      deriveTakeRegions([
+        { id: "old", timelineOffset: 0, duration: 5 },
+        { id: "new", timelineOffset: 3, duration: 4 },
+      ]),
+    ).toEqual([
+      { takeId: "old", timelineOffset: 0, sourceOffset: 0, duration: 3 },
+      { takeId: "new", timelineOffset: 3, sourceOffset: 0, duration: 4 },
+    ]);
+  });
+
+  it("splits an older take around a contained newer take", () => {
+    expect(
+      deriveTakeRegions([
+        { id: "old", timelineOffset: 0, duration: 10 },
+        { id: "new", timelineOffset: 3, duration: 4 },
+      ]),
+    ).toEqual([
+      { takeId: "old", timelineOffset: 0, sourceOffset: 0, duration: 3 },
+      { takeId: "new", timelineOffset: 3, sourceOffset: 0, duration: 4 },
+      { takeId: "old", timelineOffset: 7, sourceOffset: 7, duration: 3 },
+    ]);
+  });
+
+  it("uses the newest take for equal ranges", () => {
+    expect(
+      deriveTakeRegions([
+        { id: "old", timelineOffset: 1, duration: 4 },
+        { id: "new", timelineOffset: 1, duration: 4 },
+      ]),
+    ).toEqual([
+      { takeId: "new", timelineOffset: 1, sourceOffset: 0, duration: 4 },
+    ]);
+  });
+
+  it("preserves negative timeline offsets", () => {
+    expect(
+      deriveTakeRegions([
+        { id: "old", timelineOffset: -4, duration: 6 },
+        { id: "new", timelineOffset: -2, duration: 3 },
+      ]),
+    ).toEqual([
+      { takeId: "old", timelineOffset: -4, sourceOffset: 0, duration: 2 },
+      { takeId: "new", timelineOffset: -2, sourceOffset: 0, duration: 3 },
+      { takeId: "old", timelineOffset: 1, sourceOffset: 5, duration: 1 },
+    ]);
+  });
+});

--- a/src/lib/recorder/take-regions.ts
+++ b/src/lib/recorder/take-regions.ts
@@ -1,0 +1,78 @@
+export interface TakeRange {
+  id: string;
+  timelineOffset: number;
+  duration: number;
+}
+
+export interface TakeRegion {
+  takeId: string;
+  timelineOffset: number;
+  sourceOffset: number;
+  duration: number;
+}
+
+/** Resolves overlapping takes so later array entries win their timeline range. */
+export function deriveTakeRegions(takes: readonly TakeRange[]): TakeRegion[] {
+  let regions: TakeRegion[] = [];
+
+  for (const take of takes) {
+    if (take.duration <= 0) {
+      continue;
+    }
+    const takeEnd = take.timelineOffset + take.duration;
+    const nextRegions: TakeRegion[] = [];
+    for (const region of regions) {
+      const regionEnd = region.timelineOffset + region.duration;
+      if (
+        regionEnd <= take.timelineOffset ||
+        region.timelineOffset >= takeEnd
+      ) {
+        nextRegions.push(region);
+        continue;
+      }
+      if (region.timelineOffset < take.timelineOffset) {
+        nextRegions.push({
+          ...region,
+          duration: take.timelineOffset - region.timelineOffset,
+        });
+      }
+      if (regionEnd > takeEnd) {
+        nextRegions.push({
+          ...region,
+          timelineOffset: takeEnd,
+          sourceOffset: region.sourceOffset + takeEnd - region.timelineOffset,
+          duration: regionEnd - takeEnd,
+        });
+      }
+    }
+    nextRegions.push({
+      takeId: take.id,
+      timelineOffset: take.timelineOffset,
+      sourceOffset: 0,
+      duration: take.duration,
+    });
+    regions = mergeAdjacentRegions(
+      nextRegions.sort((a, b) => a.timelineOffset - b.timelineOffset),
+    );
+  }
+
+  return regions;
+}
+
+function mergeAdjacentRegions(regions: readonly TakeRegion[]): TakeRegion[] {
+  const merged: TakeRegion[] = [];
+  for (const region of regions) {
+    const previous = merged.at(-1);
+    if (
+      previous &&
+      previous.takeId === region.takeId &&
+      previous.timelineOffset + previous.duration === region.timelineOffset &&
+      previous.sourceOffset + previous.duration === region.sourceOffset
+    ) {
+      previous.duration += region.duration;
+    } else {
+      merged.push({ ...region });
+    }
+  }
+  return merged;
+}

--- a/src/lib/recorder/take-regions.ts
+++ b/src/lib/recorder/take-regions.ts
@@ -16,7 +16,7 @@ export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
       const regionEnd = region.timelineOffset + region.duration;
       if (
         regionEnd <= take.timelineOffset ||
-        region.timelineOffset >= takeEnd
+        takeEnd <= region.timelineOffset
       ) {
         // Half-open intervals that only touch at an edge do not overlap.
         nextRegions.push(region);
@@ -29,7 +29,7 @@ export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
           duration: take.timelineOffset - region.timelineOffset,
         });
       }
-      if (regionEnd > takeEnd) {
+      if (takeEnd < regionEnd) {
         // Preserve the older region after the new take. Advance sourceOffset by
         // the removed timeline span so it still addresses the same source audio.
         nextRegions.push({

--- a/src/lib/recorder/take-regions.ts
+++ b/src/lib/recorder/take-regions.ts
@@ -10,16 +10,13 @@ export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
     if (take.duration <= 0) {
       continue;
     }
-    const takeEnd = take.timelineOffset + take.duration;
+    const takeStart = take.timelineOffset;
+    const takeEnd = takeStart + take.duration;
     const nextRegions: TakeRegion[] = [];
     for (const region of regions) {
-      const regionEnd = region.timelineOffset + region.duration;
       // no overlap
       // [--region--] [---take---]  (or reversed)
-      if (
-        regionEnd <= take.timelineOffset ||
-        takeEnd <= region.timelineOffset
-      ) {
+      if (region.timelineEnd <= takeStart || takeEnd <= region.timelineStart) {
         // Half-open intervals that only touch at an edge do not overlap.
         nextRegions.push(region);
         continue;
@@ -29,11 +26,11 @@ export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
       // or
       // [------region-------]
       //     [---take---]
-      if (region.timelineOffset < take.timelineOffset) {
+      if (region.timelineStart < takeStart) {
         // Preserve the older region before the new take starts.
         nextRegions.push({
           ...region,
-          duration: take.timelineOffset - region.timelineOffset,
+          timelineEnd: takeStart,
         });
       }
       //         [--region--]
@@ -41,12 +38,11 @@ export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
       // or
       // [------region------]
       //     [---take---]
-      if (takeEnd < regionEnd) {
+      if (takeEnd < region.timelineEnd) {
         // Preserve the older timeline slice after the new take.
         nextRegions.push({
           ...region,
-          timelineOffset: takeEnd,
-          duration: regionEnd - takeEnd,
+          timelineStart: takeEnd,
         });
       }
       // otherwise region gets covered fully and disappears
@@ -57,11 +53,11 @@ export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
     // already been removed from older regions.
     nextRegions.push({
       takeId: take.id,
-      timelineOffset: take.timelineOffset,
-      duration: take.duration,
+      timelineStart: takeStart,
+      timelineEnd: takeEnd,
     });
     regions = nextRegions;
   }
 
-  return regions.sort((a, b) => a.timelineOffset - b.timelineOffset);
+  return regions.sort((a, b) => a.timelineStart - b.timelineStart);
 }

--- a/src/lib/recorder/take-regions.ts
+++ b/src/lib/recorder/take-regions.ts
@@ -1,18 +1,7 @@
-export interface TakeRange {
-  id: string;
-  timelineOffset: number;
-  duration: number;
-}
-
-export interface TakeRegion {
-  takeId: string;
-  timelineOffset: number;
-  sourceOffset: number;
-  duration: number;
-}
+import type { TakeRegion, TakeState } from "./take.ts";
 
 /** Resolves overlapping takes so later array entries win their timeline range. */
-export function deriveTakeRegions(takes: readonly TakeRange[]): TakeRegion[] {
+export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
   let regions: TakeRegion[] = [];
 
   for (const take of takes) {

--- a/src/lib/recorder/take-regions.ts
+++ b/src/lib/recorder/take-regions.ts
@@ -4,6 +4,8 @@ import type { TakeRegion, TakeState } from "./take.ts";
 export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
   let regions: TakeRegion[] = [];
 
+  // Apply takes oldest to newest. Each new take subtracts its interval from
+  // every existing region before being inserted as the winning region.
   for (const take of takes) {
     if (take.duration <= 0) {
       continue;
@@ -16,16 +18,20 @@ export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
         regionEnd <= take.timelineOffset ||
         region.timelineOffset >= takeEnd
       ) {
+        // Half-open intervals that only touch at an edge do not overlap.
         nextRegions.push(region);
         continue;
       }
       if (region.timelineOffset < take.timelineOffset) {
+        // Preserve the older region before the new take starts.
         nextRegions.push({
           ...region,
           duration: take.timelineOffset - region.timelineOffset,
         });
       }
       if (regionEnd > takeEnd) {
+        // Preserve the older region after the new take. Advance sourceOffset by
+        // the removed timeline span so it still addresses the same source audio.
         nextRegions.push({
           ...region,
           timelineOffset: takeEnd,
@@ -34,6 +40,8 @@ export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
         });
       }
     }
+    // The complete new take wins its own interval because all overlaps have
+    // already been removed from older regions.
     nextRegions.push({
       takeId: take.id,
       timelineOffset: take.timelineOffset,
@@ -55,6 +63,7 @@ function mergeAdjacentRegions(regions: readonly TakeRegion[]): TakeRegion[] {
     if (
       previous &&
       previous.takeId === region.takeId &&
+      // Merge only when both timeline and source coordinates are contiguous.
       previous.timelineOffset + previous.duration === region.timelineOffset &&
       previous.sourceOffset + previous.duration === region.sourceOffset
     ) {

--- a/src/lib/recorder/take-regions.ts
+++ b/src/lib/recorder/take-regions.ts
@@ -63,8 +63,8 @@ export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
       sourceOffset: 0,
       duration: take.duration,
     });
-    regions = nextRegions.sort((a, b) => a.timelineOffset - b.timelineOffset);
+    regions = nextRegions;
   }
 
-  return regions;
+  return regions.sort((a, b) => a.timelineOffset - b.timelineOffset);
 }

--- a/src/lib/recorder/take-regions.ts
+++ b/src/lib/recorder/take-regions.ts
@@ -42,12 +42,10 @@ export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
       // [------region------]
       //     [---take---]
       if (takeEnd < regionEnd) {
-        // Preserve the older region after the new take. Advance sourceOffset by
-        // the removed timeline span so it still addresses the same source audio.
+        // Preserve the older timeline slice after the new take.
         nextRegions.push({
           ...region,
           timelineOffset: takeEnd,
-          sourceOffset: region.sourceOffset + takeEnd - region.timelineOffset,
           duration: regionEnd - takeEnd,
         });
       }
@@ -60,7 +58,6 @@ export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
     nextRegions.push({
       takeId: take.id,
       timelineOffset: take.timelineOffset,
-      sourceOffset: 0,
       duration: take.duration,
     });
     regions = nextRegions;

--- a/src/lib/recorder/take-regions.ts
+++ b/src/lib/recorder/take-regions.ts
@@ -14,6 +14,8 @@ export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
     const nextRegions: TakeRegion[] = [];
     for (const region of regions) {
       const regionEnd = region.timelineOffset + region.duration;
+      // no overlap
+      // [--region--] [---take---]  (or reversed)
       if (
         regionEnd <= take.timelineOffset ||
         takeEnd <= region.timelineOffset
@@ -22,6 +24,11 @@ export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
         nextRegions.push(region);
         continue;
       }
+      // [--region--]
+      //     [---take---]
+      // or
+      // [------region-------]
+      //     [---take---]
       if (region.timelineOffset < take.timelineOffset) {
         // Preserve the older region before the new take starts.
         nextRegions.push({
@@ -29,6 +36,11 @@ export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
           duration: take.timelineOffset - region.timelineOffset,
         });
       }
+      //         [--region--]
+      //     [---take---]
+      // or
+      // [------region------]
+      //     [---take---]
       if (takeEnd < regionEnd) {
         // Preserve the older region after the new take. Advance sourceOffset by
         // the removed timeline span so it still addresses the same source audio.
@@ -39,6 +51,9 @@ export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
           duration: regionEnd - takeEnd,
         });
       }
+      // otherwise region gets covered fully and disappears
+      //    [--region--]
+      // [------take------]
     }
     // The complete new take wins its own interval because all overlaps have
     // already been removed from older regions.
@@ -48,29 +63,8 @@ export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
       sourceOffset: 0,
       duration: take.duration,
     });
-    regions = mergeAdjacentRegions(
-      nextRegions.sort((a, b) => a.timelineOffset - b.timelineOffset),
-    );
+    regions = nextRegions.sort((a, b) => a.timelineOffset - b.timelineOffset);
   }
 
   return regions;
-}
-
-function mergeAdjacentRegions(regions: readonly TakeRegion[]): TakeRegion[] {
-  const merged: TakeRegion[] = [];
-  for (const region of regions) {
-    const previous = merged.at(-1);
-    if (
-      previous &&
-      previous.takeId === region.takeId &&
-      // Merge only when both timeline and source coordinates are contiguous.
-      previous.timelineOffset + previous.duration === region.timelineOffset &&
-      previous.sourceOffset + previous.duration === region.sourceOffset
-    ) {
-      previous.duration += region.duration;
-    } else {
-      merged.push({ ...region });
-    }
-  }
-  return merged;
 }

--- a/src/lib/recorder/take.ts
+++ b/src/lib/recorder/take.ts
@@ -11,6 +11,6 @@ export interface TakeState {
 
 export interface TakeRegion {
   takeId: string;
-  timelineOffset: number;
-  duration: number;
+  timelineStart: number;
+  timelineEnd: number;
 }

--- a/src/lib/recorder/take.ts
+++ b/src/lib/recorder/take.ts
@@ -1,0 +1,17 @@
+import type { AudioView } from "../audio-view.ts";
+
+export interface TakeState {
+  id: string;
+  number: number;
+  duration: number;
+  timelineOffset: number;
+  buffer?: AudioBuffer;
+  audioView?: AudioView;
+}
+
+export interface TakeRegion {
+  takeId: string;
+  timelineOffset: number;
+  sourceOffset: number;
+  duration: number;
+}

--- a/src/lib/recorder/take.ts
+++ b/src/lib/recorder/take.ts
@@ -12,6 +12,5 @@ export interface TakeState {
 export interface TakeRegion {
   takeId: string;
   timelineOffset: number;
-  sourceOffset: number;
   duration: number;
 }


### PR DESCRIPTION
- part of https://github.com/hi-ogawa/toy-midi/issues/364
- explain diff https://gisthost.github.io/?57a7a54107941edcbc3ad78de54fa46a/2026-08-25-pr-365-multi-take-comping.html

Recording a new section currently destroys the previous take, which prevents building a performance incrementally. This PR retains each finalized recording and derives non-overlapping playback regions where newer takes win only across their recorded range.

The Capture timeline shows the retained source waveforms as stacked lanes, supports selecting and deleting a take, and exports the resolved comp as one WAV. Pending capture stays transient, take identity and numbering persist across projects, and bounded playback regions keep overlap policy out of the transport primitive.