### PR TITLE
refactor: route recorder trim through clip interaction

### DIFF
--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -269,14 +269,13 @@ export function Recorder({ projectId }: { projectId: string }) {
                       additive,
                     )
                   }
-                  onTrimStartChange={(trimStart) =>
-                    runtime.setAudioTrackTrimStart(track.id, trimStart)
+                  onTrimStart={(edge) =>
+                    clipInteraction.startTrim({
+                      clip: { type: "audio", id: track.id },
+                      edge,
+                    })
                   }
-                  onTrimEndChange={(trimEnd) =>
-                    runtime.setAudioTrackTrimEnd(track.id, trimEnd)
-                  }
-                  trimStart={track.trimStart}
-                  trimEnd={track.trimEnd}
+                  onTrimMove={clipInteraction.trim}
                   onClipDragStart={(additive) =>
                     clipInteraction.startMove({
                       clip: { type: "audio", id: track.id },
@@ -371,12 +370,13 @@ export function Recorder({ projectId }: { projectId: string }) {
                   clipInteraction.select({ type: "take", id }, additive)
                 }
                 onTakeDragMove={clipInteraction.move}
-                onTakeTrimStartChange={(id, trimStart) =>
-                  runtime.setTakeTrimStart(id, trimStart)
+                onTakeTrimStart={(id, edge) =>
+                  clipInteraction.startTrim({
+                    clip: { type: "take", id },
+                    edge,
+                  })
                 }
-                onTakeTrimEndChange={(id, trimEnd) =>
-                  runtime.setTakeTrimEnd(id, trimEnd)
-                }
+                onTakeTrimMove={clipInteraction.trim}
               />
             </CaptureTrackRow>
           </div>

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -14,7 +14,10 @@ import { AudioWaveformView } from "../audio-waveform";
 import { openFilePicker } from "../file-drop-input";
 import { Button } from "../ui/button";
 import { cn } from "../ui/utils";
-import type { RecorderClipMoveSnapshot } from "./use-recorder-clip-interaction";
+import type {
+  RecorderClipMoveSnapshot,
+  RecorderClipTrimSnapshot,
+} from "./use-recorder-clip-interaction";
 
 export function TimelineHeader({
   beatsPerBar,
@@ -181,8 +184,8 @@ export function TakeTimelineLane({
   onTakeDragStart,
   onTakeClick,
   onTakeDragMove,
-  onTakeTrimStartChange,
-  onTakeTrimEndChange,
+  onTakeTrimStart,
+  onTakeTrimMove,
 }: {
   takes: RecorderRuntimeState["recordingTrack"]["takes"];
   pendingRecording: RecorderRuntimeState["pendingRecording"];
@@ -198,8 +201,11 @@ export function TakeTimelineLane({
   onTakeDragStart: (id: string, additive: boolean) => RecorderClipMoveSnapshot;
   onTakeClick: (id: string, additive: boolean) => void;
   onTakeDragMove: (snapshot: RecorderClipMoveSnapshot, delta: number) => void;
-  onTakeTrimStartChange: (id: string, trimStart: number) => void;
-  onTakeTrimEndChange: (id: string, trimEnd: number) => void;
+  onTakeTrimStart: (
+    id: string,
+    edge: "start" | "end",
+  ) => RecorderClipTrimSnapshot;
+  onTakeTrimMove: (snapshot: RecorderClipTrimSnapshot, delta: number) => void;
 }) {
   return (
     <div
@@ -243,12 +249,8 @@ export function TakeTimelineLane({
             onClipDragStart={(additive) => onTakeDragStart(take.id, additive)}
             onClipClick={(additive) => onTakeClick(take.id, additive)}
             onClipDragMove={onTakeDragMove}
-            onTrimStartChange={(trimStart) =>
-              onTakeTrimStartChange(take.id, trimStart)
-            }
-            onTrimEndChange={(trimEnd) => onTakeTrimEndChange(take.id, trimEnd)}
-            trimStart={take.trimStart}
-            trimEnd={take.trimEnd}
+            onTrimStart={(edge) => onTakeTrimStart(take.id, edge)}
+            onTrimMove={onTakeTrimMove}
             selected={isTakeSelected(take.id)}
           />
         </div>
@@ -288,10 +290,8 @@ export function TimelineLane({
   onClipDragStart,
   onClipClick,
   onClipDragMove,
-  onTrimStartChange,
-  onTrimEndChange,
-  trimStart,
-  trimEnd,
+  onTrimStart,
+  onTrimMove,
   subdivisionsPerBeat,
   onSeek,
 }: {
@@ -306,10 +306,8 @@ export function TimelineLane({
   onClipDragStart: (additive: boolean) => RecorderClipMoveSnapshot;
   onClipClick: (additive: boolean) => void;
   onClipDragMove: (snapshot: RecorderClipMoveSnapshot, delta: number) => void;
-  onTrimStartChange?: (offset: number) => void;
-  onTrimEndChange?: (offset: number) => void;
-  trimStart?: number;
-  trimEnd?: number;
+  onTrimStart?: (edge: "start" | "end") => RecorderClipTrimSnapshot;
+  onTrimMove?: (snapshot: RecorderClipTrimSnapshot, delta: number) => void;
   subdivisionsPerBeat: number;
   onSeek: (position: number) => void;
 }) {
@@ -342,10 +340,8 @@ export function TimelineLane({
           onClipDragStart={onClipDragStart}
           onClipClick={onClipClick}
           onClipDragMove={onClipDragMove}
-          onTrimStartChange={onTrimStartChange}
-          onTrimEndChange={onTrimEndChange}
-          trimStart={trimStart}
-          trimEnd={trimEnd}
+          onTrimStart={onTrimStart}
+          onTrimMove={onTrimMove}
         />
       ) : (
         <div className="absolute inset-0 grid place-items-center text-xs text-neutral-600">
@@ -365,10 +361,8 @@ function TimelineClip({
   onClipDragStart,
   onClipClick,
   onClipDragMove,
-  onTrimStartChange,
-  onTrimEndChange,
-  trimStart,
-  trimEnd,
+  onTrimStart,
+  onTrimMove,
   selected = false,
 }: {
   clip: RecorderTimelineClip;
@@ -379,10 +373,8 @@ function TimelineClip({
   onClipDragStart?: (additive: boolean) => RecorderClipMoveSnapshot;
   onClipClick?: (additive: boolean) => void;
   onClipDragMove?: (snapshot: RecorderClipMoveSnapshot, delta: number) => void;
-  onTrimStartChange?: (offset: number) => void;
-  onTrimEndChange?: (offset: number) => void;
-  trimStart?: number;
-  trimEnd?: number;
+  onTrimStart?: (edge: "start" | "end") => RecorderClipTrimSnapshot;
+  onTrimMove?: (snapshot: RecorderClipTrimSnapshot, delta: number) => void;
   selected?: boolean;
 }) {
   const [isDragging, setIsDragging] = useState(false);
@@ -421,7 +413,7 @@ function TimelineClip({
       event.stopPropagation();
       return {
         startClientX: event.clientX,
-        initialValue: trimStart!,
+        snapshot: onTrimStart!("start"),
       };
     },
     onMove: (event, drag) => {
@@ -429,7 +421,7 @@ function TimelineClip({
         (event.clientX - drag.startClientX) / pixelsPerBeat,
         tempo,
       );
-      onTrimStartChange!(drag.initialValue + delta);
+      onTrimMove!(drag.snapshot, delta);
     },
   });
   const trimEndRef = usePointerDrag({
@@ -438,7 +430,7 @@ function TimelineClip({
       event.stopPropagation();
       return {
         startClientX: event.clientX,
-        initialValue: trimEnd!,
+        snapshot: onTrimStart!("end"),
       };
     },
     onMove: (event, drag) => {
@@ -446,7 +438,7 @@ function TimelineClip({
         (event.clientX - drag.startClientX) / pixelsPerBeat,
         tempo,
       );
-      onTrimEndChange!(drag.initialValue + delta);
+      onTrimMove!(drag.snapshot, delta);
     },
   });
   const clipClass = {
@@ -509,7 +501,7 @@ function TimelineClip({
           )}
         </div>
       </div>
-      {onTrimStartChange && (
+      {onTrimStart && (
         <div
           ref={trimStartRef}
           data-testid="recorder-take-trim-start"
@@ -517,7 +509,7 @@ function TimelineClip({
           className="absolute inset-y-0 -left-[3px] z-20 w-1.5 cursor-ew-resize after:absolute after:inset-y-0 after:left-[3px] after:w-0.5 after:bg-transparent hover:after:bg-white/50"
         />
       )}
-      {onTrimEndChange && (
+      {onTrimStart && (
         <div
           ref={trimEndRef}
           data-testid="recorder-take-trim-end"

--- a/src/components/recorder/use-recorder-clip-interaction.ts
+++ b/src/components/recorder/use-recorder-clip-interaction.ts
@@ -11,6 +11,12 @@ export type RecorderClipMoveSnapshot = {
   minimumVisibleStart: number;
 };
 
+export type RecorderClipTrimSnapshot = {
+  clip: RecorderClipId;
+  edge: "start" | "end";
+  initialValue: number;
+};
+
 export function useRecorderClipInteraction({
   runtime,
   state,
@@ -117,6 +123,35 @@ export function useRecorderClipInteraction({
     );
   }
 
+  function startTrim({
+    clip,
+    edge,
+  }: {
+    clip: RecorderClipId;
+    edge: "start" | "end";
+  }): RecorderClipTrimSnapshot {
+    const selected =
+      clip.type === "audio"
+        ? state.audioTracks.find((track) => track.id === clip.id)
+        : state.recordingTrack.takes.find((take) => take.id === clip.id);
+    if (!selected) {
+      throw new Error("Recorder clip state is missing.");
+    }
+    return {
+      clip,
+      edge,
+      initialValue: edge === "start" ? selected.trimStart : selected.trimEnd,
+    };
+  }
+
+  function trim(snapshot: RecorderClipTrimSnapshot, delta: number): void {
+    runtime.trimClip({
+      ...snapshot.clip,
+      edge: snapshot.edge,
+      value: snapshot.initialValue + delta,
+    });
+  }
+
   function removeSelected(): void {
     const selected = getSelectedClips(keys);
     runtime.removeClips([
@@ -139,6 +174,8 @@ export function useRecorderClipInteraction({
     select,
     startMove,
     move,
+    startTrim,
+    trim,
     removeSelected,
   };
 }

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -92,6 +92,11 @@ export type RecorderClipId = { type: "audio" | "take"; id: string };
 
 export type RecorderClipMove = RecorderClipId & { timelineOffset: number };
 
+export type RecorderClipTrim = RecorderClipId & {
+  edge: "start" | "end";
+  value: number;
+};
+
 const METRONOME_GAIN = 0.5;
 
 export function createDefaultRecorderRuntimeState(): RecorderRuntimeState {
@@ -286,7 +291,28 @@ export class RecorderRuntime {
     }
   }
 
-  setAudioTrackTrimStart(id: string, trimStart: number): void {
+  trimClip({ type, id, edge, value }: RecorderClipTrim): void {
+    switch (type) {
+      case "audio": {
+        if (edge === "start") {
+          this.setAudioTrackTrimStart(id, value);
+        } else {
+          this.setAudioTrackTrimEnd(id, value);
+        }
+        break;
+      }
+      case "take": {
+        if (edge === "start") {
+          this.setTakeTrimStart(id, value);
+        } else {
+          this.setTakeTrimEnd(id, value);
+        }
+        break;
+      }
+    }
+  }
+
+  private setAudioTrackTrimStart(id: string, trimStart: number): void {
     const track = this.updateAudioTrack(id, (track) => ({
       ...track,
       trimStart: clamp(trimStart, 0, track.trimEnd - MIN_TAKE_DURATION),
@@ -294,7 +320,7 @@ export class RecorderRuntime {
     this.syncAudioTrackPlayback(track);
   }
 
-  setAudioTrackTrimEnd(id: string, trimEnd: number): void {
+  private setAudioTrackTrimEnd(id: string, trimEnd: number): void {
     const track = this.updateAudioTrack(id, (track) => ({
       ...track,
       trimEnd: clamp(
@@ -444,14 +470,14 @@ export class RecorderRuntime {
     });
   }
 
-  setTakeTrimStart(id: string, trimStart: number): void {
+  private setTakeTrimStart(id: string, trimStart: number): void {
     this.updateTake(id, (take) => ({
       ...take,
       trimStart: clamp(trimStart, 0, take.trimEnd - MIN_TAKE_DURATION),
     }));
   }
 
-  setTakeTrimEnd(id: string, trimEnd: number): void {
+  private setTakeTrimEnd(id: string, trimEnd: number): void {
     this.updateTake(id, (take) => ({
       ...take,
       trimEnd: clamp(


### PR DESCRIPTION
Recorder trim gestures bypassed the clip interaction boundary, so the timeline held model trim values and the recorder component dispatched separate audio and take mutations. This made trim structurally different from the existing move and delete interactions.

This PR routes single-clip trim snapshots and deltas through `useRecorderClipInteraction`, adds one typed runtime trim entry point, and leaves pointer mechanics in the timeline. Existing trim behavior and selection semantics remain unchanged.