### PR TITLE
feat: trim and clear recorder audio clips

### DIFF
--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -18,6 +18,33 @@ test("uploads and plays a backing track", async ({ page }) => {
   await expect(clip).toContainText("test-audio.wav");
   await expect(clip.locator("svg")).toBeVisible();
 
+  // Backing audio supports the same non-destructive move and trim workflow.
+  const beforeEdit = await clip.boundingBox();
+  expect(beforeEdit).not.toBeNull();
+  await dragBy(page, clip, 80);
+  const afterMove = await clip.boundingBox();
+  expect(afterMove).not.toBeNull();
+  expect(afterMove!.x).toBeCloseTo(beforeEdit!.x + 80, -1);
+  const trimPixels = afterMove!.width / 4;
+
+  await dragBy(page, clip.getByTestId("recorder-take-trim-start"), trimPixels);
+  const afterStartTrim = await clip.boundingBox();
+  expect(afterStartTrim).not.toBeNull();
+  expect(afterStartTrim!.x).toBeCloseTo(afterMove!.x + trimPixels, -1);
+  expect(afterStartTrim!.x + afterStartTrim!.width).toBeCloseTo(
+    afterMove!.x + afterMove!.width,
+    -1,
+  );
+
+  await dragBy(page, clip.getByTestId("recorder-take-trim-end"), -trimPixels);
+  const afterEndTrim = await clip.boundingBox();
+  expect(afterEndTrim).not.toBeNull();
+  expect(afterEndTrim!.x).toBeCloseTo(afterStartTrim!.x, -1);
+  expect(afterEndTrim!.width).toBeCloseTo(
+    afterStartTrim!.width - trimPixels,
+    -1,
+  );
+
   // Playback rolls the shared transport and can be paused from its new position.
   const playButton = page.getByTestId("recorder-play-button");
   const position = page.getByTestId("recorder-position");
@@ -27,6 +54,13 @@ test("uploads and plays a backing track", async ({ page }) => {
   await expect(position).not.toHaveText("01|01 - 00:00.000");
   await playButton.click();
   await expect(playButton).toHaveAttribute("aria-pressed", "false");
+
+  // Clearing the source preserves the empty audio track row.
+  await page.getByRole("button", { name: "Audio 1 actions" }).click();
+  await page.getByRole("menuitem", { name: "Clear audio" }).click();
+  await expect(clip).toHaveCount(0);
+  await expect(page.getByText("Load an audio file")).toBeVisible();
+  await expect(page.getByText("No file loaded")).toBeVisible();
 });
 
 test("records, plays, and manages multiple takes", async ({ page }) => {

--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -25,8 +25,8 @@ test("uploads and plays a backing track", async ({ page }) => {
   const afterMove = await clip.boundingBox();
   expect(afterMove).not.toBeNull();
   expect(afterMove!.x).toBeCloseTo(beforeEdit!.x + 80, -1);
-  const trimPixels = afterMove!.width / 4;
 
+  const trimPixels = afterMove!.width / 4;
   await dragBy(page, clip.getByTestId("recorder-take-trim-start"), trimPixels);
   const afterStartTrim = await clip.boundingBox();
   expect(afterStartTrim).not.toBeNull();

--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -55,9 +55,10 @@ test("uploads and plays a backing track", async ({ page }) => {
   await playButton.click();
   await expect(playButton).toHaveAttribute("aria-pressed", "false");
 
-  // Clearing the source preserves the empty audio track row.
-  await page.getByRole("button", { name: "Audio 1 actions" }).click();
-  await page.getByRole("menuitem", { name: "Clear audio" }).click();
+  // Deleting the selected clip preserves the empty audio track row.
+  await clip.dispatchEvent("click");
+  await expect(clip).toHaveClass(/border-sky-300/);
+  await page.keyboard.press("Delete");
   await expect(clip).toHaveCount(0);
   await expect(page.getByText("Load an audio file")).toBeVisible();
   await expect(page.getByText("No file loaded")).toBeVisible();

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -301,6 +301,8 @@ export function Recorder({ projectId }: { projectId: string }) {
                     onFileChange={(file) =>
                       audioTrackMutation.mutate({ file, id: track.id })
                     }
+                    hasAudio={Boolean(track.clip)}
+                    onClear={() => runtime.clearAudioTrack(track.id)}
                     onRemove={() => runtime.removeAudioTrack(track.id)}
                   />
                 }
@@ -309,11 +311,13 @@ export function Recorder({ projectId }: { projectId: string }) {
                   clip={
                     track.clip
                       ? {
-                          duration: track.clip.buffer.duration,
+                          duration: track.trimEnd - track.trimStart,
                           label: track.clip.name,
-                          offset: track.timelineOffset,
+                          offset: track.timelineOffset + track.trimStart,
                           variant: "audio",
                           audioView: track.clip.audioView,
+                          audioDuration: track.clip.buffer.duration,
+                          audioOffset: track.trimStart,
                         }
                       : undefined
                   }
@@ -325,8 +329,19 @@ export function Recorder({ projectId }: { projectId: string }) {
                   viewportWidth={timeline.viewportWidth}
                   emptyLabel="Load an audio file"
                   onClipOffsetChange={(offset) =>
-                    runtime.setAudioTrackOffset(track.id, offset)
+                    runtime.setAudioTrackOffset(
+                      track.id,
+                      offset - track.trimStart,
+                    )
                   }
+                  onTrimStartChange={(trimStart) =>
+                    runtime.setAudioTrackTrimStart(track.id, trimStart)
+                  }
+                  onTrimEndChange={(trimEnd) =>
+                    runtime.setAudioTrackTrimEnd(track.id, trimEnd)
+                  }
+                  trimStart={track.trimStart}
+                  trimEnd={track.trimEnd}
                   onClipDragEnd={() => {
                     if (state.isPlaying) {
                       runtime.pause();
@@ -1184,11 +1199,15 @@ function TimelineHeader({
 
 function AudioTrackActions({
   label,
+  hasAudio,
   onFileChange,
+  onClear,
   onRemove,
 }: {
   label: string;
+  hasAudio: boolean;
   onFileChange: (file: File) => void;
+  onClear: () => void;
   onRemove: () => void;
 }) {
   return (
@@ -1210,6 +1229,12 @@ function AudioTrackActions({
           <UploadIcon />
           Replace audio
         </DropdownMenuItem>
+        {hasAudio && (
+          <DropdownMenuItem onSelect={onClear}>
+            <Trash2Icon />
+            Clear audio
+          </DropdownMenuItem>
+        )}
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={onRemove} className="text-red-400">
           <Trash2Icon />
@@ -1680,6 +1705,10 @@ function TimelineLane({
   viewportWidth,
   onClipOffsetChange,
   onClipDragEnd,
+  onTrimStartChange,
+  onTrimEndChange,
+  trimStart,
+  trimEnd,
   subdivisionsPerBeat,
   onSeek,
 }: {
@@ -1692,6 +1721,10 @@ function TimelineLane({
   viewportWidth: number;
   onClipOffsetChange?: (offset: number) => void;
   onClipDragEnd?: () => void;
+  onTrimStartChange?: (offset: number) => void;
+  onTrimEndChange?: (offset: number) => void;
+  trimStart?: number;
+  trimEnd?: number;
   subdivisionsPerBeat: number;
   onSeek: (position: number) => void;
 }) {
@@ -1722,6 +1755,10 @@ function TimelineLane({
           viewportWidth={viewportWidth}
           onClipOffsetChange={onClipOffsetChange}
           onClipDragEnd={onClipDragEnd}
+          onTrimStartChange={onTrimStartChange}
+          onTrimEndChange={onTrimEndChange}
+          trimStart={trimStart}
+          trimEnd={trimEnd}
         />
       ) : (
         <div className="absolute inset-0 grid place-items-center text-xs text-neutral-600">

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -114,7 +114,7 @@ export function Recorder({ projectId }: { projectId: string }) {
     timeSignature: state.timeSignature,
   });
   const project = useRecorderProject({ projectId, runtime });
-  const takeSelection = useRecorderTakeSelection({
+  const clipSelection = useRecorderClipSelection({
     runtime,
     state,
   });
@@ -192,16 +192,16 @@ export function Recorder({ projectId }: { projectId: string }) {
     if (isShortcutTextInputTarget(event.target) || event.repeat) {
       return;
     }
-    if (matchKeyboardEvent(event, "Escape") && takeSelection.selectedId) {
+    if (matchKeyboardEvent(event, "Escape") && clipSelection.selected) {
       event.preventDefault();
-      takeSelection.clear();
+      clipSelection.clear();
     } else if (
-      takeSelection.selectedId &&
+      clipSelection.selected &&
       (matchKeyboardEvent(event, "Delete") ||
         matchKeyboardEvent(event, "Backspace"))
     ) {
       event.preventDefault();
-      takeSelection.remove(takeSelection.selectedId);
+      clipSelection.remove();
     } else if (matchKeyboardEvent(event, "Space")) {
       event.preventDefault();
       togglePlay();
@@ -301,8 +301,6 @@ export function Recorder({ projectId }: { projectId: string }) {
                     onFileChange={(file) =>
                       audioTrackMutation.mutate({ file, id: track.id })
                     }
-                    hasAudio={Boolean(track.clip)}
-                    onClear={() => runtime.clearAudioTrack(track.id)}
                     onRemove={() => runtime.removeAudioTrack(track.id)}
                   />
                 }
@@ -342,6 +340,13 @@ export function Recorder({ projectId }: { projectId: string }) {
                   }
                   trimStart={track.trimStart}
                   trimEnd={track.trimEnd}
+                  onSelect={() =>
+                    clipSelection.select({ type: "audio", id: track.id })
+                  }
+                  selected={
+                    clipSelection.selected?.type === "audio" &&
+                    clipSelection.selected.id === track.id
+                  }
                   onClipDragEnd={() => {
                     if (state.isPlaying) {
                       runtime.pause();
@@ -409,7 +414,11 @@ export function Recorder({ projectId }: { projectId: string }) {
                 takes={takes}
                 pendingRecording={state.pendingRecording}
                 captureStatus={state.captureStatus}
-                selectedTakeId={takeSelection.selectedId}
+                selectedTakeId={
+                  clipSelection.selected?.type === "take"
+                    ? clipSelection.selected.id
+                    : undefined
+                }
                 beatsPerBar={timeline.beatsPerBar}
                 subdivisionsPerBeat={timeline.subdivisionsPerBeat}
                 pixelsPerBeat={timeline.pixelsPerBeat}
@@ -417,7 +426,9 @@ export function Recorder({ projectId }: { projectId: string }) {
                 viewportStartBeat={timeline.viewportStartBeat}
                 viewportWidth={timeline.viewportWidth}
                 onSeek={(position) => runtime.seek(position)}
-                onTakeSelect={takeSelection.select}
+                onTakeSelect={(id) =>
+                  clipSelection.select({ type: "take", id })
+                }
                 onTakeOffsetChange={(id, offset) =>
                   runtime.setTakeTimelineOffset(id, offset)
                 }
@@ -475,32 +486,47 @@ export function Recorder({ projectId }: { projectId: string }) {
 
 type SaveStatus = "saved" | "unsaved" | "saving" | "error";
 
-function useRecorderTakeSelection({
+type RecorderClipSelection =
+  | { type: "audio"; id: string }
+  | { type: "take"; id: string };
+
+function useRecorderClipSelection({
   runtime,
   state,
 }: {
   runtime: RecorderRuntime;
   state: RecorderRuntimeState;
 }) {
-  const [selectedId, setSelectedId] = useState<string>();
+  const [selected, setSelected] = useState<RecorderClipSelection>();
   const takes = state.recordingTrack.takes;
+  const audioTracks = state.audioTracks;
 
   useEffect(() => {
-    if (selectedId && !takes.some((take) => take.id === selectedId)) {
-      setSelectedId(undefined);
+    if (
+      selected?.type === "take" &&
+      !takes.some((take) => take.id === selected.id)
+    ) {
+      setSelected(undefined);
+    } else if (
+      selected?.type === "audio" &&
+      !audioTracks.some((track) => track.id === selected.id && track.clip)
+    ) {
+      setSelected(undefined);
     }
-  }, [selectedId, takes]);
+  }, [audioTracks, selected, takes]);
 
   return {
-    clear: () => setSelectedId(undefined),
-    remove: (id: string) => {
-      runtime.removeTake(id);
-      if (selectedId === id) {
-        setSelectedId(undefined);
+    clear: () => setSelected(undefined),
+    remove: () => {
+      if (selected?.type === "take") {
+        runtime.removeTake(selected.id);
+      } else if (selected?.type === "audio") {
+        runtime.clearAudioTrack(selected.id);
       }
+      setSelected(undefined);
     },
-    select: setSelectedId,
-    selectedId,
+    select: setSelected,
+    selected,
   };
 }
 
@@ -1199,15 +1225,11 @@ function TimelineHeader({
 
 function AudioTrackActions({
   label,
-  hasAudio,
   onFileChange,
-  onClear,
   onRemove,
 }: {
   label: string;
-  hasAudio: boolean;
   onFileChange: (file: File) => void;
-  onClear: () => void;
   onRemove: () => void;
 }) {
   return (
@@ -1229,12 +1251,6 @@ function AudioTrackActions({
           <UploadIcon />
           Replace audio
         </DropdownMenuItem>
-        {hasAudio && (
-          <DropdownMenuItem onSelect={onClear}>
-            <Trash2Icon />
-            Clear audio
-          </DropdownMenuItem>
-        )}
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={onRemove} className="text-red-400">
           <Trash2Icon />
@@ -1709,6 +1725,8 @@ function TimelineLane({
   onTrimEndChange,
   trimStart,
   trimEnd,
+  onSelect,
+  selected,
   subdivisionsPerBeat,
   onSeek,
 }: {
@@ -1725,6 +1743,8 @@ function TimelineLane({
   onTrimEndChange?: (offset: number) => void;
   trimStart?: number;
   trimEnd?: number;
+  onSelect?: () => void;
+  selected?: boolean;
   subdivisionsPerBeat: number;
   onSeek: (position: number) => void;
 }) {
@@ -1759,6 +1779,8 @@ function TimelineLane({
           onTrimEndChange={onTrimEndChange}
           trimStart={trimStart}
           trimEnd={trimEnd}
+          onSelect={onSelect}
+          selected={selected}
         />
       ) : (
         <div className="absolute inset-0 grid place-items-center text-xs text-neutral-600">

--- a/src/lib/recorder/persistence.ts
+++ b/src/lib/recorder/persistence.ts
@@ -36,6 +36,8 @@ interface SerializedAudioTrackState {
   muted: boolean;
   soloed: boolean;
   timelineOffset: number;
+  trimStart?: number;
+  trimEnd?: number;
 }
 
 interface SerializedTakeState {
@@ -71,6 +73,8 @@ export function serializeRecorderRuntimeState(
       muted: track.muted,
       soloed: track.soloed,
       timelineOffset: track.timelineOffset,
+      trimStart: track.trimStart,
+      trimEnd: track.trimEnd,
     })),
     recordingTrack: {
       height: state.recordingTrack.height,
@@ -130,6 +134,8 @@ export function deserializeRecorderRuntimeState({
         muted: track.muted,
         soloed: track.soloed,
         timelineOffset: track.timelineOffset,
+        trimStart: track.trimStart ?? 0,
+        trimEnd: track.trimEnd ?? buffer?.duration ?? 0,
       };
     }),
     recordingTrack: {

--- a/src/lib/recorder/persistence.ts
+++ b/src/lib/recorder/persistence.ts
@@ -36,6 +36,7 @@ interface SerializedAudioTrackState {
   muted: boolean;
   soloed: boolean;
   timelineOffset: number;
+  // optional for back compat
   trimStart?: number;
   trimEnd?: number;
 }

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -38,6 +38,9 @@ interface AudioTrackState {
   muted: boolean;
   soloed: boolean;
   timelineOffset: number;
+  /** Audible source-buffer interval [trimStart, trimEnd), in seconds. */
+  trimStart: number;
+  trimEnd: number;
 }
 
 interface RecordingTrackState {
@@ -198,8 +201,10 @@ export class RecorderRuntime {
     const playback = this.getAudioTrackPlayback(id);
     playback.stop();
     playback.setBuffer(buffer);
-    this.updateAudioTrack(id, (track) => ({
+    const track = this.updateAudioTrack(id, (track) => ({
       ...track,
+      trimStart: 0,
+      trimEnd: buffer.duration,
       clip: {
         name: file.name,
         buffer,
@@ -210,6 +215,7 @@ export class RecorderRuntime {
         ),
       },
     }));
+    this.syncAudioTrackPlayback(track);
   }
 
   setAudioTrackMix(
@@ -223,11 +229,50 @@ export class RecorderRuntime {
   }
 
   setAudioTrackOffset(id: string, timelineOffset: number): void {
-    this.getAudioTrackPlayback(id).setBufferTimelineOffset(timelineOffset);
-    this.updateAudioTrack(id, (track) => ({
+    const track = this.updateAudioTrack(id, (track) => ({
       ...track,
       timelineOffset,
     }));
+    this.syncAudioTrackPlayback(track);
+  }
+
+  setAudioTrackTrimStart(id: string, trimStart: number): void {
+    const track = this.updateAudioTrack(id, (track) => ({
+      ...track,
+      trimStart: clamp(trimStart, 0, track.trimEnd - MIN_TAKE_DURATION),
+    }));
+    this.syncAudioTrackPlayback(track);
+  }
+
+  setAudioTrackTrimEnd(id: string, trimEnd: number): void {
+    const track = this.updateAudioTrack(id, (track) => ({
+      ...track,
+      trimEnd: clamp(
+        trimEnd,
+        track.trimStart + MIN_TAKE_DURATION,
+        track.clip?.buffer.duration ?? 0,
+      ),
+    }));
+    this.syncAudioTrackPlayback(track);
+  }
+
+  clearAudioTrack(id: string): void {
+    const wasPlaying = this.store.get().isPlaying;
+    if (wasPlaying) {
+      this.pause();
+    }
+    const playback = this.audioTrackPlaybacks.get(id);
+    playback?.stop();
+    playback?.setBuffer(undefined);
+    this.updateAudioTrack(id, (track) => ({
+      ...track,
+      clip: undefined,
+      trimStart: 0,
+      trimEnd: 0,
+    }));
+    if (wasPlaying) {
+      this.transport!.play();
+    }
   }
 
   setAudioTrackHeight(id: string, height: number): void {
@@ -251,7 +296,7 @@ export class RecorderRuntime {
   private updateAudioTrack(
     id: string,
     update: (track: AudioTrackState) => AudioTrackState,
-  ): void {
+  ): AudioTrackState {
     const audioTracks = this.store.get().audioTracks.slice();
     const index = audioTracks.findIndex((track) => track.id === id);
     const track = audioTracks[index];
@@ -260,6 +305,7 @@ export class RecorderRuntime {
     }
     audioTracks[index] = update(track);
     this.store.update({ audioTracks });
+    return audioTracks[index]!;
   }
 
   private getAudioTrackPlayback(id: string): AudioBufferPlayback {
@@ -281,6 +327,22 @@ export class RecorderRuntime {
       this.syncTrackMix();
     }
     return playback;
+  }
+
+  private syncAudioTrackPlayback(track: AudioTrackState): void {
+    const wasPlaying = this.store.get().isPlaying;
+    if (wasPlaying) {
+      this.pause();
+    }
+    const playback = this.getAudioTrackPlayback(track.id);
+    playback.setBufferTimelineOffset(track.timelineOffset);
+    playback.setTimelineRange({
+      start: track.timelineOffset + track.trimStart,
+      end: track.timelineOffset + track.trimEnd,
+    });
+    if (wasPlaying) {
+      this.transport!.play();
+    }
   }
 
   setRecordingTrackMix(
@@ -493,6 +555,10 @@ export class RecorderRuntime {
       });
       playback.setBuffer(buffer);
       playback.setBufferTimelineOffset(track.timelineOffset);
+      playback.setTimelineRange({
+        start: track.timelineOffset + track.trimStart,
+        end: track.timelineOffset + track.trimEnd,
+      });
       this.audioTrackPlaybacks.set(track.id, playback);
     }
     // Clamp loaded external state at the runtime boundary so older projects
@@ -658,6 +724,8 @@ function createAudioTrackState(): AudioTrackState {
     muted: false,
     soloed: false,
     timelineOffset: 0,
+    trimStart: 0,
+    trimEnd: 0,
   };
 }
 


### PR DESCRIPTION
- follow-up to https://github.com/hi-ogawa/toy-midi/pull/368

Recorded takes can now be moved and trimmed, but backing audio clips still only support movement and removing the whole track. This leaves basic source cleanup inconsistent and makes replacing an audio file the only way to clear it without losing the row.

This PR gives recorder audio clips the same relative source trimming and selection behavior as takes. Trimmed playback persists with the project, and Delete or Backspace clears a selected audio clip while preserving the track and its mixer settings.