### PR TITLE
feat: show recorder waveform during capture

### DIFF
--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -265,6 +265,7 @@ export function TakeTimelineLane({
                   : "Recording...",
               offset: pendingRecording.timelineOffset,
               variant: "recording",
+              audioView: pendingRecording.audioView,
             }}
             pixelsPerBeat={pixelsPerBeat}
             viewportStartBeat={viewportStartBeat}

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -302,7 +302,7 @@ export function TakeTimelineLane({
                   : "Recording...",
               offset: pendingRecording.timelineOffset,
               variant: "recording",
-              audioView: pendingRecording.audioView,
+              audioView: pendingRecording.recording.getAudioView(),
             }}
             pixelsPerBeat={pixelsPerBeat}
             viewportStartBeat={viewportStartBeat}

--- a/src/lib/audio-view.ts
+++ b/src/lib/audio-view.ts
@@ -38,8 +38,7 @@ export class AudioViewBuilder {
     const { data, samplesPerPoint } = this.view;
     for (let i = 0; i < samples.length; i++) {
       const point = Math.floor((frameOffset + i) / samplesPerPoint);
-      const abs = Math.abs(samples[i]);
-      data[point] = Math.max(data[point] ?? 0, abs);
+      data[point] = Math.max(data[point] ?? 0, Math.abs(samples[i]));
     }
   }
 

--- a/src/lib/audio-view.ts
+++ b/src/lib/audio-view.ts
@@ -20,6 +20,50 @@ export interface AudioViewSlice {
   actualEnd: number; // actual end time in seconds (aligned to data boundaries)
 }
 
