### PR TITLE
fix: synchronize waveform capture coverage

### DIFF
--- a/src/lib/audio-view.test.ts
+++ b/src/lib/audio-view.test.ts
@@ -3,6 +3,7 @@ import { range } from "../utils/array";
 import {
   type AudioView,
   type AudioViewSlice,
+  AudioViewBuilder,
   createAudioView,
   EMPTY_AUDIO_VIEW,
   queryAudioView,
@@ -74,6 +75,23 @@ describe("createAudioView", () => {
 
     expect(view.data).toHaveLength(3);
     expect(view.data[2]).toBeCloseTo(0.9);
+  });
+
+  it("fills missing frame ranges with silent points", () => {
+    const builder = new AudioViewBuilder(100, 10);
+
+    builder.append(new Float32Array([0.5]), 25);
+
+    expect(builder.view.data).toEqual([0, 0, 0.5]);
+    expect(Object.keys(builder.view.data)).toEqual(["0", "1", "2"]);
+  });
+
+  it("extends through the partial final point", () => {
+    const builder = new AudioViewBuilder(100, 10);
+
+    builder.append(new Float32Array(11).fill(0.5), 0);
+
+    expect(builder.view.data).toEqual([0.5, 0.5]);
   });
 
   it("produces correct number of points for typical audio", () => {

--- a/src/lib/audio-view.ts
+++ b/src/lib/audio-view.ts
@@ -36,9 +36,15 @@ export class AudioViewBuilder {
       return;
     }
     const { data, samplesPerPoint } = this.view;
+    const endPoint = Math.ceil(
+      (frameOffset + samples.length) / samplesPerPoint,
+    );
+    while (data.length < endPoint) {
+      data.push(0);
+    }
     for (let i = 0; i < samples.length; i++) {
       const point = Math.floor((frameOffset + i) / samplesPerPoint);
-      data[point] = Math.max(data[point] ?? 0, Math.abs(samples[i]));
+      data[point] = Math.max(data[point], Math.abs(samples[i]));
     }
   }
 


### PR DESCRIPTION
- related to https://github.com/hi-ogawa/toy-midi/issues/387

Live recording duration covers the full capture frame span, including missing ranges, but incremental waveform construction previously left skipped point indices sparse. Direct waveform queries could therefore expose holes instead of the zero-filled silence used when the take is finalized.

This PR extends `AudioView` densely through every appended chunk's frame end before applying peaks. Live waveform coverage now follows the same contiguous, zero-filled frame range as recording duration and final audio assembly.