### PR TITLE
feat: move and trim recorder takes

### DIFF
--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -136,14 +136,14 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
 
   // Selecting a source take does not seek, and Escape clears the selection.
   const positionBeforeSelection = await position.textContent();
-  await take.nth(0).click({ position: { x: 10, y: 10 } });
+  await take.nth(0).dispatchEvent("click");
   await expect(position).toHaveText(positionBeforeSelection!);
   await expect(take.nth(0)).toHaveClass(/border-sky-300/);
   await page.keyboard.press("Escape");
   await expect(take.nth(0)).not.toHaveClass(/border-sky-300/);
 
   // Deleting a selected source take leaves the other take intact.
-  await take.nth(0).click({ position: { x: 10, y: 10 } });
+  await take.nth(0).dispatchEvent("click");
   await page.keyboard.press("Delete");
   await expect(take).toHaveCount(1);
   await expect(take).toContainText("Take 2");

--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -72,6 +72,35 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
     Number.parseFloat(await take.evaluate((element) => element.style.left)),
   ).toBeCloseTo(160, -2);
 
+  // The take can be moved and trimmed without changing its source audio.
+  const beforeEdit = await take.boundingBox();
+  expect(beforeEdit).not.toBeNull();
+  await dragBy(page, take, 80);
+  const afterMove = await take.boundingBox();
+  expect(afterMove).not.toBeNull();
+  expect(afterMove!.x).toBeCloseTo(beforeEdit!.x + 80, -1);
+  const trimPixels = Math.max(2, afterMove!.width / 4);
+
+  const trimStart = take.getByTestId("recorder-take-trim-start");
+  await dragBy(page, trimStart, trimPixels);
+  const afterStartTrim = await take.boundingBox();
+  expect(afterStartTrim).not.toBeNull();
+  expect(afterStartTrim!.x).toBeCloseTo(afterMove!.x + trimPixels, -1);
+  expect(afterStartTrim!.x + afterStartTrim!.width).toBeCloseTo(
+    afterMove!.x + afterMove!.width,
+    -1,
+  );
+
+  const trimEnd = take.getByTestId("recorder-take-trim-end");
+  await dragBy(page, trimEnd, -trimPixels);
+  const afterEndTrim = await take.boundingBox();
+  expect(afterEndTrim).not.toBeNull();
+  expect(afterEndTrim!.x).toBeCloseTo(afterStartTrim!.x, -1);
+  expect(afterEndTrim!.width).toBeCloseTo(
+    afterStartTrim!.width - trimPixels,
+    -1,
+  );
+
   // The resolved recording downloads as a timestamped WAV file.
   const downloadPromise = page.waitForEvent("download");
   await captureActions.click();
@@ -107,14 +136,14 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
 
   // Selecting a source take does not seek, and Escape clears the selection.
   const positionBeforeSelection = await position.textContent();
-  await take.nth(0).click();
+  await take.nth(0).getByText("Take 1").click();
   await expect(position).toHaveText(positionBeforeSelection!);
   await expect(take.nth(0)).toHaveClass(/border-sky-300/);
   await page.keyboard.press("Escape");
   await expect(take.nth(0)).not.toHaveClass(/border-sky-300/);
 
   // Deleting a selected source take leaves the other take intact.
-  await take.nth(0).click();
+  await take.nth(0).getByText("Take 1").click();
   await page.keyboard.press("Delete");
   await expect(take).toHaveCount(1);
   await expect(take).toContainText("Take 2");
