### PR TITLE
fix: preserve unsaved recorder changes on focus

### DIFF
--- a/e2e/fake-audio/recorder-persistence.test.ts
+++ b/e2e/fake-audio/recorder-persistence.test.ts
@@ -79,33 +79,3 @@ test("saves and restores a recorder project", async ({ page }) => {
   await page.goto(projectUrl);
   await expect(page.getByText(/Recorder project .* not found/)).toBeVisible();
 });
-
-test("keeps unsaved changes when the tab regains focus", async ({
-  context,
-  page,
-}) => {
-  await createRecorderProject(page);
-
-  await page.getByTestId("recorder-tempo-input").fill("140");
-  await page.getByTestId("recorder-tempo-input").press("Enter");
-  const saveButton = page.getByRole("button", {
-    name: "Unsaved changes (Ctrl/Cmd+S to save)",
-  });
-  await expect(saveButton).toBeEnabled();
-
-  const otherPage = await context.newPage();
-  await otherPage.goto("/recorder");
-  await otherPage.bringToFront();
-  await otherPage.getByTestId("new-recorder-project-button").focus();
-  await page.bringToFront();
-  await page.getByTestId("recorder-project-name").click();
-  await page.evaluate(() =>
-    window.dispatchEvent(new Event("visibilitychange")),
-  );
-  await page.getByTestId("recorder-tempo-input").press("ArrowUp");
-  await expect
-    .poll(() => page.getByTestId("recorder-tempo-input").inputValue())
-    .toBe("141");
-
-  await expect(saveButton).toBeEnabled();
-});

--- a/e2e/fake-audio/recorder-persistence.test.ts
+++ b/e2e/fake-audio/recorder-persistence.test.ts
@@ -79,3 +79,24 @@ test("saves and restores a recorder project", async ({ page }) => {
   await page.goto(projectUrl);
   await expect(page.getByText(/Recorder project .* not found/)).toBeVisible();
 });
+
+test("keeps unsaved changes when the tab regains focus", async ({
+  context,
+  page,
+}) => {
+  await createRecorderProject(page);
+
+  await page.getByTestId("recorder-tempo-input").fill("140");
+  await page.getByTestId("recorder-tempo-input").press("Enter");
+  const saveButton = page.getByRole("button", {
+    name: "Unsaved changes (Ctrl/Cmd+S to save)",
+  });
+  await expect(saveButton).toBeEnabled();
+
+  const otherPage = await context.newPage();
+  await otherPage.bringToFront();
+  await page.bringToFront();
+
+  await expect(page.getByTestId("recorder-tempo-input")).toHaveValue("140");
+  await expect(saveButton).toBeEnabled();
+});

--- a/e2e/fake-audio/recorder-persistence.test.ts
+++ b/e2e/fake-audio/recorder-persistence.test.ts
@@ -80,7 +80,10 @@ test("saves and restores a recorder project", async ({ page }) => {
   await expect(page.getByText(/Recorder project .* not found/)).toBeVisible();
 });
 
-test("keeps unsaved changes when the tab regains focus", async ({ page }) => {
+test("keeps unsaved changes when the tab regains focus", async ({
+  context,
+  page,
+}) => {
   await createRecorderProject(page);
 
   await page.getByTestId("recorder-tempo-input").fill("140");
@@ -90,10 +93,19 @@ test("keeps unsaved changes when the tab regains focus", async ({ page }) => {
   });
   await expect(saveButton).toBeEnabled();
 
+  const otherPage = await context.newPage();
+  await otherPage.goto("/recorder");
+  await otherPage.bringToFront();
+  await otherPage.getByTestId("new-recorder-project-button").focus();
+  await page.bringToFront();
+  await page.getByTestId("recorder-project-name").click();
   await page.evaluate(() =>
     window.dispatchEvent(new Event("visibilitychange")),
   );
+  await page.getByTestId("recorder-tempo-input").press("ArrowUp");
+  await expect
+    .poll(() => page.getByTestId("recorder-tempo-input").inputValue())
+    .toBe("141");
 
-  await expect(page.getByTestId("recorder-tempo-input")).toHaveValue("140");
   await expect(saveButton).toBeEnabled();
 });

--- a/e2e/fake-audio/recorder-persistence.test.ts
+++ b/e2e/fake-audio/recorder-persistence.test.ts
@@ -80,10 +80,7 @@ test("saves and restores a recorder project", async ({ page }) => {
   await expect(page.getByText(/Recorder project .* not found/)).toBeVisible();
 });
 
-test("keeps unsaved changes when the tab regains focus", async ({
-  context,
-  page,
-}) => {
+test("keeps unsaved changes when the tab regains focus", async ({ page }) => {
   await createRecorderProject(page);
 
   await page.getByTestId("recorder-tempo-input").fill("140");
@@ -93,9 +90,9 @@ test("keeps unsaved changes when the tab regains focus", async ({
   });
   await expect(saveButton).toBeEnabled();
 
-  const otherPage = await context.newPage();
-  await otherPage.bringToFront();
-  await page.bringToFront();
+  await page.evaluate(() =>
+    window.dispatchEvent(new Event("visibilitychange")),
+  );
 
   await expect(page.getByTestId("recorder-tempo-input")).toHaveValue("140");
   await expect(saveButton).toBeEnabled();

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -453,7 +453,6 @@ function useRecorderProject({
   const projectQuery = useQuery({
     queryKey: ["recorder-project", projectId],
     retry: false,
-    refetchOnMount: false,
     staleTime: Infinity,
     queryFn: async () => {
       const project = await recorderProjectStorage.load(projectId);

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -454,6 +454,7 @@ function useRecorderProject({
     queryKey: ["recorder-project", projectId],
     retry: false,
     refetchOnMount: false,
+    staleTime: Infinity,
     queryFn: async () => {
       const project = await recorderProjectStorage.load(projectId);
       runtime.deserializeProject(project);


### PR DESCRIPTION
The recorder project query is hydration from IndexedDB, but React Query treated it as immediately stale and refetched when the tab regained focus. That could deserialize the saved project over unsaved runtime changes and leave the save indicator misleading.

This PR keeps the hydration query fresh indefinitely so focus changes do not reload persisted state over the active recorder session.