### PR TITLE
refactor: retain take source in comp regions

### DIFF
--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -211,8 +211,6 @@ export function TakeTimelineLane({
   ) => RecorderClipTrimSnapshot;
   onTakeTrimMove: (snapshot: RecorderClipTrimSnapshot, delta: number) => void;
 }) {
-  const takeById = new Map(takes.map((take) => [take.id, take]));
-
   return (
     <div
       className="relative overflow-hidden bg-neutral-900"
@@ -238,7 +236,7 @@ export function TakeTimelineLane({
       )}
       <div className="pointer-events-none absolute inset-0">
         {regions.map((region, index) => {
-          const take = takeById.get(region.takeId)!;
+          const { take } = region;
           const audioOffset = region.timelineStart - take.timelineOffset;
           const previous = regions[index - 1];
           const next = regions[index + 1];
@@ -252,7 +250,7 @@ export function TakeTimelineLane({
               TIMELINE_EPSILON;
           return (
             <TimelineClip
-              key={`${region.takeId}:${index}`}
+              key={`${take.id}:${index}`}
               clip={{
                 label: `Take ${take.number}`,
                 duration: region.timelineEnd - region.timelineStart,

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -615,7 +615,6 @@ export class RecorderRuntime {
     return renderTakeComp({
       context: this.ensureContext(),
       regions: this.store.get().takeRegions,
-      takes: this.store.get().recordingTrack.takes,
     });
   }
 
@@ -795,24 +794,18 @@ export class RecorderRuntime {
     const { recordingTrack } = update;
     const takeRegions = deriveTakeRegions(recordingTrack.takes);
     this.store.update({ ...update, takeRegions });
-    this.syncTakePlayback({ takes: recordingTrack.takes, takeRegions });
+    this.syncTakePlayback(takeRegions);
   }
 
-  private syncTakePlayback({
-    takes,
-    takeRegions,
-  }: {
-    takes: TakeState[];
-    takeRegions: TakeRegion[];
-  }): void {
+  private syncTakePlayback(takeRegions: TakeRegion[]): void {
     const context = this.ensureContext();
     for (const playback of this.recordingTrackPlaybacks) {
       playback.dispose();
     }
     this.recordingTrackPlaybacks = [];
     for (const region of takeRegions) {
-      const take = takes.find((entry) => entry.id === region.takeId);
-      if (!take?.buffer) {
+      const { take } = region;
+      if (!take.buffer) {
         continue;
       }
       const playback = new AudioBufferPlayback({

--- a/src/lib/recorder/take-comp.test.ts
+++ b/src/lib/recorder/take-comp.test.ts
@@ -29,7 +29,6 @@ describe(renderTakeComp, () => {
     const result = renderTakeComp({
       context,
       regions: deriveTakeRegions(takes),
-      takes,
     });
 
     expect(Array.from(result!.getChannelData(0))).toEqual([
@@ -52,7 +51,6 @@ describe(renderTakeComp, () => {
     const result = renderTakeComp({
       context: createContext(4),
       regions: deriveTakeRegions(takes),
-      takes,
     });
 
     expect(Array.from(result!.getChannelData(0))).toEqual([0, 0.5, 1, 1]);
@@ -73,7 +71,6 @@ describe(renderTakeComp, () => {
     const result = renderTakeComp({
       context: createContext(2),
       regions: deriveTakeRegions(takes),
-      takes,
     });
 
     expect(Array.from(result!.getChannelData(0))).toEqual([0, 0, 1, 1]);

--- a/src/lib/recorder/take-comp.ts
+++ b/src/lib/recorder/take-comp.ts
@@ -1,13 +1,11 @@
-import type { TakeRegion, TakeState } from "./take.ts";
+import type { TakeRegion } from "./take.ts";
 
 export function renderTakeComp({
   context,
   regions,
-  takes,
 }: {
   context: BaseAudioContext;
   regions: readonly TakeRegion[];
-  takes: readonly TakeState[];
 }): AudioBuffer | undefined {
   if (regions.length === 0) {
     return undefined;
@@ -24,8 +22,8 @@ export function renderTakeComp({
   );
   const output = buffer.getChannelData(0);
   for (const region of regions) {
-    const take = takes.find((entry) => entry.id === region.takeId);
-    if (!take?.buffer) {
+    const { take } = region;
+    if (!take.buffer) {
       continue;
     }
     const source = take.buffer.getChannelData(0);

--- a/src/lib/recorder/take-regions.test.ts
+++ b/src/lib/recorder/take-regions.test.ts
@@ -4,16 +4,16 @@ import type { TakeState } from "./take.ts";
 
 describe(deriveTakeRegions, () => {
   it("keeps disjoint takes in timeline order", () => {
-    expect(
-      deriveTakeRegions([take("first", 4, 2), take("second", 0, 2)]),
-    ).toEqual([
+    const first = take("first", 4, 2);
+    const second = take("second", 0, 2);
+    expect(deriveTakeRegions([first, second])).toEqual([
       {
-        takeId: "second",
+        take: second,
         timelineStart: 0,
         timelineEnd: 2,
       },
       {
-        takeId: "first",
+        take: first,
         timelineStart: 4,
         timelineEnd: 6,
       },
@@ -21,40 +21,47 @@ describe(deriveTakeRegions, () => {
   });
 
   it("lets a newer take replace the end of an older take", () => {
-    expect(deriveTakeRegions([take("old", 0, 5), take("new", 3, 4)])).toEqual([
-      { takeId: "old", timelineStart: 0, timelineEnd: 3 },
-      { takeId: "new", timelineStart: 3, timelineEnd: 7 },
+    const old = take("old", 0, 5);
+    const next = take("new", 3, 4);
+    expect(deriveTakeRegions([old, next])).toEqual([
+      { take: old, timelineStart: 0, timelineEnd: 3 },
+      { take: next, timelineStart: 3, timelineEnd: 7 },
     ]);
   });
 
   it("splits an older take around a contained newer take", () => {
-    expect(deriveTakeRegions([take("old", 0, 10), take("new", 3, 4)])).toEqual([
-      { takeId: "old", timelineStart: 0, timelineEnd: 3 },
-      { takeId: "new", timelineStart: 3, timelineEnd: 7 },
-      { takeId: "old", timelineStart: 7, timelineEnd: 10 },
+    const old = take("old", 0, 10);
+    const next = take("new", 3, 4);
+    expect(deriveTakeRegions([old, next])).toEqual([
+      { take: old, timelineStart: 0, timelineEnd: 3 },
+      { take: next, timelineStart: 3, timelineEnd: 7 },
+      { take: old, timelineStart: 7, timelineEnd: 10 },
     ]);
   });
 
   it("uses the newest take for equal ranges", () => {
-    expect(deriveTakeRegions([take("old", 1, 4), take("new", 1, 4)])).toEqual([
-      { takeId: "new", timelineStart: 1, timelineEnd: 5 },
+    const old = take("old", 1, 4);
+    const next = take("new", 1, 4);
+    expect(deriveTakeRegions([old, next])).toEqual([
+      { take: next, timelineStart: 1, timelineEnd: 5 },
     ]);
   });
 
   it("preserves negative timeline offsets", () => {
-    expect(deriveTakeRegions([take("old", -4, 6), take("new", -2, 3)])).toEqual(
-      [
-        { takeId: "old", timelineStart: -4, timelineEnd: -2 },
-        { takeId: "new", timelineStart: -2, timelineEnd: 1 },
-        { takeId: "old", timelineStart: 1, timelineEnd: 2 },
-      ],
-    );
+    const old = take("old", -4, 6);
+    const next = take("new", -2, 3);
+    expect(deriveTakeRegions([old, next])).toEqual([
+      { take: old, timelineStart: -4, timelineEnd: -2 },
+      { take: next, timelineStart: -2, timelineEnd: 1 },
+      { take: old, timelineStart: 1, timelineEnd: 2 },
+    ]);
   });
 
   it("uses the trimmed source interval on the timeline", () => {
-    expect(
-      deriveTakeRegions([{ ...take("take", 3, 6), trimStart: 1, trimEnd: 5 }]),
-    ).toEqual([{ takeId: "take", timelineStart: 4, timelineEnd: 8 }]);
+    const trimmed = { ...take("take", 3, 6), trimStart: 1, trimEnd: 5 };
+    expect(deriveTakeRegions([trimmed])).toEqual([
+      { take: trimmed, timelineStart: 4, timelineEnd: 8 },
+    ]);
   });
 });
 

--- a/src/lib/recorder/take-regions.ts
+++ b/src/lib/recorder/take-regions.ts
@@ -52,7 +52,7 @@ export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
     // The complete new take wins its own interval because all overlaps have
     // already been removed from older regions.
     nextRegions.push({
-      takeId: take.id,
+      take,
       timelineStart: takeStart,
       timelineEnd: takeEnd,
     });

--- a/src/lib/recorder/take.ts
+++ b/src/lib/recorder/take.ts
@@ -13,7 +13,7 @@ export interface TakeState {
 }
 
 export interface TakeRegion {
-  takeId: string;
+  take: TakeState;
   timelineStart: number;
   timelineEnd: number;
 }


### PR DESCRIPTION
- related https://github.com/hi-ogawa/toy-midi/issues/388

Comp-region derivation already has the source take, but consumers currently reconstruct that relationship through `takeId` lookups and non-null assumptions.

This PR retains the source `TakeState` directly on each derived region. Timeline rendering, playback setup, and comp export can then consume the region without rebuilding the association. This is a behavior-neutral refactor that prepares committed and provisional recording regions to share the same rendering contract.