+export class AudioViewBuilder {
+  readonly view: AudioView;
+
+  constructor(sampleRate: number, targetPointsPerSecond: number) {
+    this.view = {
+      data: [],
+      samplesPerPoint: Math.floor(sampleRate / targetPointsPerSecond),
+      sampleRate,
+    };
+  }
+
+  append(samples: Float32Array, frameOffset: number): void {
+    if (samples.length === 0 || this.view.samplesPerPoint <= 0) {
+      return;
+    }
+    const sourceStart = Math.max(0, -frameOffset);
+    const targetStart = Math.max(0, frameOffset);
+    const length = samples.length - sourceStart;
+    if (length <= 0) {
+      return;
+    }
+    const { data, samplesPerPoint } = this.view;
+    const end = targetStart + length;
+    for (let offset = targetStart; offset < end; offset++) {
+      const point = Math.floor(offset / samplesPerPoint);
+      const abs = Math.abs(samples[sourceStart + offset - targetStart]);
+      data[point] = Math.max(data[point] ?? 0, abs);
+    }
+  }
+
+  finish(length: number): AudioView {
+    if (this.view.samplesPerPoint <= 0 || length <= 0) {
+      this.view.data.length = 0;
+      return this.view;
+    }
+    this.view.data.length = Math.ceil(length / this.view.samplesPerPoint);
+    return this.view;
+  }
+
+  reset(): void {
+    this.view.data.length = 0;
+  }
+}
+
 // Build AudioView from raw samples
 export function createAudioView(
   samples: Float32Array,
@@ -30,26 +74,12 @@ export function createAudioView(
     return EMPTY_AUDIO_VIEW;
   }
 
-  const samplesPerPoint = Math.floor(sampleRate / targetPointsPerSecond);
-  if (samplesPerPoint <= 0) {
+  const builder = new AudioViewBuilder(sampleRate, targetPointsPerSecond);
+  if (builder.view.samplesPerPoint <= 0) {
     return EMPTY_AUDIO_VIEW;
   }
-
-  const data: number[] = [];
-
-  for (let i = 0; i < samples.length; i += samplesPerPoint) {
-    let max = 0;
-    const end = Math.min(i + samplesPerPoint, samples.length);
-    for (let j = i; j < end; j++) {
-      const abs = Math.abs(samples[j]);
-      if (abs > max) {
-        max = abs;
-      }
-    }
-    data.push(max);
-  }
-
-  return { data, samplesPerPoint, sampleRate };
+  builder.append(samples, 0);
+  return builder.finish(samples.length);
 }
 
 // Query visible range, downsample to pixel width

--- a/src/lib/audio-view.ts
+++ b/src/lib/audio-view.ts
@@ -36,10 +36,9 @@ export class AudioViewBuilder {
       return;
     }
     const { data, samplesPerPoint } = this.view;
-    const end = frameOffset + samples.length;
-    for (let offset = frameOffset; offset < end; offset++) {
-      const point = Math.floor(offset / samplesPerPoint);
-      const abs = Math.abs(samples[offset - frameOffset]);
+    for (let i = 0; i < samples.length; i++) {
+      const point = Math.floor((frameOffset + i) / samplesPerPoint);
+      const abs = Math.abs(samples[i]);
       data[point] = Math.max(data[point] ?? 0, abs);
     }
   }

--- a/src/lib/audio-view.ts
+++ b/src/lib/audio-view.ts
@@ -35,13 +35,6 @@ export class AudioViewBuilder {
     if (samples.length === 0 || this.view.samplesPerPoint <= 0) {
       return;
     }
-    if (frameOffset < 0) {
-      samples = samples.subarray(-frameOffset);
-      frameOffset = 0;
-    }
-    if (samples.length === 0) {
-      return;
-    }
     const { data, samplesPerPoint } = this.view;
     const end = frameOffset + samples.length;
     for (let offset = frameOffset; offset < end; offset++) {

--- a/src/lib/audio-view.ts
+++ b/src/lib/audio-view.ts
@@ -35,17 +35,18 @@ export class AudioViewBuilder {
     if (samples.length === 0 || this.view.samplesPerPoint <= 0) {
       return;
     }
-    const sourceStart = Math.max(0, -frameOffset);
-    const targetStart = Math.max(0, frameOffset);
-    const length = samples.length - sourceStart;
-    if (length <= 0) {
+    if (frameOffset < 0) {
+      samples = samples.subarray(-frameOffset);
+      frameOffset = 0;
+    }
+    if (samples.length === 0) {
       return;
     }
     const { data, samplesPerPoint } = this.view;
-    const end = targetStart + length;
-    for (let offset = targetStart; offset < end; offset++) {
+    const end = frameOffset + samples.length;
+    for (let offset = frameOffset; offset < end; offset++) {
       const point = Math.floor(offset / samplesPerPoint);
-      const abs = Math.abs(samples[sourceStart + offset - targetStart]);
+      const abs = Math.abs(samples[offset - frameOffset]);
       data[point] = Math.max(data[point] ?? 0, abs);
     }
   }

--- a/src/lib/audio-view.ts
+++ b/src/lib/audio-view.ts
@@ -42,14 +42,6 @@ export class AudioViewBuilder {
     }
   }
 
-  finish(length: number): void {
-    if (this.view.samplesPerPoint <= 0 || length <= 0) {
-      this.view.data.length = 0;
-      return;
-    }
-    this.view.data.length = Math.ceil(length / this.view.samplesPerPoint);
-  }
-
   reset(): void {
     this.view.data.length = 0;
   }
@@ -70,7 +62,6 @@ export function createAudioView(
     return EMPTY_AUDIO_VIEW;
   }
   builder.append(samples, 0);
-  builder.finish(samples.length);
   return builder.view;
 }
 

--- a/src/lib/audio-view.ts
+++ b/src/lib/audio-view.ts
@@ -42,13 +42,12 @@ export class AudioViewBuilder {
     }
   }
 
-  finish(length: number): AudioView {
+  finish(length: number): void {
     if (this.view.samplesPerPoint <= 0 || length <= 0) {
       this.view.data.length = 0;
-      return this.view;
+      return;
     }
     this.view.data.length = Math.ceil(length / this.view.samplesPerPoint);
-    return this.view;
   }
 
   reset(): void {
@@ -71,7 +70,8 @@ export function createAudioView(
     return EMPTY_AUDIO_VIEW;
   }
   builder.append(samples, 0);
-  return builder.finish(samples.length);
+  builder.finish(samples.length);
+  return builder.view;
 }
 
 // Query visible range, downsample to pixel width

--- a/src/lib/recorder/recording.ts
+++ b/src/lib/recorder/recording.ts
@@ -25,6 +25,7 @@ export class ActiveRecording {
   }
 
   append(chunk: CaptureChunk): void {
+    // Capture can begin before the transport-derived recording start.
     if (chunk.frameStart < this.startFrame) {
       const sampleOffset = this.startFrame - chunk.frameStart;
       chunk = {

--- a/src/lib/recorder/recording.ts
+++ b/src/lib/recorder/recording.ts
@@ -26,12 +26,10 @@ export class ActiveRecording {
 
   append(chunk: CaptureChunk): void {
     this.chunks.push(chunk);
-    const frameOffset = chunk.frameStart - this.startFrame;
-    if (frameOffset < this.getDurationFrames()) {
-      this.rebuildAudioViewWithPcm();
-    } else {
-      this.audioViewBuilder.append(chunk.samples, frameOffset);
-    }
+    this.audioViewBuilder.append(
+      chunk.samples,
+      chunk.frameStart - this.startFrame,
+    );
     this.endFrame = Math.max(
       this.endFrame,
       chunk.frameStart + chunk.samples.length,
@@ -67,20 +65,6 @@ export class ActiveRecording {
     this.audioViewBuilder.append(samples, 0);
     this.audioViewBuilder.finish(length);
     return samples;
-  }
-
-  private rebuildAudioViewWithPcm(stopFrame = this.endFrame): void {
-    const length = Math.max(0, stopFrame - this.startFrame);
-    const samples = new Float32Array(length);
-    for (const chunk of this.chunks) {
-      setArrayClipped(
-        samples,
-        chunk.samples,
-        chunk.frameStart - this.startFrame,
-      );
-    }
-    this.audioViewBuilder.reset();
-    this.audioViewBuilder.append(samples, 0);
   }
 }
 

--- a/src/lib/recorder/recording.ts
+++ b/src/lib/recorder/recording.ts
@@ -25,6 +25,17 @@ export class ActiveRecording {
   }
 
   append(chunk: CaptureChunk): void {
+    if (chunk.frameStart < this.startFrame) {
+      const sampleOffset = this.startFrame - chunk.frameStart;
+      chunk = {
+        ...chunk,
+        frameStart: this.startFrame,
+        samples: chunk.samples.subarray(sampleOffset),
+      };
+    }
+    if (chunk.samples.length === 0) {
+      return;
+    }
     this.chunks.push(chunk);
     this.audioViewBuilder.append(
       chunk.samples,

--- a/src/lib/recorder/recording.ts
+++ b/src/lib/recorder/recording.ts
@@ -71,7 +71,6 @@ export class ActiveRecording {
     }
     this.audioViewBuilder.reset();
     this.audioViewBuilder.append(samples, 0);
-    this.audioViewBuilder.finish(length);
     return samples;
   }
 }

--- a/src/lib/recorder/recording.ts
+++ b/src/lib/recorder/recording.ts
@@ -1,21 +1,45 @@
+import { AudioViewBuilder, type AudioView } from "../audio-view.ts";
 import type { CaptureChunk } from "./capture-worklet.ts";
 
 export class ActiveRecording {
   private readonly chunks: CaptureChunk[] = [];
+  private readonly audioViewBuilder: AudioViewBuilder;
   private readonly startFrame: number;
   private endFrame: number;
 
-  constructor(startFrame: number) {
+  constructor({
+    startFrame,
+    sampleRate,
+    waveformPointsPerSecond,
+  }: {
+    startFrame: number;
+    sampleRate: number;
+    waveformPointsPerSecond: number;
+  }) {
     this.startFrame = startFrame;
     this.endFrame = startFrame;
+    this.audioViewBuilder = new AudioViewBuilder(
+      sampleRate,
+      waveformPointsPerSecond,
+    );
   }
 
   append(chunk: CaptureChunk): void {
     this.chunks.push(chunk);
+    const frameOffset = chunk.frameStart - this.startFrame;
+    if (frameOffset < this.getDurationFrames()) {
+      this.rebuildAudioViewWithPcm();
+    } else {
+      this.audioViewBuilder.append(chunk.samples, frameOffset);
+    }
     this.endFrame = Math.max(
       this.endFrame,
       chunk.frameStart + chunk.samples.length,
     );
+  }
+
+  getAudioView(): AudioView {
+    return this.audioViewBuilder.view;
   }
 
   getDurationFrames(): number {
@@ -39,7 +63,24 @@ export class ActiveRecording {
         chunk.frameStart - this.startFrame,
       );
     }
+    this.audioViewBuilder.reset();
+    this.audioViewBuilder.append(samples, 0);
+    this.audioViewBuilder.finish(length);
     return samples;
+  }
+
+  private rebuildAudioViewWithPcm(stopFrame = this.endFrame): void {
+    const length = Math.max(0, stopFrame - this.startFrame);
+    const samples = new Float32Array(length);
+    for (const chunk of this.chunks) {
+      setArrayClipped(
+        samples,
+        chunk.samples,
+        chunk.frameStart - this.startFrame,
+      );
+    }
+    this.audioViewBuilder.reset();
+    this.audioViewBuilder.append(samples, 0);
   }
 }
 

--- a/src/lib/recorder/recording.ts
+++ b/src/lib/recorder/recording.ts
@@ -29,13 +29,9 @@ export class ActiveRecording {
     if (chunk.frameStart < this.startFrame) {
       const sampleOffset = this.startFrame - chunk.frameStart;
       chunk = {
-        ...chunk,
         frameStart: this.startFrame,
         samples: chunk.samples.subarray(sampleOffset),
       };
-    }
-    if (chunk.samples.length === 0) {
-      return;
     }
     this.chunks.push(chunk);
     this.audioViewBuilder.append(

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -563,17 +563,16 @@ export class RecorderRuntime {
       ) - this.store.get().latencyCompensation;
     const id = crypto.randomUUID();
     const number = this.store.get().recordingTrack.nextTakeNumber;
-    const recording = new ActiveRecording({
-      startFrame,
-      sampleRate: context.sampleRate,
-      waveformPointsPerSecond: WAVEFORM_POINTS_PER_SECOND,
-    });
     const pendingRecording: PendingRecordingState = {
       id,
       number,
       duration: 0,
       timelineOffset,
-      recording,
+      recording: new ActiveRecording({
+        startFrame,
+        sampleRate: context.sampleRate,
+        waveformPointsPerSecond: WAVEFORM_POINTS_PER_SECOND,
+      }),
     };
     this.store.update({
       captureStatus: "recording",

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -57,6 +57,7 @@ interface PendingRecordingState extends Pick<
   "id" | "number" | "duration" | "timelineOffset"
 > {
   recording: ActiveRecording;
+  audioView: AudioView;
 }
 
 export interface RecorderRuntimeState {
@@ -560,12 +561,18 @@ export class RecorderRuntime {
       ) - this.store.get().latencyCompensation;
     const id = crypto.randomUUID();
     const number = this.store.get().recordingTrack.nextTakeNumber;
+    const recording = new ActiveRecording({
+      startFrame,
+      sampleRate: context.sampleRate,
+      waveformPointsPerSecond: WAVEFORM_POINTS_PER_SECOND,
+    });
     const pendingRecording: PendingRecordingState = {
       id,
       number,
       duration: 0,
       timelineOffset,
-      recording: new ActiveRecording(startFrame),
+      recording,
+      audioView: recording.getAudioView(),
     };
     this.store.update({
       captureStatus: "recording",
@@ -770,11 +777,7 @@ export class RecorderRuntime {
             trimStart: 0,
             trimEnd: takeBuffer.duration,
             timelineOffset: pendingRecording.timelineOffset,
-            audioView: createAudioView(
-              samples,
-              context.sampleRate,
-              WAVEFORM_POINTS_PER_SECOND,
-            ),
+            audioView: pendingRecording.audioView,
           },
         ],
       },

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -57,7 +57,6 @@ interface PendingRecordingState extends Pick<
   "id" | "number" | "duration" | "timelineOffset"
 > {
   recording: ActiveRecording;
-  audioView: AudioView;
 }
 
 export interface RecorderRuntimeState {
@@ -575,7 +574,6 @@ export class RecorderRuntime {
       duration: 0,
       timelineOffset,
       recording,
-      audioView: recording.getAudioView(),
     };
     this.store.update({
       captureStatus: "recording",
@@ -778,7 +776,7 @@ export class RecorderRuntime {
             trimStart: 0,
             trimEnd: takeBuffer.duration,
             timelineOffset: pendingRecording.timelineOffset,
-            audioView: pendingRecording.audioView,
+            audioView: pendingRecording.recording.getAudioView(),
           },
         ],
       },


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/toy-midi/issues/382
- [interactive explain-diff](https://gisthost.github.io/?c266dc27237e70e2cfd6f28f5e16412b/toy-midi-pr-384-explain-diff.html)

The pending recorder clip previously showed no waveform because waveform extraction only ran after capture stopped.

This PR adds an incremental `AudioViewBuilder`, feeds retained capture chunks into it using recording-relative frame offsets, and exposes its stable view through the pending recording state. Overlapping or out-of-order chunks rebuild from retained PCM to preserve replacement semantics, and finalization reuses the same view after applying the exact stop boundary.