### PR TITLE
refactor: remove redundant take clip wrappers

### DIFF
--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -231,29 +231,28 @@ export function TakeTimelineLane({
         </div>
       )}
       {takes.map((take) => (
-        <div key={take.id}>
-          <TimelineClip
-            clip={{
-              label: `Take ${take.number}`,
-              duration: take.trimEnd - take.trimStart,
-              offset: take.timelineOffset + take.trimStart,
-              audioDuration: take.duration,
-              audioOffset: take.trimStart,
-              variant: "take",
-              audioView: take.audioView,
-            }}
-            pixelsPerBeat={pixelsPerBeat}
-            viewportStartBeat={viewportStartBeat}
-            tempo={tempo}
-            viewportWidth={viewportWidth}
-            onClipDragStart={(additive) => onTakeDragStart(take.id, additive)}
-            onClipClick={(additive) => onTakeClick(take.id, additive)}
-            onClipDragMove={onTakeDragMove}
-            onTrimStart={(edge) => onTakeTrimStart(take.id, edge)}
-            onTrimMove={onTakeTrimMove}
-            selected={isTakeSelected(take.id)}
-          />
-        </div>
+        <TimelineClip
+          key={take.id}
+          clip={{
+            label: `Take ${take.number}`,
+            duration: take.trimEnd - take.trimStart,
+            offset: take.timelineOffset + take.trimStart,
+            audioDuration: take.duration,
+            audioOffset: take.trimStart,
+            variant: "take",
+            audioView: take.audioView,
+          }}
+          pixelsPerBeat={pixelsPerBeat}
+          viewportStartBeat={viewportStartBeat}
+          tempo={tempo}
+          viewportWidth={viewportWidth}
+          onClipDragStart={(additive) => onTakeDragStart(take.id, additive)}
+          onClipClick={(additive) => onTakeClick(take.id, additive)}
+          onClipDragMove={onTakeDragMove}
+          onTrimStart={(edge) => onTakeTrimStart(take.id, edge)}
+          onTrimMove={onTakeTrimMove}
+          selected={isTakeSelected(take.id)}
+        />
       ))}
       {pendingRecording && (
         <div>


### PR DESCRIPTION
Take timeline clips are already absolutely positioned relative to the lane, so the per-take wrapper elements do not affect their layout. This PR removes those redundant wrappers and moves each React key onto the clip itself.