### PR TITLE
fix: separate recording comp visualization

### DIFF
--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -58,6 +58,7 @@ test("uploads and plays a backing track", async ({ page }) => {
   // Deleting the selected clip preserves the empty audio track row.
   await clip.dispatchEvent("click");
   await expect(clip).toHaveAttribute("data-selected", "true");
+  await expect(clip.getByTestId("recorder-clip-selection")).toBeVisible();
   await page.keyboard.press("Delete");
   await expect(clip).toHaveCount(0);
   await expect(page.getByText("Load an audio file")).toBeVisible();

--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -79,7 +79,7 @@ test("selects and moves audio and take clips together", async ({ page }) => {
   await recordButton.click();
   await waitForRecordingSamples(page.getByTestId("recorder-clip-recording"));
   await recordButton.click();
-  const take = page.getByTestId("recorder-clip-take-interaction");
+  const take = page.getByTestId("recorder-clip-take");
   await expect(take).toBeVisible();
 
   // Ctrl-click adds the take to the selected backing track.
@@ -142,8 +142,8 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   await recordButton.click();
   await expect(recordButton).toHaveAttribute("aria-pressed", "false");
   await expect(playButton).toHaveAttribute("aria-pressed", "false");
-  const take = page.getByTestId("recorder-clip-take-interaction");
-  const compRegion = page.getByTestId("recorder-clip-take");
+  const take = page.getByTestId("recorder-clip-take");
+  const compRegion = page.getByTestId("recorder-clip-comp");
   await expect(take).toHaveCount(1);
   await expect(compRegion).toContainText("Take 1");
   await expect(compRegion.locator("svg")).toBeVisible();

--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -143,8 +143,10 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   await expect(recordButton).toHaveAttribute("aria-pressed", "false");
   await expect(playButton).toHaveAttribute("aria-pressed", "false");
   const take = page.getByTestId("recorder-clip-take");
-  await expect(take).toContainText("Take 1");
-  await expect(take.locator("svg")).toBeVisible();
+  const compRegion = page.getByTestId("recorder-comp-region");
+  await expect(take).toHaveAttribute("aria-label", "Take 1");
+  await expect(compRegion).toContainText("Take 1");
+  await expect(compRegion.locator("svg")).toBeVisible();
   await captureActions.click();
   await expect(page.getByTestId("recorder-download-take")).toBeEnabled();
   await page.keyboard.press("Escape");
@@ -206,8 +208,8 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
 
   // The second recording is retained as a new source take.
   await expect(take).toHaveCount(2);
-  await expect(take.nth(0)).toContainText("Take 1");
-  await expect(take.nth(1)).toContainText("Take 2");
+  await expect(take.nth(0)).toHaveAttribute("aria-label", "Take 1");
+  await expect(take.nth(1)).toHaveAttribute("aria-label", "Take 2");
   expect(
     Number.parseFloat(
       await take.nth(1).evaluate((element) => element.style.left),

--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -79,7 +79,7 @@ test("selects and moves audio and take clips together", async ({ page }) => {
   await recordButton.click();
   await waitForRecordingSamples(page.getByTestId("recorder-clip-recording"));
   await recordButton.click();
-  const take = page.getByTestId("recorder-clip-take");
+  const take = page.getByTestId("recorder-clip-take-interaction");
   await expect(take).toBeVisible();
 
   // Ctrl-click adds the take to the selected backing track.
@@ -142,9 +142,9 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   await recordButton.click();
   await expect(recordButton).toHaveAttribute("aria-pressed", "false");
   await expect(playButton).toHaveAttribute("aria-pressed", "false");
-  const take = page.getByTestId("recorder-clip-take");
-  const compRegion = page.getByTestId("recorder-comp-region");
-  await expect(take).toHaveAttribute("aria-label", "Take 1");
+  const take = page.getByTestId("recorder-clip-take-interaction");
+  const compRegion = page.getByTestId("recorder-clip-take");
+  await expect(take).toHaveCount(1);
   await expect(compRegion).toContainText("Take 1");
   await expect(compRegion.locator("svg")).toBeVisible();
   await captureActions.click();
@@ -208,8 +208,6 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
 
   // The second recording is retained as a new source take.
   await expect(take).toHaveCount(2);
-  await expect(take.nth(0)).toHaveAttribute("aria-label", "Take 1");
-  await expect(take.nth(1)).toHaveAttribute("aria-label", "Take 2");
   expect(
     Number.parseFloat(
       await take.nth(1).evaluate((element) => element.style.left),

--- a/e2e/fake-audio/recorder.test.ts
+++ b/e2e/fake-audio/recorder.test.ts
@@ -57,7 +57,7 @@ test("uploads and plays a backing track", async ({ page }) => {
 
   // Deleting the selected clip preserves the empty audio track row.
   await clip.dispatchEvent("click");
-  await expect(clip).toHaveClass(/border-sky-300/);
+  await expect(clip).toHaveAttribute("data-selected", "true");
   await page.keyboard.press("Delete");
   await expect(clip).toHaveCount(0);
   await expect(page.getByText("Load an audio file")).toBeVisible();
@@ -218,9 +218,9 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   const positionBeforeSelection = await position.textContent();
   await take.nth(0).click();
   await expect(position).toHaveText(positionBeforeSelection!);
-  await expect(take.nth(0)).toHaveClass(/border-sky-300/);
+  await expect(take.nth(0)).toHaveAttribute("data-selected", "true");
   await page.keyboard.press("Escape");
-  await expect(take.nth(0)).not.toHaveClass(/border-sky-300/);
+  await expect(take.nth(0)).not.toHaveAttribute("data-selected", "true");
 
   // Delete removes every selected source take together.
   await take.nth(0).click();

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -345,6 +345,7 @@ export function Recorder({ projectId }: { projectId: string }) {
             >
               <TakeTimelineLane
                 takes={takes}
+                regions={state.takeRegions}
                 pendingRecording={state.pendingRecording}
                 captureStatus={state.captureStatus}
                 isTakeSelected={(id) =>

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -528,7 +528,7 @@ function TimelineClip({
         onClipDragMove && "cursor-ew-resize select-none",
         onClipDragStart && "cursor-pointer",
         joinsPrevious && "rounded-l-none",
-        joinsNext && "rounded-r-none border-r-0",
+        joinsNext && "rounded-r-none border-r-transparent",
         selected && "border-sky-300 ring-1 ring-inset ring-sky-300",
         isDragging &&
           (interactionOnly

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -4,7 +4,6 @@ import { usePointerDrag } from "../../hooks/use-pointer-drag";
 import { usePointerGesture } from "../../hooks/use-pointer-gesture";
 import { AudioView } from "../../lib/audio-view";
 import type { RecorderRuntimeState } from "../../lib/recorder/runtime";
-import { deriveTakeRegions } from "../../lib/recorder/take-regions";
 import {
   beatsToSeconds,
   getVisibleBarInterval,
@@ -174,6 +173,7 @@ const TIMELINE_EPSILON = 1e-6;
 
 export function TakeTimelineLane({
   takes,
+  regions,
   pendingRecording,
   captureStatus,
   isTakeSelected,
@@ -191,6 +191,7 @@ export function TakeTimelineLane({
   onTakeTrimMove,
 }: {
   takes: RecorderRuntimeState["recordingTrack"]["takes"];
+  regions: RecorderRuntimeState["takeRegions"];
   pendingRecording: RecorderRuntimeState["pendingRecording"];
   captureStatus: RecorderRuntimeState["captureStatus"];
   isTakeSelected: (id: string) => boolean;
@@ -211,7 +212,6 @@ export function TakeTimelineLane({
   onTakeTrimMove: (snapshot: RecorderClipTrimSnapshot, delta: number) => void;
 }) {
   const takeById = new Map(takes.map((take) => [take.id, take]));
-  const regions = deriveTakeRegions(takes);
 
   return (
     <div

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -4,6 +4,7 @@ import { usePointerDrag } from "../../hooks/use-pointer-drag";
 import { usePointerGesture } from "../../hooks/use-pointer-gesture";
 import { AudioView } from "../../lib/audio-view";
 import type { RecorderRuntimeState } from "../../lib/recorder/runtime";
+import { deriveTakeRegions } from "../../lib/recorder/take-regions";
 import {
   beatsToSeconds,
   getVisibleBarInterval,
@@ -207,6 +208,9 @@ export function TakeTimelineLane({
   ) => RecorderClipTrimSnapshot;
   onTakeTrimMove: (snapshot: RecorderClipTrimSnapshot, delta: number) => void;
 }) {
+  const takeById = new Map(takes.map((take) => [take.id, take]));
+  const regions = deriveTakeRegions(takes);
+
   return (
     <div
       className="relative overflow-hidden bg-neutral-900"
@@ -230,17 +234,40 @@ export function TakeTimelineLane({
           Enable input, place the playhead, then record
         </div>
       )}
-      {takes.map((take) => (
-        <div key={take.id}>
+      <div className="pointer-events-none absolute inset-0">
+        {regions.map((region, index) => {
+          const take = takeById.get(region.takeId)!;
+          const audioOffset = region.timelineStart - take.timelineOffset;
+          return (
+            <TimelineClip
+              key={`${region.takeId}:${index}`}
+              clip={{
+                label: `Take ${take.number}`,
+                duration: region.timelineEnd - region.timelineStart,
+                offset: region.timelineStart,
+                audioDuration: take.duration,
+                audioOffset,
+                variant: "take",
+                audioView: take.audioView,
+              }}
+              pixelsPerBeat={pixelsPerBeat}
+              viewportStartBeat={viewportStartBeat}
+              tempo={tempo}
+              viewportWidth={viewportWidth}
+              testId="recorder-comp-region"
+            />
+          );
+        })}
+      </div>
+      <div className="absolute inset-0">
+        {takes.map((take) => (
           <TimelineClip
+            key={take.id}
             clip={{
               label: `Take ${take.number}`,
               duration: take.trimEnd - take.trimStart,
               offset: take.timelineOffset + take.trimStart,
-              audioDuration: take.duration,
-              audioOffset: take.trimStart,
               variant: "take",
-              audioView: take.audioView,
             }}
             pixelsPerBeat={pixelsPerBeat}
             viewportStartBeat={viewportStartBeat}
@@ -252,9 +279,10 @@ export function TakeTimelineLane({
             onTrimStart={(edge) => onTakeTrimStart(take.id, edge)}
             onTrimMove={onTakeTrimMove}
             selected={isTakeSelected(take.id)}
+            interactionOnly
           />
-        </div>
-      ))}
+        ))}
+      </div>
       {pendingRecording && (
         <div>
           <TimelineClip
@@ -363,6 +391,8 @@ function TimelineClip({
   onClipDragMove,
   onTrimStart,
   onTrimMove,
+  interactionOnly = false,
+  testId,
   selected = false,
 }: {
   clip: RecorderTimelineClip;
@@ -375,6 +405,8 @@ function TimelineClip({
   onClipDragMove?: (snapshot: RecorderClipMoveSnapshot, delta: number) => void;
   onTrimStart?: (edge: "start" | "end") => RecorderClipTrimSnapshot;
   onTrimMove?: (snapshot: RecorderClipTrimSnapshot, delta: number) => void;
+  interactionOnly?: boolean;
+  testId?: string;
   selected?: boolean;
 }) {
   const [isDragging, setIsDragging] = useState(false);
@@ -466,41 +498,49 @@ function TimelineClip({
   );
   return (
     <div
-      data-testid={`recorder-clip-${clip.variant}`}
+      aria-label={interactionOnly ? clip.label : undefined}
+      data-testid={testId ?? `recorder-clip-${clip.variant}`}
       data-selected={selected ? "true" : undefined}
       ref={onClipDragMove ? dragRef : undefined}
       className={cn(
         "absolute inset-y-1 rounded-sm border text-[11px]",
-        clipClass,
+        interactionOnly
+          ? "border-transparent bg-transparent text-transparent"
+          : clipClass,
         onClipDragMove && "cursor-ew-resize select-none",
         onClipDragStart && "cursor-pointer",
         selected && "border-sky-300 ring-1 ring-inset ring-sky-300",
-        isDragging && "brightness-125",
+        isDragging &&
+          (interactionOnly
+            ? "border-sky-300 ring-1 ring-inset ring-sky-300"
+            : "brightness-125"),
       )}
       style={{
         left: (clipStartBeat - viewportStartBeat) * pixelsPerBeat,
         width: clipWidth,
       }}
     >
-      <div className="absolute inset-0 overflow-hidden rounded-[inherit]">
-        {clip.audioView && visibleEnd > visibleStart && (
-          <AudioWaveformView
-            audioView={clip.audioView}
-            audioDuration={clip.audioDuration ?? clip.duration}
-            rangeStart={clip.audioOffset ?? 0}
-            rangeEnd={(clip.audioOffset ?? 0) + clip.duration}
-            visibleStart={visibleStart}
-            visibleEnd={visibleEnd}
-            pixelWidth={clipWidth}
-          />
-        )}
-        <div className="absolute left-1 top-0.5 z-10 whitespace-nowrap">
-          <span className="mr-1.5">{clip.label}</span>
-          {onClipDragMove && clip.offset > 0 && (
-            <span className="opacity-75">+{clip.offset.toFixed(3)}s</span>
+      {!interactionOnly && (
+        <div className="absolute inset-0 overflow-hidden rounded-[inherit]">
+          {clip.audioView && visibleEnd > visibleStart && (
+            <AudioWaveformView
+              audioView={clip.audioView}
+              audioDuration={clip.audioDuration ?? clip.duration}
+              rangeStart={clip.audioOffset ?? 0}
+              rangeEnd={(clip.audioOffset ?? 0) + clip.duration}
+              visibleStart={visibleStart}
+              visibleEnd={visibleEnd}
+              pixelWidth={clipWidth}
+            />
           )}
+          <div className="absolute left-1 top-0.5 z-10 whitespace-nowrap">
+            <span className="mr-1.5">{clip.label}</span>
+            {onClipDragMove && clip.offset > 0 && (
+              <span className="opacity-75">+{clip.offset.toFixed(3)}s</span>
+            )}
+          </div>
         </div>
-      </div>
+      )}
       {onTrimStart && (
         <div
           ref={trimStartRef}

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -484,7 +484,6 @@ function TimelineClip({
     },
   });
   const hidePresentation = clip.variant === "take";
-  const overlayBorder = clip.variant === "comp";
   const clipClass =
     clip.variant === "recording"
       ? "bg-red-400/20 text-red-100"
@@ -518,20 +517,12 @@ function TimelineClip({
       ref={onClipDragMove ? dragRef : undefined}
       className={cn(
         "absolute inset-y-1 rounded-sm text-[11px]",
-        !overlayBorder && "border",
-        hidePresentation
-          ? "border-transparent bg-transparent text-transparent"
-          : clipClass,
-        !hidePresentation && !overlayBorder && clipBorderClass,
+        hidePresentation ? "bg-transparent text-transparent" : clipClass,
         onClipDragMove && "cursor-ew-resize select-none",
         onClipDragStart && "cursor-pointer",
         joinsPrevious && "rounded-l-none",
         joinsNext && "rounded-r-none",
-        selected && "border-sky-300 ring-1 ring-inset ring-sky-300",
-        isDragging &&
-          (hidePresentation
-            ? "border-sky-300 ring-1 ring-inset ring-sky-300"
-            : "brightness-125"),
+        isDragging && !hidePresentation && "brightness-125",
       )}
       style={{
         left: (clipStartBeat - viewportStartBeat) * pixelsPerBeat,
@@ -559,7 +550,7 @@ function TimelineClip({
           </div>
         </div>
       )}
-      {overlayBorder && (
+      {!hidePresentation && (
         <div
           className={cn(
             "pointer-events-none absolute inset-0 rounded-[inherit] border",
@@ -567,6 +558,9 @@ function TimelineClip({
             joinsNext && "border-r-0",
           )}
         />
+      )}
+      {hidePresentation && (selected || isDragging) && (
+        <div className="pointer-events-none absolute inset-0 rounded-[inherit] border border-sky-300 ring-1 ring-inset ring-sky-300" />
       )}
       {onTrimStart && (
         <div

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -266,7 +266,6 @@ export function TakeTimelineLane({
               viewportStartBeat={viewportStartBeat}
               tempo={tempo}
               viewportWidth={viewportWidth}
-              testId="recorder-comp-region"
               joinsPrevious={joinsPrevious}
               joinsNext={joinsNext}
               overlayBorder
@@ -294,7 +293,7 @@ export function TakeTimelineLane({
             onTrimStart={(edge) => onTakeTrimStart(take.id, edge)}
             onTrimMove={onTakeTrimMove}
             selected={isTakeSelected(take.id)}
-            interactionOnly
+            hidePresentation
           />
         ))}
       </div>
@@ -406,11 +405,10 @@ function TimelineClip({
   onClipDragMove,
   onTrimStart,
   onTrimMove,
-  interactionOnly = false,
+  hidePresentation = false,
   joinsPrevious = false,
   joinsNext = false,
   overlayBorder = false,
-  testId,
   selected = false,
 }: {
   clip: RecorderTimelineClip;
@@ -423,11 +421,10 @@ function TimelineClip({
   onClipDragMove?: (snapshot: RecorderClipMoveSnapshot, delta: number) => void;
   onTrimStart?: (edge: "start" | "end") => RecorderClipTrimSnapshot;
   onTrimMove?: (snapshot: RecorderClipTrimSnapshot, delta: number) => void;
-  interactionOnly?: boolean;
+  hidePresentation?: boolean;
   joinsPrevious?: boolean;
   joinsNext?: boolean;
   overlayBorder?: boolean;
-  testId?: string;
   selected?: boolean;
 }) {
   const [isDragging, setIsDragging] = useState(false);
@@ -524,24 +521,23 @@ function TimelineClip({
   );
   return (
     <div
-      aria-label={interactionOnly ? clip.label : undefined}
-      data-testid={testId ?? `recorder-clip-${clip.variant}`}
+      data-testid={`recorder-clip-${clip.variant}${hidePresentation ? "-interaction" : ""}`}
       data-selected={selected ? "true" : undefined}
       ref={onClipDragMove ? dragRef : undefined}
       className={cn(
         "absolute inset-y-1 rounded-sm text-[11px]",
         !overlayBorder && "border",
-        interactionOnly
+        hidePresentation
           ? "border-transparent bg-transparent text-transparent"
           : clipClass,
-        !interactionOnly && !overlayBorder && clipBorderClass,
+        !hidePresentation && !overlayBorder && clipBorderClass,
         onClipDragMove && "cursor-ew-resize select-none",
         onClipDragStart && "cursor-pointer",
         joinsPrevious && "rounded-l-none",
         joinsNext && "rounded-r-none",
         selected && "border-sky-300 ring-1 ring-inset ring-sky-300",
         isDragging &&
-          (interactionOnly
+          (hidePresentation
             ? "border-sky-300 ring-1 ring-inset ring-sky-300"
             : "brightness-125"),
       )}
@@ -550,7 +546,7 @@ function TimelineClip({
         width: clipWidth,
       }}
     >
-      {!interactionOnly && (
+      {!hidePresentation && (
         <div className="absolute inset-0 overflow-hidden rounded-[inherit]">
           {clip.audioView && visibleEnd > visibleStart && (
             <AudioWaveformView

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -530,37 +530,40 @@ function TimelineClip({
       }}
     >
       {!hidePresentation && (
-        <div className="absolute inset-0 overflow-hidden rounded-[inherit]">
-          {clip.audioView && visibleEnd > visibleStart && (
-            <AudioWaveformView
-              audioView={clip.audioView}
-              audioDuration={clip.audioDuration ?? clip.duration}
-              rangeStart={clip.audioOffset ?? 0}
-              rangeEnd={(clip.audioOffset ?? 0) + clip.duration}
-              visibleStart={visibleStart}
-              visibleEnd={visibleEnd}
-              pixelWidth={clipWidth}
-            />
-          )}
-          <div className="absolute left-1 top-0.5 z-10 whitespace-nowrap">
-            <span className="mr-1.5">{clip.label}</span>
-            {onClipDragMove && clip.offset > 0 && (
-              <span className="opacity-75">+{clip.offset.toFixed(3)}s</span>
+        <>
+          <div className="absolute inset-0 overflow-hidden rounded-[inherit]">
+            {clip.audioView && visibleEnd > visibleStart && (
+              <AudioWaveformView
+                audioView={clip.audioView}
+                audioDuration={clip.audioDuration ?? clip.duration}
+                rangeStart={clip.audioOffset ?? 0}
+                rangeEnd={(clip.audioOffset ?? 0) + clip.duration}
+                visibleStart={visibleStart}
+                visibleEnd={visibleEnd}
+                pixelWidth={clipWidth}
+              />
             )}
+            <div className="absolute left-1 top-0.5 z-10 whitespace-nowrap">
+              <span className="mr-1.5">{clip.label}</span>
+              {onClipDragMove && clip.offset > 0 && (
+                <span className="opacity-75">+{clip.offset.toFixed(3)}s</span>
+              )}
+            </div>
           </div>
-        </div>
+          <div
+            className={cn(
+              "pointer-events-none absolute inset-0 rounded-[inherit] border",
+              clipBorderClass,
+              joinsNext && "border-r-0",
+            )}
+          />
+        </>
       )}
-      {!hidePresentation && (
+      {(selected || (hidePresentation && isDragging)) && (
         <div
-          className={cn(
-            "pointer-events-none absolute inset-0 rounded-[inherit] border",
-            clipBorderClass,
-            joinsNext && "border-r-0",
-          )}
+          data-testid="recorder-clip-selection"
+          className="pointer-events-none absolute inset-0 rounded-[inherit] border border-sky-300 ring-1 ring-inset ring-sky-300"
         />
-      )}
-      {hidePresentation && (selected || isDragging) && (
-        <div className="pointer-events-none absolute inset-0 rounded-[inherit] border border-sky-300 ring-1 ring-inset ring-sky-300" />
       )}
       {onTrimStart && (
         <div

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -268,7 +268,6 @@ export function TakeTimelineLane({
               viewportWidth={viewportWidth}
               joinsPrevious={joinsPrevious}
               joinsNext={joinsNext}
-              overlayBorder
             />
           );
         })}
@@ -404,7 +403,6 @@ function TimelineClip({
   onTrimMove,
   joinsPrevious = false,
   joinsNext = false,
-  overlayBorder = false,
   selected = false,
 }: {
   clip: RecorderTimelineClip;
@@ -419,7 +417,6 @@ function TimelineClip({
   onTrimMove?: (snapshot: RecorderClipTrimSnapshot, delta: number) => void;
   joinsPrevious?: boolean;
   joinsNext?: boolean;
-  overlayBorder?: boolean;
   selected?: boolean;
 }) {
   const [isDragging, setIsDragging] = useState(false);
@@ -487,6 +484,7 @@ function TimelineClip({
     },
   });
   const hidePresentation = clip.variant === "take";
+  const overlayBorder = clip.variant === "comp";
   const clipClass =
     clip.variant === "recording"
       ? "bg-red-400/20 text-red-100"

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -165,7 +165,7 @@ type RecorderTimelineClip = {
   audioDuration?: number;
   /** Visible clip start relative to the source buffer, in seconds. */
   audioOffset?: number;
-  variant: "audio" | "take" | "recording";
+  variant: "audio" | "comp" | "take" | "recording";
   audioView?: AudioView;
 };
 
@@ -259,7 +259,7 @@ export function TakeTimelineLane({
                 offset: region.timelineStart,
                 audioDuration: take.duration,
                 audioOffset,
-                variant: "take",
+                variant: "comp",
                 audioView: take.audioView,
               }}
               pixelsPerBeat={pixelsPerBeat}
@@ -292,7 +292,6 @@ export function TakeTimelineLane({
           onTrimStart={(edge) => onTakeTrimStart(take.id, edge)}
           onTrimMove={onTakeTrimMove}
           selected={isTakeSelected(take.id)}
-          hidePresentation
         />
       ))}
       {pendingRecording && (
@@ -403,7 +402,6 @@ function TimelineClip({
   onClipDragMove,
   onTrimStart,
   onTrimMove,
-  hidePresentation = false,
   joinsPrevious = false,
   joinsNext = false,
   overlayBorder = false,
@@ -419,7 +417,6 @@ function TimelineClip({
   onClipDragMove?: (snapshot: RecorderClipMoveSnapshot, delta: number) => void;
   onTrimStart?: (edge: "start" | "end") => RecorderClipTrimSnapshot;
   onTrimMove?: (snapshot: RecorderClipTrimSnapshot, delta: number) => void;
-  hidePresentation?: boolean;
   joinsPrevious?: boolean;
   joinsNext?: boolean;
   overlayBorder?: boolean;
@@ -489,16 +486,15 @@ function TimelineClip({
       onTrimMove!(drag.snapshot, delta);
     },
   });
-  const clipClass = {
-    audio: "bg-emerald-400/20 text-emerald-100",
-    take: "bg-emerald-400/20 text-emerald-100",
-    recording: "bg-red-400/20 text-red-100",
-  }[clip.variant];
-  const clipBorderClass = {
-    audio: "border-emerald-400/60",
-    take: "border-emerald-400/60",
-    recording: "border-red-400/70",
-  }[clip.variant];
+  const hidePresentation = clip.variant === "take";
+  const clipClass =
+    clip.variant === "recording"
+      ? "bg-red-400/20 text-red-100"
+      : "bg-emerald-400/20 text-emerald-100";
+  const clipBorderClass =
+    clip.variant === "recording"
+      ? "border-red-400/70"
+      : "border-emerald-400/60";
   const clipStartBeat = secondsToBeats(clip.offset, tempo);
   const clipWidth = Math.max(
     2,
@@ -519,7 +515,7 @@ function TimelineClip({
   );
   return (
     <div
-      data-testid={`recorder-clip-${clip.variant}${hidePresentation ? "-interaction" : ""}`}
+      data-testid={`recorder-clip-${clip.variant}`}
       data-selected={selected ? "true" : undefined}
       ref={onClipDragMove ? dragRef : undefined}
       className={cn(

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -170,6 +170,8 @@ type RecorderTimelineClip = {
   audioView?: AudioView;
 };
 
+const TIMELINE_EPSILON = 1e-6;
+
 export function TakeTimelineLane({
   takes,
   pendingRecording,
@@ -238,6 +240,16 @@ export function TakeTimelineLane({
         {regions.map((region, index) => {
           const take = takeById.get(region.takeId)!;
           const audioOffset = region.timelineStart - take.timelineOffset;
+          const previous = regions[index - 1];
+          const next = regions[index + 1];
+          const joinsPrevious =
+            previous !== undefined &&
+            Math.abs(previous.timelineEnd - region.timelineStart) <
+              TIMELINE_EPSILON;
+          const joinsNext =
+            next !== undefined &&
+            Math.abs(region.timelineEnd - next.timelineStart) <
+              TIMELINE_EPSILON;
           return (
             <TimelineClip
               key={`${region.takeId}:${index}`}
@@ -255,6 +267,8 @@ export function TakeTimelineLane({
               tempo={tempo}
               viewportWidth={viewportWidth}
               testId="recorder-comp-region"
+              joinsPrevious={joinsPrevious}
+              joinsNext={joinsNext}
             />
           );
         })}
@@ -392,6 +406,8 @@ function TimelineClip({
   onTrimStart,
   onTrimMove,
   interactionOnly = false,
+  joinsPrevious = false,
+  joinsNext = false,
   testId,
   selected = false,
 }: {
@@ -406,6 +422,8 @@ function TimelineClip({
   onTrimStart?: (edge: "start" | "end") => RecorderClipTrimSnapshot;
   onTrimMove?: (snapshot: RecorderClipTrimSnapshot, delta: number) => void;
   interactionOnly?: boolean;
+  joinsPrevious?: boolean;
+  joinsNext?: boolean;
   testId?: string;
   selected?: boolean;
 }) {
@@ -509,6 +527,8 @@ function TimelineClip({
           : clipClass,
         onClipDragMove && "cursor-ew-resize select-none",
         onClipDragStart && "cursor-pointer",
+        joinsPrevious && "rounded-l-none",
+        joinsNext && "rounded-r-none border-r-0",
         selected && "border-sky-300 ring-1 ring-inset ring-sky-300",
         isDragging &&
           (interactionOnly

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -269,6 +269,7 @@ export function TakeTimelineLane({
               testId="recorder-comp-region"
               joinsPrevious={joinsPrevious}
               joinsNext={joinsNext}
+              overlayBorder
             />
           );
         })}
@@ -408,6 +409,7 @@ function TimelineClip({
   interactionOnly = false,
   joinsPrevious = false,
   joinsNext = false,
+  overlayBorder = false,
   testId,
   selected = false,
 }: {
@@ -424,6 +426,7 @@ function TimelineClip({
   interactionOnly?: boolean;
   joinsPrevious?: boolean;
   joinsNext?: boolean;
+  overlayBorder?: boolean;
   testId?: string;
   selected?: boolean;
 }) {
@@ -492,9 +495,14 @@ function TimelineClip({
     },
   });
   const clipClass = {
-    audio: "border-emerald-400/60 bg-emerald-400/20 text-emerald-100",
-    take: "border-emerald-400/60 bg-emerald-400/20 text-emerald-100",
-    recording: "border-red-400/70 bg-red-400/20 text-red-100",
+    audio: "bg-emerald-400/20 text-emerald-100",
+    take: "bg-emerald-400/20 text-emerald-100",
+    recording: "bg-red-400/20 text-red-100",
+  }[clip.variant];
+  const clipBorderClass = {
+    audio: "border-emerald-400/60",
+    take: "border-emerald-400/60",
+    recording: "border-red-400/70",
   }[clip.variant];
   const clipStartBeat = secondsToBeats(clip.offset, tempo);
   const clipWidth = Math.max(
@@ -521,14 +529,16 @@ function TimelineClip({
       data-selected={selected ? "true" : undefined}
       ref={onClipDragMove ? dragRef : undefined}
       className={cn(
-        "absolute inset-y-1 rounded-sm border text-[11px]",
+        "absolute inset-y-1 rounded-sm text-[11px]",
+        !overlayBorder && "border",
         interactionOnly
           ? "border-transparent bg-transparent text-transparent"
           : clipClass,
+        !interactionOnly && !overlayBorder && clipBorderClass,
         onClipDragMove && "cursor-ew-resize select-none",
         onClipDragStart && "cursor-pointer",
         joinsPrevious && "rounded-l-none",
-        joinsNext && "rounded-r-none border-r-transparent",
+        joinsNext && "rounded-r-none",
         selected && "border-sky-300 ring-1 ring-inset ring-sky-300",
         isDragging &&
           (interactionOnly
@@ -560,6 +570,15 @@ function TimelineClip({
             )}
           </div>
         </div>
+      )}
+      {overlayBorder && (
+        <div
+          className={cn(
+            "pointer-events-none absolute inset-0 rounded-[inherit] border",
+            clipBorderClass,
+            joinsNext && "border-r-0",
+          )}
+        />
       )}
       {onTrimStart && (
         <div

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -369,12 +369,16 @@ export class RecorderRuntime {
         ? { ...track, clip: undefined, trimStart: 0, trimEnd: 0 }
         : track,
     );
-    const recordingTrack = {
-      ...state.recordingTrack,
-      takes: state.recordingTrack.takes.filter((take) => !takeIds.has(take.id)),
-    };
     if (takeIds.size > 0) {
-      this.updateRecordingTrack({ recordingTrack, audioTracks });
+      this.updateRecordingTrack({
+        audioTracks,
+        recordingTrack: {
+          ...state.recordingTrack,
+          takes: state.recordingTrack.takes.filter(
+            (take) => !takeIds.has(take.id),
+          ),
+        },
+      });
     } else {
       this.store.update({ audioTracks });
     }

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -70,6 +70,7 @@ export interface RecorderRuntimeState {
   // Tracks
   audioTracks: AudioTrackState[];
   recordingTrack: RecordingTrackState;
+  takeRegions: TakeRegion[];
   pendingRecording?: PendingRecordingState;
   // Capture
   captureStatus: CaptureStatus;
@@ -109,6 +110,7 @@ export function createDefaultRecorderRuntimeState(): RecorderRuntimeState {
     metronomeEnabled: false,
     audioTracks: [],
     recordingTrack: createRecordingTrackState(),
+    takeRegions: [],
     captureStatus: "disabled",
     inputChannelCount: 0,
     selectedChannel: 0,
@@ -124,7 +126,6 @@ export class RecorderRuntime {
   captureInput?: CaptureInput;
   private audioTrackPlaybacks = new Map<string, AudioBufferPlayback>();
   private recordingTrackPlaybacks: AudioBufferPlayback[] = [];
-  private takeRegions: TakeRegion[] = [];
   private metronome?: RecorderMetronome;
 
   async startInput({
@@ -277,14 +278,15 @@ export class RecorderRuntime {
         timelineOffset: takeOffsets.get(take.id) ?? take.timelineOffset,
       })),
     };
-    this.store.update({ audioTracks, recordingTrack });
+    if (takeOffsets.size > 0) {
+      this.updateRecordingTrack({ recordingTrack, audioTracks });
+    } else {
+      this.store.update({ audioTracks });
+    }
     for (const id of audioOffsets.keys()) {
       this.syncAudioTrackPlayback(
         audioTracks.find((track) => track.id === id)!,
       );
-    }
-    if (takeOffsets.size > 0) {
-      this.syncTakeRegions();
     }
     if (wasPlaying) {
       this.transport!.play();
@@ -362,21 +364,19 @@ export class RecorderRuntime {
       playback?.stop();
       playback?.setBuffer(undefined);
     }
-    this.store.update({
-      audioTracks: state.audioTracks.map((track) =>
-        audioIds.has(track.id)
-          ? { ...track, clip: undefined, trimStart: 0, trimEnd: 0 }
-          : track,
-      ),
-      recordingTrack: {
-        ...state.recordingTrack,
-        takes: state.recordingTrack.takes.filter(
-          (take) => !takeIds.has(take.id),
-        ),
-      },
-    });
+    const audioTracks = state.audioTracks.map((track) =>
+      audioIds.has(track.id)
+        ? { ...track, clip: undefined, trimStart: 0, trimEnd: 0 }
+        : track,
+    );
+    const recordingTrack = {
+      ...state.recordingTrack,
+      takes: state.recordingTrack.takes.filter((take) => !takeIds.has(take.id)),
+    };
     if (takeIds.size > 0) {
-      this.syncTakeRegions();
+      this.updateRecordingTrack({ recordingTrack, audioTracks });
+    } else {
+      this.store.update({ audioTracks });
     }
     if (wasPlaying) {
       this.transport!.play();
@@ -510,13 +510,12 @@ export class RecorderRuntime {
       this.pause();
     }
     const recordingTrack = this.store.get().recordingTrack;
-    this.store.update({
+    this.updateRecordingTrack({
       recordingTrack: {
         ...recordingTrack,
         takes: updateFn(recordingTrack.takes),
       },
     });
-    this.syncTakeRegions();
     if (wasPlaying) {
       this.transport!.play();
     }
@@ -611,7 +610,7 @@ export class RecorderRuntime {
   renderComp(): AudioBuffer | undefined {
     return renderTakeComp({
       context: this.ensureContext(),
-      regions: this.takeRegions,
+      regions: this.store.get().takeRegions,
       takes: this.store.get().recordingTrack.takes,
     });
   }
@@ -663,7 +662,7 @@ export class RecorderRuntime {
     }
     // Clamp loaded external state at the runtime boundary so older projects
     // cannot restore a Capture row too short for its current controls.
-    this.store.update({
+    this.updateRecordingTrack({
       ...project,
       position: 0,
       recordingTrack: {
@@ -674,7 +673,6 @@ export class RecorderRuntime {
     this.transport!.seek(0);
     this.metronome!.setTempo(project.tempo);
     this.metronome!.setTimeSignature(project.timeSignature);
-    this.syncTakeRegions();
     this.syncTrackMix();
   }
 
@@ -754,7 +752,7 @@ export class RecorderRuntime {
     );
     takeBuffer.getChannelData(0).set(samples);
     const recordingTrack = this.store.get().recordingTrack;
-    this.store.update({
+    this.updateRecordingTrack({
       captureStatus: "ready",
       pendingRecording: undefined,
       recordingTrack: {
@@ -779,7 +777,6 @@ export class RecorderRuntime {
         ],
       },
     });
-    this.syncTakeRegions();
   }
 
   private closeInput(): void {
@@ -787,15 +784,29 @@ export class RecorderRuntime {
     this.captureInput = undefined;
   }
 
-  private syncTakeRegions(): void {
+  private updateRecordingTrack(
+    update: Partial<RecorderRuntimeState> &
+      Pick<RecorderRuntimeState, "recordingTrack">,
+  ): void {
+    const { recordingTrack } = update;
+    const takeRegions = deriveTakeRegions(recordingTrack.takes);
+    this.store.update({ ...update, takeRegions });
+    this.syncTakePlayback({ takes: recordingTrack.takes, takeRegions });
+  }
+
+  private syncTakePlayback({
+    takes,
+    takeRegions,
+  }: {
+    takes: TakeState[];
+    takeRegions: TakeRegion[];
+  }): void {
     const context = this.ensureContext();
-    const takes = this.store.get().recordingTrack.takes;
-    this.takeRegions = deriveTakeRegions(takes);
     for (const playback of this.recordingTrackPlaybacks) {
       playback.dispose();
     }
     this.recordingTrackPlaybacks = [];
-    for (const region of this.takeRegions) {
+    for (const region of takeRegions) {
       const take = takes.find((entry) => entry.id === region.takeId);
       if (!take?.buffer) {
         continue;


### PR DESCRIPTION
- explain diff: https://gisthost.github.io/?5ed24c523ed3a3e7b154c9ecb892feec/toy-midi-pr-381-explain-diff.html
- part of https://github.com/hi-ogawa/toy-midi/issues/364
- supersedes https://github.com/hi-ogawa/toy-midi/pull/380

Transparent overlapping source takes make the Capture lane look like a mix, but making the derived comp regions interactive causes the element owning a drag to change or disappear as takes cross.

This PR separates those responsibilities. Pointer-transparent derived regions render only the newest-take-wins waveform with translucent styling, while stable source-take elements retain selection, dragging, trimming, and pointer capture.