@@ -125,6 +154,23 @@ async function seekRecorderByPixels(page: Page, pixels: number) {
   const box = await ruler.boundingBox();
   expect(box).not.toBeNull();
   await page.mouse.click(box!.x + pixels, box!.y + box!.height / 2);
+}
+
+async function dragBy(
+  page: Page,
+  locator: ReturnType<Page["getByTestId"]>,
+  deltaX: number,
+) {
+  const box = await locator.boundingBox();
+  expect(box).not.toBeNull();
+  await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(
+    box!.x + box!.width / 2 + deltaX,
+    box!.y + box!.height / 2,
+    { steps: 4 },
+  );
+  await page.mouse.up();
 }
 
 async function enableInput(page: Page) {

--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -79,9 +79,9 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   const afterMove = await take.boundingBox();
   expect(afterMove).not.toBeNull();
   expect(afterMove!.x).toBeCloseTo(beforeEdit!.x + 80, -1);
-  const trimPixels = Math.max(2, afterMove!.width / 4);
 
   const trimStart = take.getByTestId("recorder-take-trim-start");
+  const trimPixels = Math.max(2, afterMove!.width / 4);
   await dragBy(page, trimStart, trimPixels);
   const afterStartTrim = await take.boundingBox();
   expect(afterStartTrim).not.toBeNull();

--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -49,14 +49,7 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   await expect(playButton).toHaveAttribute("aria-pressed", "true");
   const recording = page.getByTestId("recorder-clip-recording");
   await expect(recording).toContainText("Recording...");
-  const initialWidth = await recording.evaluate(
-    (element) => element.getBoundingClientRect().width,
-  );
-  await expect
-    .poll(() =>
-      recording.evaluate((element) => element.getBoundingClientRect().width),
-    )
-    .toBeGreaterThan(initialWidth);
+  await waitForRecordingSamples(recording);
 
   // Stopping flushes the worklet and finalizes a nonempty waveform-backed take.
   await recordButton.click();
@@ -119,9 +112,9 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   // They move later in the song and record another attempt.
   await seekRecorderByPixels(page, 320);
   await recordButton.click();
-  await expect(page.getByTestId("recorder-clip-recording")).toContainText(
-    "Recording...",
-  );
+  const secondRecording = page.getByTestId("recorder-clip-recording");
+  await expect(secondRecording).toContainText("Recording...");
+  await waitForRecordingSamples(secondRecording);
   await recordButton.click();
 
   // The second recording is retained as a new source take.
@@ -167,6 +160,17 @@ async function dragBy(page: Page, locator: Locator, deltaX: number) {
     { steps: 4 },
   );
   await page.mouse.up();
+}
+
+async function waitForRecordingSamples(recording: Locator) {
+  const initialWidth = await recording.evaluate(
+    (element) => element.getBoundingClientRect().width,
+  );
+  await expect
+    .poll(() =>
+      recording.evaluate((element) => element.getBoundingClientRect().width),
+    )
+    .toBeGreaterThan(initialWidth);
 }
 
 async function enableInput(page: Page) {

--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -136,14 +136,14 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
 
   // Selecting a source take does not seek, and Escape clears the selection.
   const positionBeforeSelection = await position.textContent();
-  await take.nth(0).getByText("Take 1").click();
+  await take.nth(0).click({ position: { x: 10, y: 10 } });
   await expect(position).toHaveText(positionBeforeSelection!);
   await expect(take.nth(0)).toHaveClass(/border-sky-300/);
   await page.keyboard.press("Escape");
   await expect(take.nth(0)).not.toHaveClass(/border-sky-300/);
 
   // Deleting a selected source take leaves the other take intact.
-  await take.nth(0).getByText("Take 1").click();
+  await take.nth(0).click({ position: { x: 10, y: 10 } });
   await page.keyboard.press("Delete");
   await expect(take).toHaveCount(1);
   await expect(take).toContainText("Take 2");

--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { expect, type Page, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 import { createRecorderProject } from "../helpers";
 
 test.beforeEach(async ({ page }) => {
@@ -156,11 +156,7 @@ async function seekRecorderByPixels(page: Page, pixels: number) {
   await page.mouse.click(box!.x + pixels, box!.y + box!.height / 2);
 }
 
-async function dragBy(
-  page: Page,
-  locator: ReturnType<Page["getByTestId"]>,
-  deltaX: number,
-) {
+async function dragBy(page: Page, locator: Locator, deltaX: number) {
   const box = await locator.boundingBox();
   expect(box).not.toBeNull();
   await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);

--- a/src/components/audio-waveform.tsx
+++ b/src/components/audio-waveform.tsx
@@ -3,12 +3,16 @@ import { type AudioView, queryAudioView } from "../lib/audio-view";
 export function AudioWaveformView({
   audioView,
   audioDuration,
+  displayStart = 0,
+  displayEnd = audioDuration,
   visibleStart,
   visibleEnd,
   pixelWidth,
 }: {
   audioView: AudioView;
   audioDuration: number;
+  displayStart?: number;
+  displayEnd?: number;
   visibleStart: number;
   visibleEnd: number;
   pixelWidth: number;
@@ -17,10 +21,11 @@ export function AudioWaveformView({
     return null;
   }
 
+  const displayDuration = displayEnd - displayStart;
   const visibleDuration = visibleEnd - visibleStart;
   const visiblePixelWidth = Math.max(
     1,
-    Math.round((visibleDuration / audioDuration) * pixelWidth),
+    Math.round((visibleDuration / displayDuration) * pixelWidth),
   );
   const slice = queryAudioView(
     audioView,
@@ -33,9 +38,10 @@ export function AudioWaveformView({
     return null;
   }
 
-  const leftPercent = (slice.actualStart / audioDuration) * 100;
+  const leftPercent =
+    ((slice.actualStart - displayStart) / displayDuration) * 100;
   const widthPercent =
-    ((slice.actualEnd - slice.actualStart) / audioDuration) * 100;
+    ((slice.actualEnd - slice.actualStart) / displayDuration) * 100;
   const upperPoints: string[] = [];
   const lowerPoints: string[] = [];
   for (let i = 0; i < slice.data.length; i++) {

--- a/src/components/audio-waveform.tsx
+++ b/src/components/audio-waveform.tsx
@@ -10,11 +10,15 @@ export function AudioWaveformView({
   pixelWidth,
 }: {
   audioView: AudioView;
+  /** Complete source-buffer length, in seconds. */
   audioDuration: number;
+  /** Source interval mapped across the component width; defaults to the full buffer. */
   displayStart?: number;
   displayEnd?: number;
+  /** Viewport-visible subset of the displayed source interval, in seconds. */
   visibleStart: number;
   visibleEnd: number;
+  /** Pixel width occupied by the complete displayed source interval. */
   pixelWidth: number;
 }) {
   if (audioView.data.length === 0) {

--- a/src/components/audio-waveform.tsx
+++ b/src/components/audio-waveform.tsx
@@ -3,8 +3,8 @@ import { type AudioView, queryAudioView } from "../lib/audio-view";
 export function AudioWaveformView({
   audioView,
   audioDuration,
-  displayStart = 0,
-  displayEnd = audioDuration,
+  rangeStart = 0,
+  rangeEnd = audioDuration,
   visibleStart,
   visibleEnd,
   pixelWidth,
@@ -12,24 +12,24 @@ export function AudioWaveformView({
   audioView: AudioView;
   /** Complete source-buffer length, in seconds. */
   audioDuration: number;
-  /** Source interval mapped across the component width; defaults to the full buffer. */
-  displayStart?: number;
-  displayEnd?: number;
+  /** Source interval mapped across pixelWidth; defaults to the full buffer. */
+  rangeStart?: number;
+  rangeEnd?: number;
   /** Viewport-visible source interval to query and render, in seconds. */
   visibleStart: number;
   visibleEnd: number;
-  /** Pixel width occupied by the complete displayed source interval. */
+  /** Pixel width corresponding to [rangeStart, rangeEnd). */
   pixelWidth: number;
 }) {
   if (audioView.data.length === 0) {
     return null;
   }
 
-  const displayDuration = displayEnd - displayStart;
+  const rangeDuration = rangeEnd - rangeStart;
   const visibleDuration = visibleEnd - visibleStart;
   const visiblePixelWidth = Math.max(
     1,
-    Math.round((visibleDuration / displayDuration) * pixelWidth),
+    Math.round((visibleDuration / rangeDuration) * pixelWidth),
   );
   const slice = queryAudioView(
     audioView,
@@ -42,10 +42,9 @@ export function AudioWaveformView({
     return null;
   }
 
-  const leftPercent =
-    ((slice.actualStart - displayStart) / displayDuration) * 100;
+  const leftPercent = ((slice.actualStart - rangeStart) / rangeDuration) * 100;
   const widthPercent =
-    ((slice.actualEnd - slice.actualStart) / displayDuration) * 100;
+    ((slice.actualEnd - slice.actualStart) / rangeDuration) * 100;
   const upperPoints: string[] = [];
   const lowerPoints: string[] = [];
   for (let i = 0; i < slice.data.length; i++) {

--- a/src/components/audio-waveform.tsx
+++ b/src/components/audio-waveform.tsx
@@ -15,7 +15,7 @@ export function AudioWaveformView({
   /** Source interval mapped across the component width; defaults to the full buffer. */
   displayStart?: number;
   displayEnd?: number;
-  /** Viewport-visible subset of the displayed source interval, in seconds. */
+  /** Viewport-visible source interval to query and render, in seconds. */
   visibleStart: number;
   visibleEnd: number;
   /** Pixel width occupied by the complete displayed source interval. */

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1899,7 +1899,7 @@ function TimelineClip({
           ref={trimStartRef}
           data-testid="recorder-take-trim-start"
           onClick={(event) => event.stopPropagation()}
-          className="absolute inset-y-0 left-0 z-20 w-1.5 cursor-ew-resize bg-white/20"
+          className="absolute inset-y-0 left-0 z-20 w-1.5 cursor-ew-resize border-l border-transparent hover:border-white/40"
         />
       )}
       {onTrimEndChange && (
@@ -1907,7 +1907,7 @@ function TimelineClip({
           ref={trimEndRef}
           data-testid="recorder-take-trim-end"
           onClick={(event) => event.stopPropagation()}
-          className="absolute inset-y-0 right-0 z-20 w-1.5 cursor-ew-resize bg-white/20"
+          className="absolute inset-y-0 right-0 z-20 w-1.5 cursor-ew-resize border-r border-transparent hover:border-white/40"
         />
       )}
     </div>

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1870,24 +1870,15 @@ function TimelineClip({
     >
       <div className="absolute inset-0 overflow-hidden rounded-[inherit]">
         {clip.audioView && visibleEnd > visibleStart && (
-          <div
-            className="absolute inset-0"
-            style={{
-              left: `${(-100 * (clip.audioOffset ?? 0)) / clip.duration}%`,
-              width: `${(100 * (clip.audioDuration ?? clip.duration)) / clip.duration}%`,
-            }}
-          >
-            <AudioWaveformView
-              audioView={clip.audioView}
-              audioDuration={clip.audioDuration ?? clip.duration}
-              visibleStart={visibleStart}
-              visibleEnd={visibleEnd}
-              pixelWidth={
-                (clipWidth * (clip.audioDuration ?? clip.duration)) /
-                clip.duration
-              }
-            />
-          </div>
+          <AudioWaveformView
+            audioView={clip.audioView}
+            audioDuration={clip.audioDuration ?? clip.duration}
+            displayStart={clip.audioOffset ?? 0}
+            displayEnd={(clip.audioOffset ?? 0) + clip.duration}
+            visibleStart={visibleStart}
+            visibleEnd={visibleEnd}
+            pixelWidth={clipWidth}
+          />
         )}
         <div className="absolute left-1 top-0.5 z-10 whitespace-nowrap">
           <span className="mr-1.5">{clip.label}</span>

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1770,13 +1770,13 @@ function TimelineClip({
       setIsDragging(true);
       return {
         startClientX: event.clientX,
-        startOffset: clip!.offset,
+        initialValue: clip.offset,
       };
     },
     onMove: (event, drag) => {
       const deltaBeats = (event.clientX - drag.startClientX) / pixelsPerBeat;
       onClipOffsetChange!(
-        Math.max(0, drag.startOffset + beatsToSeconds(deltaBeats, tempo)),
+        Math.max(0, drag.initialValue + beatsToSeconds(deltaBeats, tempo)),
       );
     },
     onEnd: () => {
@@ -1790,7 +1790,7 @@ function TimelineClip({
       event.stopPropagation();
       return {
         startClientX: event.clientX,
-        startTrim: trimStart!,
+        initialValue: trimStart!,
       };
     },
     onMove: (event, drag) => {
@@ -1798,7 +1798,7 @@ function TimelineClip({
         (event.clientX - drag.startClientX) / pixelsPerBeat,
         tempo,
       );
-      onTrimStartChange!(drag.startTrim + delta);
+      onTrimStartChange!(drag.initialValue + delta);
     },
   });
   const trimEndRef = usePointerDrag({
@@ -1807,7 +1807,7 @@ function TimelineClip({
       event.stopPropagation();
       return {
         startClientX: event.clientX,
-        startTrim: trimEnd!,
+        initialValue: trimEnd!,
       };
     },
     onMove: (event, drag) => {
@@ -1815,7 +1815,7 @@ function TimelineClip({
         (event.clientX - drag.startClientX) / pixelsPerBeat,
         tempo,
       );
-      onTrimEndChange!(drag.startTrim + delta);
+      onTrimEndChange!(drag.initialValue + delta);
     },
   });
   const clipClass = {

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -40,6 +40,7 @@ import {
   matchKeyboardEvent,
 } from "../../lib/keyboard";
 import {
+  clamp,
   dbToPercent,
   formatGainDb,
   gainToPercent,
@@ -1805,12 +1806,10 @@ function TimelineClip({
         drag.tempo,
       );
       onTrimStartChange!(
-        Math.max(
+        clamp(
+          drag.startOffset + delta,
           trimBounds!.start,
-          Math.min(
-            drag.startOffset + delta,
-            clip.offset + clip.duration - MIN_TAKE_DURATION,
-          ),
+          clip.offset + clip.duration - MIN_TAKE_DURATION,
         ),
       );
     },
@@ -1832,9 +1831,10 @@ function TimelineClip({
         drag.tempo,
       );
       onTrimEndChange!(
-        Math.min(
+        clamp(
+          drag.startOffset + delta,
+          clip.offset + MIN_TAKE_DURATION,
           trimBounds!.end,
-          Math.max(drag.startOffset + delta, clip.offset + MIN_TAKE_DURATION),
         ),
       );
     },

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1901,7 +1901,7 @@ function TimelineClip({
           ref={trimStartRef}
           data-testid="recorder-take-trim-start"
           onClick={(event) => event.stopPropagation()}
-          className="absolute inset-y-0 left-0 z-20 w-1.5 cursor-ew-resize after:absolute after:inset-y-0 after:left-0 after:w-0.5 after:bg-transparent hover:after:bg-white/50"
+          className="absolute inset-y-0 -left-[3px] z-20 w-1.5 cursor-ew-resize after:absolute after:inset-y-0 after:left-[3px] after:w-0.5 after:bg-transparent hover:after:bg-white/50"
         />
       )}
       {onTrimEndChange && (
@@ -1909,7 +1909,7 @@ function TimelineClip({
           ref={trimEndRef}
           data-testid="recorder-take-trim-end"
           onClick={(event) => event.stopPropagation()}
-          className="absolute inset-y-0 right-0 z-20 w-1.5 cursor-ew-resize after:absolute after:inset-y-0 after:right-0 after:w-0.5 after:bg-transparent hover:after:bg-white/50"
+          className="absolute inset-y-0 -right-[3px] z-20 w-1.5 cursor-ew-resize after:absolute after:inset-y-0 after:right-[3px] after:w-0.5 after:bg-transparent hover:after:bg-white/50"
         />
       )}
     </div>

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1617,41 +1617,36 @@ function TakeTimelineLane({
           Enable input, place the playhead, then record
         </div>
       )}
-      {takes.map((take) => {
-        const timelineStart = take.timelineOffset + take.trimStart;
-        return (
-          <div key={take.id}>
-            <TimelineClip
-              clip={{
-                duration: take.trimEnd - take.trimStart,
-                label: `Take ${take.number}`,
-                offset: timelineStart,
-                variant: "take",
-                audioView: take.audioView,
-                audioDuration: take.duration,
-                audioOffset: take.trimStart,
-              }}
-              pixelsPerBeat={pixelsPerBeat}
-              viewportStartBeat={viewportStartBeat}
-              tempo={tempo}
-              viewportWidth={viewportWidth}
-              onSelect={() => onTakeSelect(take.id)}
-              onClipOffsetChange={(offset) =>
-                onTakeOffsetChange(take.id, offset - take.trimStart)
-              }
-              onTrimStartChange={(trimStart) =>
-                onTakeTrimStartChange(take.id, trimStart)
-              }
-              onTrimEndChange={(trimEnd) =>
-                onTakeTrimEndChange(take.id, trimEnd)
-              }
-              trimStart={take.trimStart}
-              trimEnd={take.trimEnd}
-              selected={selectedTakeId === take.id}
-            />
-          </div>
-        );
-      })}
+      {takes.map((take) => (
+        <div key={take.id}>
+          <TimelineClip
+            clip={{
+              duration: take.trimEnd - take.trimStart,
+              label: `Take ${take.number}`,
+              offset: take.timelineOffset + take.trimStart,
+              variant: "take",
+              audioView: take.audioView,
+              audioDuration: take.duration,
+              audioOffset: take.trimStart,
+            }}
+            pixelsPerBeat={pixelsPerBeat}
+            viewportStartBeat={viewportStartBeat}
+            tempo={tempo}
+            viewportWidth={viewportWidth}
+            onSelect={() => onTakeSelect(take.id)}
+            onClipOffsetChange={(offset) =>
+              onTakeOffsetChange(take.id, offset - take.trimStart)
+            }
+            onTrimStartChange={(trimStart) =>
+              onTakeTrimStartChange(take.id, trimStart)
+            }
+            onTrimEndChange={(trimEnd) => onTakeTrimEndChange(take.id, trimEnd)}
+            trimStart={take.trimStart}
+            trimEnd={take.trimEnd}
+            selected={selectedTakeId === take.id}
+          />
+        </div>
+      ))}
       {pendingRecording && (
         <div>
           <TimelineClip

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -40,7 +40,6 @@ import {
   matchKeyboardEvent,
 } from "../../lib/keyboard";
 import {
-  clamp,
   dbToPercent,
   formatGainDb,
   gainToPercent,
@@ -52,7 +51,6 @@ import {
 } from "../../lib/recorder/capture-input";
 import { recorderProjectStorage } from "../../lib/recorder/project-storage";
 import {
-  MIN_TAKE_DURATION,
   RecorderRuntime,
   RecorderRuntimeState,
 } from "../../lib/recorder/runtime";
@@ -1637,16 +1635,14 @@ function TakeTimelineLane({
               onClipOffsetChange={(offset) =>
                 onTakeOffsetChange(take.id, offset - take.trimStart)
               }
-              onTrimStartChange={(offset) =>
-                onTakeTrimStartChange(take.id, offset - take.timelineOffset)
+              onTrimStartChange={(trimStart) =>
+                onTakeTrimStartChange(take.id, trimStart)
               }
-              onTrimEndChange={(offset) =>
-                onTakeTrimEndChange(take.id, offset - take.timelineOffset)
+              onTrimEndChange={(trimEnd) =>
+                onTakeTrimEndChange(take.id, trimEnd)
               }
-              trimBounds={{
-                start: take.timelineOffset,
-                end: take.timelineOffset + take.duration,
-              }}
+              trimStart={take.trimStart}
+              trimEnd={take.trimEnd}
               selected={selectedTakeId === take.id}
             />
           </div>
@@ -1748,7 +1744,8 @@ function TimelineClip({
   onSelect,
   onTrimStartChange,
   onTrimEndChange,
-  trimBounds,
+  trimStart,
+  trimEnd,
   selected = false,
 }: {
   clip: RecorderTimelineClip;
@@ -1761,7 +1758,8 @@ function TimelineClip({
   onSelect?: () => void;
   onTrimStartChange?: (offset: number) => void;
   onTrimEndChange?: (offset: number) => void;
-  trimBounds?: { start: number; end: number };
+  trimStart?: number;
+  trimEnd?: number;
   selected?: boolean;
 }) {
   const [isDragging, setIsDragging] = useState(false);
@@ -1795,7 +1793,7 @@ function TimelineClip({
       event.stopPropagation();
       return {
         startClientX: event.clientX,
-        startOffset: clip.offset,
+        startTrim: trimStart!,
         pixelsPerBeat,
         tempo,
       };
@@ -1805,13 +1803,7 @@ function TimelineClip({
         (event.clientX - drag.startClientX) / drag.pixelsPerBeat,
         drag.tempo,
       );
-      onTrimStartChange!(
-        clamp(
-          drag.startOffset + delta,
-          trimBounds!.start,
-          clip.offset + clip.duration - MIN_TAKE_DURATION,
-        ),
-      );
+      onTrimStartChange!(drag.startTrim + delta);
     },
   });
   const trimEndRef = usePointerDrag({
@@ -1820,7 +1812,7 @@ function TimelineClip({
       event.stopPropagation();
       return {
         startClientX: event.clientX,
-        startOffset: clip.offset + clip.duration,
+        startTrim: trimEnd!,
         pixelsPerBeat,
         tempo,
       };
@@ -1830,13 +1822,7 @@ function TimelineClip({
         (event.clientX - drag.startClientX) / drag.pixelsPerBeat,
         drag.tempo,
       );
-      onTrimEndChange!(
-        clamp(
-          drag.startOffset + delta,
-          clip.offset + MIN_TAKE_DURATION,
-          trimBounds!.end,
-        ),
-      );
+      onTrimEndChange!(drag.startTrim + delta);
     },
   });
   const clipClass = {

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1621,13 +1621,13 @@ function TakeTimelineLane({
         <div key={take.id}>
           <TimelineClip
             clip={{
-              duration: take.trimEnd - take.trimStart,
               label: `Take ${take.number}`,
+              duration: take.trimEnd - take.trimStart,
               offset: take.timelineOffset + take.trimStart,
-              variant: "take",
-              audioView: take.audioView,
               audioDuration: take.duration,
               audioOffset: take.trimStart,
+              variant: "take",
+              audioView: take.audioView,
             }}
             pixelsPerBeat={pixelsPerBeat}
             viewportStartBeat={viewportStartBeat}

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1771,15 +1771,12 @@ function TimelineClip({
       return {
         startClientX: event.clientX,
         startOffset: clip!.offset,
-        pixelsPerBeat,
-        tempo,
       };
     },
     onMove: (event, drag) => {
-      const deltaBeats =
-        (event.clientX - drag.startClientX) / drag.pixelsPerBeat;
+      const deltaBeats = (event.clientX - drag.startClientX) / pixelsPerBeat;
       onClipOffsetChange!(
-        Math.max(0, drag.startOffset + beatsToSeconds(deltaBeats, drag.tempo)),
+        Math.max(0, drag.startOffset + beatsToSeconds(deltaBeats, tempo)),
       );
     },
     onEnd: () => {
@@ -1794,14 +1791,12 @@ function TimelineClip({
       return {
         startClientX: event.clientX,
         startTrim: trimStart!,
-        pixelsPerBeat,
-        tempo,
       };
     },
     onMove: (event, drag) => {
       const delta = beatsToSeconds(
-        (event.clientX - drag.startClientX) / drag.pixelsPerBeat,
-        drag.tempo,
+        (event.clientX - drag.startClientX) / pixelsPerBeat,
+        tempo,
       );
       onTrimStartChange!(drag.startTrim + delta);
     },
@@ -1813,14 +1808,12 @@ function TimelineClip({
       return {
         startClientX: event.clientX,
         startTrim: trimEnd!,
-        pixelsPerBeat,
-        tempo,
       };
     },
     onMove: (event, drag) => {
       const delta = beatsToSeconds(
-        (event.clientX - drag.startClientX) / drag.pixelsPerBeat,
-        drag.tempo,
+        (event.clientX - drag.startClientX) / pixelsPerBeat,
+        tempo,
       );
       onTrimEndChange!(drag.startTrim + delta);
     },

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1548,12 +1548,16 @@ function CaptureTrackRow({
 }
 
 type RecorderTimelineClip = {
+  /** Visible clip length on the timeline, in seconds. */
   duration: number;
   label: string;
+  /** Absolute timeline position where the visible clip begins. */
   offset: number;
   variant: "audio" | "take" | "recording";
   audioView?: AudioView;
+  /** Complete source-buffer length, used to render a trimmed waveform. */
   audioDuration?: number;
+  /** Visible clip start relative to the source buffer, in seconds. */
   audioOffset?: number;
 };
 

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1856,7 +1856,7 @@ function TimelineClip({
         }
       }}
       className={cn(
-        "absolute inset-y-1 overflow-hidden rounded-sm border text-[11px]",
+        "absolute inset-y-1 rounded-sm border text-[11px]",
         clipClass,
         onClipOffsetChange && "cursor-ew-resize select-none",
         onSelect && "cursor-pointer",
@@ -1868,38 +1868,40 @@ function TimelineClip({
         width: clipWidth,
       }}
     >
-      {clip.audioView && visibleEnd > visibleStart && (
-        <div
-          className="absolute inset-0"
-          style={{
-            left: `${(-100 * (clip.audioOffset ?? 0)) / clip.duration}%`,
-            width: `${(100 * (clip.audioDuration ?? clip.duration)) / clip.duration}%`,
-          }}
-        >
-          <AudioWaveformView
-            audioView={clip.audioView}
-            audioDuration={clip.audioDuration ?? clip.duration}
-            visibleStart={visibleStart}
-            visibleEnd={visibleEnd}
-            pixelWidth={
-              (clipWidth * (clip.audioDuration ?? clip.duration)) /
-              clip.duration
-            }
-          />
-        </div>
-      )}
-      <div className="absolute left-1 top-0.5 z-10 whitespace-nowrap">
-        <span className="mr-1.5">{clip.label}</span>
-        {onClipOffsetChange && clip.offset > 0 && (
-          <span className="opacity-75">+{clip.offset.toFixed(3)}s</span>
+      <div className="absolute inset-0 overflow-hidden rounded-[inherit]">
+        {clip.audioView && visibleEnd > visibleStart && (
+          <div
+            className="absolute inset-0"
+            style={{
+              left: `${(-100 * (clip.audioOffset ?? 0)) / clip.duration}%`,
+              width: `${(100 * (clip.audioDuration ?? clip.duration)) / clip.duration}%`,
+            }}
+          >
+            <AudioWaveformView
+              audioView={clip.audioView}
+              audioDuration={clip.audioDuration ?? clip.duration}
+              visibleStart={visibleStart}
+              visibleEnd={visibleEnd}
+              pixelWidth={
+                (clipWidth * (clip.audioDuration ?? clip.duration)) /
+                clip.duration
+              }
+            />
+          </div>
         )}
+        <div className="absolute left-1 top-0.5 z-10 whitespace-nowrap">
+          <span className="mr-1.5">{clip.label}</span>
+          {onClipOffsetChange && clip.offset > 0 && (
+            <span className="opacity-75">+{clip.offset.toFixed(3)}s</span>
+          )}
+        </div>
       </div>
       {onTrimStartChange && (
         <div
           ref={trimStartRef}
           data-testid="recorder-take-trim-start"
           onClick={(event) => event.stopPropagation()}
-          className="absolute inset-y-0 left-0 z-20 w-1.5 cursor-ew-resize border-l border-transparent hover:border-white/40"
+          className="absolute inset-y-0 -left-0.75 z-20 w-1.5 cursor-ew-resize border-x-2 border-transparent hover:border-white/40"
         />
       )}
       {onTrimEndChange && (
@@ -1907,7 +1909,7 @@ function TimelineClip({
           ref={trimEndRef}
           data-testid="recorder-take-trim-end"
           onClick={(event) => event.stopPropagation()}
-          className="absolute inset-y-0 right-0 z-20 w-1.5 cursor-ew-resize border-r border-transparent hover:border-white/40"
+          className="absolute inset-y-0 -right-0.75 z-20 w-1.5 cursor-ew-resize border-x-2 border-transparent hover:border-white/40"
         />
       )}
     </div>

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1901,7 +1901,7 @@ function TimelineClip({
           ref={trimStartRef}
           data-testid="recorder-take-trim-start"
           onClick={(event) => event.stopPropagation()}
-          className="absolute inset-y-0 -left-0.75 z-20 w-1.5 cursor-ew-resize after:absolute after:inset-y-0 after:left-1/2 after:w-0.5 after:-translate-x-1/2 after:bg-transparent hover:after:bg-white/50"
+          className="absolute inset-y-0 left-0 z-20 w-1.5 cursor-ew-resize after:absolute after:inset-y-0 after:left-0 after:w-0.5 after:bg-transparent hover:after:bg-white/50"
         />
       )}
       {onTrimEndChange && (
@@ -1909,7 +1909,7 @@ function TimelineClip({
           ref={trimEndRef}
           data-testid="recorder-take-trim-end"
           onClick={(event) => event.stopPropagation()}
-          className="absolute inset-y-0 -right-0.75 z-20 w-1.5 cursor-ew-resize after:absolute after:inset-y-0 after:left-1/2 after:w-0.5 after:-translate-x-1/2 after:bg-transparent hover:after:bg-white/50"
+          className="absolute inset-y-0 right-0 z-20 w-1.5 cursor-ew-resize after:absolute after:inset-y-0 after:right-0 after:w-0.5 after:bg-transparent hover:after:bg-white/50"
         />
       )}
     </div>

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1873,8 +1873,8 @@ function TimelineClip({
           <AudioWaveformView
             audioView={clip.audioView}
             audioDuration={clip.audioDuration ?? clip.duration}
-            displayStart={clip.audioOffset ?? 0}
-            displayEnd={(clip.audioOffset ?? 0) + clip.duration}
+            rangeStart={clip.audioOffset ?? 0}
+            rangeEnd={(clip.audioOffset ?? 0) + clip.duration}
             visibleStart={visibleStart}
             visibleEnd={visibleEnd}
             pixelWidth={clipWidth}

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1548,17 +1548,17 @@ function CaptureTrackRow({
 }
 
 type RecorderTimelineClip = {
+  label: string;
   /** Visible clip length on the timeline, in seconds. */
   duration: number;
-  label: string;
   /** Absolute timeline position where the visible clip begins. */
   offset: number;
-  variant: "audio" | "take" | "recording";
-  audioView?: AudioView;
   /** Complete source-buffer length, used to render a trimmed waveform. */
   audioDuration?: number;
   /** Visible clip start relative to the source buffer, in seconds. */
   audioOffset?: number;
+  variant: "audio" | "take" | "recording";
+  audioView?: AudioView;
 };
 
 function TakeTimelineLane({

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1901,7 +1901,7 @@ function TimelineClip({
           ref={trimStartRef}
           data-testid="recorder-take-trim-start"
           onClick={(event) => event.stopPropagation()}
-          className="absolute inset-y-0 -left-0.75 z-20 w-1.5 cursor-ew-resize border-x-2 border-transparent hover:border-white/40"
+          className="absolute inset-y-0 -left-0.75 z-20 w-1.5 cursor-ew-resize after:absolute after:inset-y-0 after:left-1/2 after:w-0.5 after:-translate-x-1/2 after:bg-transparent hover:after:bg-white/50"
         />
       )}
       {onTrimEndChange && (
@@ -1909,7 +1909,7 @@ function TimelineClip({
           ref={trimEndRef}
           data-testid="recorder-take-trim-end"
           onClick={(event) => event.stopPropagation()}
-          className="absolute inset-y-0 -right-0.75 z-20 w-1.5 cursor-ew-resize border-x-2 border-transparent hover:border-white/40"
+          className="absolute inset-y-0 -right-0.75 z-20 w-1.5 cursor-ew-resize after:absolute after:inset-y-0 after:left-1/2 after:w-0.5 after:-translate-x-1/2 after:bg-transparent hover:after:bg-white/50"
         />
       )}
     </div>

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -51,6 +51,7 @@ import {
 } from "../../lib/recorder/capture-input";
 import { recorderProjectStorage } from "../../lib/recorder/project-storage";
 import {
+  MIN_TAKE_DURATION,
   RecorderRuntime,
   RecorderRuntimeState,
 } from "../../lib/recorder/runtime";
@@ -403,6 +404,15 @@ export function Recorder({ projectId }: { projectId: string }) {
                 viewportWidth={timeline.viewportWidth}
                 onSeek={(position) => runtime.seek(position)}
                 onTakeSelect={takeSelection.select}
+                onTakeOffsetChange={(id, offset) =>
+                  runtime.setTakeTimelineOffset(id, offset)
+                }
+                onTakeTrimStartChange={(id, trimStart) =>
+                  runtime.setTakeTrimStart(id, trimStart)
+                }
+                onTakeTrimEndChange={(id, trimEnd) =>
+                  runtime.setTakeTrimEnd(id, trimEnd)
+                }
               />
             </CaptureTrackRow>
           </div>
@@ -1544,6 +1554,8 @@ type RecorderTimelineClip = {
   offset: number;
   variant: "audio" | "take" | "recording";
   audioView?: AudioView;
+  audioDuration?: number;
+  audioOffset?: number;
 };
 
 function TakeTimelineLane({
@@ -1559,6 +1571,9 @@ function TakeTimelineLane({
   viewportWidth,
   onSeek,
   onTakeSelect,
+  onTakeOffsetChange,
+  onTakeTrimStartChange,
+  onTakeTrimEndChange,
 }: {
   takes: RecorderRuntimeState["recordingTrack"]["takes"];
   pendingRecording: RecorderRuntimeState["pendingRecording"];
@@ -1572,6 +1587,9 @@ function TakeTimelineLane({
   viewportWidth: number;
   onSeek: (position: number) => void;
   onTakeSelect: (id: string) => void;
+  onTakeOffsetChange: (id: string, offset: number) => void;
+  onTakeTrimStartChange: (id: string, trimStart: number) => void;
+  onTakeTrimEndChange: (id: string, trimEnd: number) => void;
 }) {
   return (
     <div
@@ -1596,25 +1614,43 @@ function TakeTimelineLane({
           Enable input, place the playhead, then record
         </div>
       )}
-      {takes.map((take) => (
-        <div key={take.id}>
-          <TimelineClip
-            clip={{
-              duration: take.duration,
-              label: `Take ${take.number}`,
-              offset: take.timelineOffset,
-              variant: "take",
-              audioView: take.audioView,
-            }}
-            pixelsPerBeat={pixelsPerBeat}
-            viewportStartBeat={viewportStartBeat}
-            tempo={tempo}
-            viewportWidth={viewportWidth}
-            onSelect={() => onTakeSelect(take.id)}
-            selected={selectedTakeId === take.id}
-          />
-        </div>
-      ))}
+      {takes.map((take) => {
+        const timelineStart = take.timelineOffset + take.trimStart;
+        return (
+          <div key={take.id}>
+            <TimelineClip
+              clip={{
+                duration: take.trimEnd - take.trimStart,
+                label: `Take ${take.number}`,
+                offset: timelineStart,
+                variant: "take",
+                audioView: take.audioView,
+                audioDuration: take.duration,
+                audioOffset: take.trimStart,
+              }}
+              pixelsPerBeat={pixelsPerBeat}
+              viewportStartBeat={viewportStartBeat}
+              tempo={tempo}
+              viewportWidth={viewportWidth}
+              onSelect={() => onTakeSelect(take.id)}
+              onClipOffsetChange={(offset) =>
+                onTakeOffsetChange(take.id, offset - take.trimStart)
+              }
+              onTrimStartChange={(offset) =>
+                onTakeTrimStartChange(take.id, offset - take.timelineOffset)
+              }
+              onTrimEndChange={(offset) =>
+                onTakeTrimEndChange(take.id, offset - take.timelineOffset)
+              }
+              trimBounds={{
+                start: take.timelineOffset,
+                end: take.timelineOffset + take.duration,
+              }}
+              selected={selectedTakeId === take.id}
+            />
+          </div>
+        );
+      })}
       {pendingRecording && (
         <div>
           <TimelineClip
@@ -1709,6 +1745,9 @@ function TimelineClip({
   onClipOffsetChange,
   onClipDragEnd,
   onSelect,
+  onTrimStartChange,
+  onTrimEndChange,
+  trimBounds,
   selected = false,
 }: {
   clip: RecorderTimelineClip;
@@ -1719,6 +1758,9 @@ function TimelineClip({
   onClipOffsetChange?: (offset: number) => void;
   onClipDragEnd?: () => void;
   onSelect?: () => void;
+  onTrimStartChange?: (offset: number) => void;
+  onTrimEndChange?: (offset: number) => void;
+  trimBounds?: { start: number; end: number };
   selected?: boolean;
 }) {
   const [isDragging, setIsDragging] = useState(false);
@@ -1746,6 +1788,57 @@ function TimelineClip({
       onClipDragEnd?.();
     },
   });
+  const trimStartRef = usePointerDrag({
+    onStart: (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      return {
+        startClientX: event.clientX,
+        startOffset: clip.offset,
+        pixelsPerBeat,
+        tempo,
+      };
+    },
+    onMove: (event, drag) => {
+      const delta = beatsToSeconds(
+        (event.clientX - drag.startClientX) / drag.pixelsPerBeat,
+        drag.tempo,
+      );
+      onTrimStartChange!(
+        Math.max(
+          trimBounds!.start,
+          Math.min(
+            drag.startOffset + delta,
+            clip.offset + clip.duration - MIN_TAKE_DURATION,
+          ),
+        ),
+      );
+    },
+  });
+  const trimEndRef = usePointerDrag({
+    onStart: (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      return {
+        startClientX: event.clientX,
+        startOffset: clip.offset + clip.duration,
+        pixelsPerBeat,
+        tempo,
+      };
+    },
+    onMove: (event, drag) => {
+      const delta = beatsToSeconds(
+        (event.clientX - drag.startClientX) / drag.pixelsPerBeat,
+        drag.tempo,
+      );
+      onTrimEndChange!(
+        Math.min(
+          trimBounds!.end,
+          Math.max(drag.startOffset + delta, clip.offset + MIN_TAKE_DURATION),
+        ),
+      );
+    },
+  });
   const clipClass = {
     audio: "border-emerald-400/60 bg-emerald-400/20 text-emerald-100",
     take: "border-emerald-400/60 bg-emerald-400/20 text-emerald-100",
@@ -1758,14 +1851,16 @@ function TimelineClip({
   );
   const visibleStart = Math.max(
     0,
-    beatsToSeconds(viewportStartBeat - clipStartBeat, tempo),
+    (clip.audioOffset ?? 0) +
+      beatsToSeconds(viewportStartBeat - clipStartBeat, tempo),
   );
   const visibleEnd = Math.min(
-    clip.duration,
-    beatsToSeconds(
-      viewportStartBeat + viewportWidth / pixelsPerBeat - clipStartBeat,
-      tempo,
-    ),
+    (clip.audioOffset ?? 0) + clip.duration,
+    (clip.audioOffset ?? 0) +
+      beatsToSeconds(
+        viewportStartBeat + viewportWidth / pixelsPerBeat - clipStartBeat,
+        tempo,
+      ),
   );
   return (
     <div
@@ -1796,13 +1891,24 @@ function TimelineClip({
       }}
     >
       {clip.audioView && visibleEnd > visibleStart && (
-        <AudioWaveformView
-          audioView={clip.audioView}
-          audioDuration={clip.duration}
-          visibleStart={visibleStart}
-          visibleEnd={visibleEnd}
-          pixelWidth={clipWidth}
-        />
+        <div
+          className="absolute inset-0"
+          style={{
+            left: `${(-100 * (clip.audioOffset ?? 0)) / clip.duration}%`,
+            width: `${(100 * (clip.audioDuration ?? clip.duration)) / clip.duration}%`,
+          }}
+        >
+          <AudioWaveformView
+            audioView={clip.audioView}
+            audioDuration={clip.audioDuration ?? clip.duration}
+            visibleStart={visibleStart}
+            visibleEnd={visibleEnd}
+            pixelWidth={
+              (clipWidth * (clip.audioDuration ?? clip.duration)) /
+              clip.duration
+            }
+          />
+        </div>
       )}
       <div className="absolute left-1 top-0.5 z-10 whitespace-nowrap">
         <span className="mr-1.5">{clip.label}</span>
@@ -1810,6 +1916,22 @@ function TimelineClip({
           <span className="opacity-75">+{clip.offset.toFixed(3)}s</span>
         )}
       </div>
+      {onTrimStartChange && (
+        <div
+          ref={trimStartRef}
+          data-testid="recorder-take-trim-start"
+          onClick={(event) => event.stopPropagation()}
+          className="absolute inset-y-0 left-0 z-20 w-1.5 cursor-ew-resize bg-white/20"
+        />
+      )}
+      {onTrimEndChange && (
+        <div
+          ref={trimEndRef}
+          data-testid="recorder-take-trim-end"
+          onClick={(event) => event.stopPropagation()}
+          className="absolute inset-y-0 right-0 z-20 w-1.5 cursor-ew-resize bg-white/20"
+        />
+      )}
     </div>
   );
 }

--- a/src/lib/music.ts
+++ b/src/lib/music.ts
@@ -91,6 +91,6 @@ export function dbToPercent(db: number): number {
   return gainToPercent(dbToGain(clamp(db, MIN_DB, MAX_DB)));
 }
 
-function clamp(value: number, min: number, max: number): number {
+export function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
 }

--- a/src/lib/recorder/persistence.ts
+++ b/src/lib/recorder/persistence.ts
@@ -43,6 +43,8 @@ interface SerializedTakeState {
   id?: string;
   number?: number;
   timelineOffset: number;
+  trimStart?: number;
+  trimEnd?: number;
   pcm: RecorderPcm;
 }
 
@@ -84,6 +86,8 @@ export function serializeRecorderRuntimeState(
           id: take.id,
           number: take.number,
           timelineOffset: take.timelineOffset,
+          trimStart: take.trimStart,
+          trimEnd: take.trimEnd,
           pcm: serializeAudioBuffer(take.buffer),
         };
       }),
@@ -143,6 +147,8 @@ export function deserializeRecorderRuntimeState({
           number: take.number ?? index + 1,
           duration: buffer.duration,
           timelineOffset: take.timelineOffset,
+          trimStart: take.trimStart ?? 0,
+          trimEnd: take.trimEnd ?? buffer.duration,
           buffer,
           audioView: createAudioView(
             buffer.getChannelData(0),

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -16,6 +16,7 @@ import type { TakeRegion, TakeState } from "./take.ts";
 import { AudioContextTransport } from "./transport.ts";
 
 const MAX_RECORDING_SECONDS = 5 * 60;
+export const MIN_TAKE_DURATION = 0.01;
 export const WAVEFORM_POINTS_PER_SECOND = 800;
 const DEFAULT_TRACK_HEIGHT = 96;
 const MIN_TRACK_HEIGHT = DEFAULT_TRACK_HEIGHT;
@@ -539,6 +540,8 @@ export class RecorderRuntime {
             number: pendingRecording.number,
             buffer: takeBuffer,
             duration: takeBuffer.duration,
+            trimStart: 0,
+            trimEnd: takeBuffer.duration,
             timelineOffset: pendingRecording.timelineOffset,
             audioView: createAudioView(
               samples,
@@ -558,6 +561,47 @@ export class RecorderRuntime {
   }
 
   removeTake(id: string): void {
+    this.updateTakes((takes) => takes.filter((take) => take.id !== id));
+  }
+
+  setTakeTimelineOffset(id: string, timelineOffset: number): void {
+    this.updateTake(id, (take) => ({ ...take, timelineOffset }));
+  }
+
+  setTakeTrimStart(id: string, trimStart: number): void {
+    this.updateTake(id, (take) => ({
+      ...take,
+      trimStart: Math.max(
+        0,
+        Math.min(trimStart, take.trimEnd - MIN_TAKE_DURATION),
+      ),
+    }));
+  }
+
+  setTakeTrimEnd(id: string, trimEnd: number): void {
+    this.updateTake(id, (take) => ({
+      ...take,
+      trimEnd: Math.min(
+        take.duration,
+        Math.max(trimEnd, take.trimStart + MIN_TAKE_DURATION),
+      ),
+    }));
+  }
+
+  private updateTake(id: string, update: (take: TakeState) => TakeState): void {
+    this.updateTakes((takes) => {
+      const index = takes.findIndex((take) => take.id === id);
+      const take = takes[index];
+      if (!take) {
+        throw new Error("Recording take state is missing.");
+      }
+      const nextTakes = takes.slice();
+      nextTakes[index] = update(take);
+      return nextTakes;
+    });
+  }
+
+  private updateTakes(update: (takes: TakeState[]) => TakeState[]): void {
     const wasPlaying = this.store.get().isPlaying;
     if (wasPlaying) {
       this.pause();
@@ -566,7 +610,7 @@ export class RecorderRuntime {
     this.store.update({
       recordingTrack: {
         ...recordingTrack,
-        takes: recordingTrack.takes.filter((take) => take.id !== id),
+        takes: update(recordingTrack.takes),
       },
     });
     this.syncTakeRegions();

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -299,10 +299,6 @@ export class RecorderRuntime {
     });
   }
 
-  removeTake(id: string): void {
-    this.updateTakes((takes) => takes.filter((take) => take.id !== id));
-  }
-
   setTakeTimelineOffset(id: string, timelineOffset: number): void {
     this.updateTake(id, (take) => ({ ...take, timelineOffset }));
   }
@@ -325,6 +321,10 @@ export class RecorderRuntime {
         Math.max(trimEnd, take.trimStart + MIN_TAKE_DURATION),
       ),
     }));
+  }
+
+  removeTake(id: string): void {
+    this.updateTakes((takes) => takes.filter((take) => take.id !== id));
   }
 
   private updateTake(

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -17,7 +17,7 @@ import type { TakeRegion, TakeState } from "./take.ts";
 import { AudioContextTransport } from "./transport.ts";
 
 const MAX_RECORDING_SECONDS = 5 * 60;
-export const MIN_TAKE_DURATION = 0.01;
+const MIN_TAKE_DURATION = 0.01;
 export const WAVEFORM_POINTS_PER_SECOND = 800;
 const DEFAULT_TRACK_HEIGHT = 96;
 const MIN_TRACK_HEIGHT = DEFAULT_TRACK_HEIGHT;

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -327,7 +327,10 @@ export class RecorderRuntime {
     }));
   }
 
-  private updateTake(id: string, update: (take: TakeState) => TakeState): void {
+  private updateTake(
+    id: string,
+    updateFn: (take: TakeState) => TakeState,
+  ): void {
     this.updateTakes((takes) => {
       const index = takes.findIndex((take) => take.id === id);
       const take = takes[index];
@@ -335,12 +338,12 @@ export class RecorderRuntime {
         throw new Error("Recording take state is missing.");
       }
       const nextTakes = takes.slice();
-      nextTakes[index] = update(take);
+      nextTakes[index] = updateFn(take);
       return nextTakes;
     });
   }
 
-  private updateTakes(update: (takes: TakeState[]) => TakeState[]): void {
+  private updateTakes(updateFn: (takes: TakeState[]) => TakeState[]): void {
     const wasPlaying = this.store.get().isPlaying;
     if (wasPlaying) {
       this.pause();
@@ -349,7 +352,7 @@ export class RecorderRuntime {
     this.store.update({
       recordingTrack: {
         ...recordingTrack,
-        takes: update(recordingTrack.takes),
+        takes: updateFn(recordingTrack.takes),
       },
     });
     this.syncTakeRegions();

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_TIME_SIGNATURE, type TimeSignature } from "../../types.ts";
 import { createStore, shallowEqual } from "../../utils/store.ts";
 import { type AudioView, createAudioView } from "../audio-view.ts";
+import { clamp } from "../music.ts";
 import { AudioBufferPlayback } from "./audio-buffer-playback.ts";
 import { CaptureInput } from "./capture-input.ts";
 import { RecorderMetronome } from "./metronome.ts";
@@ -306,19 +307,17 @@ export class RecorderRuntime {
   setTakeTrimStart(id: string, trimStart: number): void {
     this.updateTake(id, (take) => ({
       ...take,
-      trimStart: Math.max(
-        0,
-        Math.min(trimStart, take.trimEnd - MIN_TAKE_DURATION),
-      ),
+      trimStart: clamp(trimStart, 0, take.trimEnd - MIN_TAKE_DURATION),
     }));
   }
 
   setTakeTrimEnd(id: string, trimEnd: number): void {
     this.updateTake(id, (take) => ({
       ...take,
-      trimEnd: Math.min(
+      trimEnd: clamp(
+        trimEnd,
+        take.trimStart + MIN_TAKE_DURATION,
         take.duration,
-        Math.max(trimEnd, take.trimStart + MIN_TAKE_DURATION),
       ),
     }));
   }

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -299,6 +299,65 @@ export class RecorderRuntime {
     });
   }
 
+  removeTake(id: string): void {
+    this.updateTakes((takes) => takes.filter((take) => take.id !== id));
+  }
+
+  setTakeTimelineOffset(id: string, timelineOffset: number): void {
+    this.updateTake(id, (take) => ({ ...take, timelineOffset }));
+  }
+
+  setTakeTrimStart(id: string, trimStart: number): void {
+    this.updateTake(id, (take) => ({
+      ...take,
+      trimStart: Math.max(
+        0,
+        Math.min(trimStart, take.trimEnd - MIN_TAKE_DURATION),
+      ),
+    }));
+  }
+
+  setTakeTrimEnd(id: string, trimEnd: number): void {
+    this.updateTake(id, (take) => ({
+      ...take,
+      trimEnd: Math.min(
+        take.duration,
+        Math.max(trimEnd, take.trimStart + MIN_TAKE_DURATION),
+      ),
+    }));
+  }
+
+  private updateTake(id: string, update: (take: TakeState) => TakeState): void {
+    this.updateTakes((takes) => {
+      const index = takes.findIndex((take) => take.id === id);
+      const take = takes[index];
+      if (!take) {
+        throw new Error("Recording take state is missing.");
+      }
+      const nextTakes = takes.slice();
+      nextTakes[index] = update(take);
+      return nextTakes;
+    });
+  }
+
+  private updateTakes(update: (takes: TakeState[]) => TakeState[]): void {
+    const wasPlaying = this.store.get().isPlaying;
+    if (wasPlaying) {
+      this.pause();
+    }
+    const recordingTrack = this.store.get().recordingTrack;
+    this.store.update({
+      recordingTrack: {
+        ...recordingTrack,
+        takes: update(recordingTrack.takes),
+      },
+    });
+    this.syncTakeRegions();
+    if (wasPlaying) {
+      this.transport!.play();
+    }
+  }
+
   async play(): Promise<void> {
     const context = this.ensureContext();
     await context.resume();
@@ -558,65 +617,6 @@ export class RecorderRuntime {
   private closeInput(): void {
     this.captureInput?.dispose();
     this.captureInput = undefined;
-  }
-
-  removeTake(id: string): void {
-    this.updateTakes((takes) => takes.filter((take) => take.id !== id));
-  }
-
-  setTakeTimelineOffset(id: string, timelineOffset: number): void {
-    this.updateTake(id, (take) => ({ ...take, timelineOffset }));
-  }
-
-  setTakeTrimStart(id: string, trimStart: number): void {
-    this.updateTake(id, (take) => ({
-      ...take,
-      trimStart: Math.max(
-        0,
-        Math.min(trimStart, take.trimEnd - MIN_TAKE_DURATION),
-      ),
-    }));
-  }
-
-  setTakeTrimEnd(id: string, trimEnd: number): void {
-    this.updateTake(id, (take) => ({
-      ...take,
-      trimEnd: Math.min(
-        take.duration,
-        Math.max(trimEnd, take.trimStart + MIN_TAKE_DURATION),
-      ),
-    }));
-  }
-
-  private updateTake(id: string, update: (take: TakeState) => TakeState): void {
-    this.updateTakes((takes) => {
-      const index = takes.findIndex((take) => take.id === id);
-      const take = takes[index];
-      if (!take) {
-        throw new Error("Recording take state is missing.");
-      }
-      const nextTakes = takes.slice();
-      nextTakes[index] = update(take);
-      return nextTakes;
-    });
-  }
-
-  private updateTakes(update: (takes: TakeState[]) => TakeState[]): void {
-    const wasPlaying = this.store.get().isPlaying;
-    if (wasPlaying) {
-      this.pause();
-    }
-    const recordingTrack = this.store.get().recordingTrack;
-    this.store.update({
-      recordingTrack: {
-        ...recordingTrack,
-        takes: update(recordingTrack.takes),
-      },
-    });
-    this.syncTakeRegions();
-    if (wasPlaying) {
-      this.transport!.play();
-    }
   }
 
   private syncTakeRegions(): void {

--- a/src/lib/recorder/take-comp.test.ts
+++ b/src/lib/recorder/take-comp.test.ts
@@ -12,6 +12,8 @@ describe(renderTakeComp, () => {
         number: 1,
         timelineOffset: 0,
         duration: 2,
+        trimStart: 0,
+        trimEnd: 2,
         buffer: createBuffer({ sampleRate: 4, samples: Array(8).fill(1) }),
       },
       {
@@ -19,6 +21,8 @@ describe(renderTakeComp, () => {
         number: 2,
         timelineOffset: 0.75,
         duration: 0.5,
+        trimStart: 0,
+        trimEnd: 0.5,
         buffer: createBuffer({ sampleRate: 4, samples: [2, 2] }),
       },
     ];
@@ -40,6 +44,8 @@ describe(renderTakeComp, () => {
         number: 1,
         timelineOffset: 0,
         duration: 1,
+        trimStart: 0,
+        trimEnd: 1,
         buffer: createBuffer({ sampleRate: 2, samples: [0, 1] }),
       },
     ];
@@ -59,6 +65,8 @@ describe(renderTakeComp, () => {
         number: 1,
         timelineOffset: 1,
         duration: 1,
+        trimStart: 0,
+        trimEnd: 1,
         buffer: createBuffer({ sampleRate: 2, samples: [1, 1] }),
       },
     ];
@@ -69,6 +77,27 @@ describe(renderTakeComp, () => {
     });
 
     expect(Array.from(result!.getChannelData(0))).toEqual([0, 0, 1, 1]);
+  });
+
+  it("renders the trimmed source samples", () => {
+    const takes: TakeState[] = [
+      {
+        id: "take",
+        number: 1,
+        timelineOffset: 0,
+        duration: 2,
+        trimStart: 0.5,
+        trimEnd: 1.5,
+        buffer: createBuffer({ sampleRate: 2, samples: [1, 2, 3, 4] }),
+      },
+    ];
+    const result = renderTakeComp({
+      context: createContext(2),
+      regions: deriveTakeRegions(takes),
+      takes,
+    });
+
+    expect(Array.from(result!.getChannelData(0))).toEqual([0, 2, 3]);
   });
 });
 

--- a/src/lib/recorder/take-comp.test.ts
+++ b/src/lib/recorder/take-comp.test.ts
@@ -78,27 +78,6 @@ describe(renderTakeComp, () => {
 
     expect(Array.from(result!.getChannelData(0))).toEqual([0, 0, 1, 1]);
   });
-
-  it("renders the trimmed source samples", () => {
-    const takes: TakeState[] = [
-      {
-        id: "take",
-        number: 1,
-        timelineOffset: 0,
-        duration: 2,
-        trimStart: 0.5,
-        trimEnd: 1.5,
-        buffer: createBuffer({ sampleRate: 2, samples: [1, 2, 3, 4] }),
-      },
-    ];
-    const result = renderTakeComp({
-      context: createContext(2),
-      regions: deriveTakeRegions(takes),
-      takes,
-    });
-
-    expect(Array.from(result!.getChannelData(0))).toEqual([0, 2, 3]);
-  });
 });
 
 function createContext(sampleRate: number): BaseAudioContext {

--- a/src/lib/recorder/take-regions.test.ts
+++ b/src/lib/recorder/take-regions.test.ts
@@ -50,8 +50,21 @@ describe(deriveTakeRegions, () => {
       ],
     );
   });
+
+  it("uses the trimmed source interval on the timeline", () => {
+    expect(
+      deriveTakeRegions([{ ...take("take", 3, 6), trimStart: 1, trimEnd: 5 }]),
+    ).toEqual([{ takeId: "take", timelineStart: 4, timelineEnd: 8 }]);
+  });
 });
 
 function take(id: string, timelineOffset: number, duration: number): TakeState {
-  return { id, number: 1, timelineOffset, duration };
+  return {
+    id,
+    number: 1,
+    timelineOffset,
+    duration,
+    trimStart: 0,
+    trimEnd: duration,
+  };
 }

--- a/src/lib/recorder/take-regions.ts
+++ b/src/lib/recorder/take-regions.ts
@@ -7,11 +7,11 @@ export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
   // Apply takes oldest to newest. Each new take subtracts its interval from
   // every existing region before being inserted as the winning region.
   for (const take of takes) {
-    if (take.duration <= 0) {
+    if (take.trimEnd <= take.trimStart) {
       continue;
     }
-    const takeStart = take.timelineOffset;
-    const takeEnd = takeStart + take.duration;
+    const takeStart = take.timelineOffset + take.trimStart;
+    const takeEnd = take.timelineOffset + take.trimEnd;
     const nextRegions: TakeRegion[] = [];
     for (const region of regions) {
       // no overlap

--- a/src/lib/recorder/take.ts
+++ b/src/lib/recorder/take.ts
@@ -4,6 +4,9 @@ export interface TakeState {
   id: string;
   number: number;
   duration: number;
+  /** Audible source-buffer interval [trimStart, trimEnd), in seconds. */
+  trimStart: number;
+  trimEnd: number;
   timelineOffset: number;
   buffer?: AudioBuffer;
   audioView?: AudioView;


### PR DESCRIPTION
- follow-up to https://github.com/hi-ogawa/toy-midi/pull/365
- explain diff https://gisthost.github.io/?060b0b6703c159c6e04311d332478fe7/toy-midi-pr-368-explain-diff.html

Multi-take recording is useful for quickly building a comp, but finalized takes are fixed to their original range. This makes even basic timing adjustments or removing noise around a take require recording again.

This PR makes completed takes movable and adds handles for non-destructive left and right trimming. Trims persist as a relative source interval, while playback, waveform rendering, and comp export continue deriving absolute timeline regions from the take placement.