### PR TITLE
fix: show recorder save tooltip promptly

### DIFF
--- a/e2e/fake-audio/recorder-persistence.test.ts
+++ b/e2e/fake-audio/recorder-persistence.test.ts
@@ -11,10 +11,13 @@ test("saves and restores a recorder project", async ({ page }) => {
   const saveButton = page.getByRole("button", { name: "All changes saved" });
   const saveTooltip = page.getByRole("tooltip");
   await expect(saveButton).not.toHaveAttribute("title");
+  await expect(saveTooltip).toHaveCSS("opacity", "0");
   await saveButton.hover();
-  await expect(saveTooltip).toBeVisible();
+  await expect(saveTooltip).toHaveCSS("opacity", "1");
+  await page.mouse.move(0, 0);
+  await expect(saveTooltip).toHaveCSS("opacity", "0");
   await saveButton.focus();
-  await expect(saveTooltip).toBeVisible();
+  await expect(saveTooltip).toHaveCSS("opacity", "1");
 
   // Transport updates are session state and do not stale persisted state.
   await page.getByTestId("recorder-play-button").click();

--- a/e2e/fake-audio/recorder-persistence.test.ts
+++ b/e2e/fake-audio/recorder-persistence.test.ts
@@ -8,6 +8,13 @@ test("saves and restores a recorder project", async ({ page }) => {
   await expect(
     page.getByRole("button", { name: "All changes saved" }),
   ).toHaveAttribute("aria-disabled", "true");
+  const saveButton = page.getByRole("button", { name: "All changes saved" });
+  const saveTooltip = page.getByRole("tooltip");
+  await expect(saveButton).not.toHaveAttribute("title");
+  await saveButton.hover();
+  await expect(saveTooltip).toBeVisible();
+  await saveButton.focus();
+  await expect(saveTooltip).toBeVisible();
 
   // Transport updates are session state and do not stale persisted state.
   await page.getByTestId("recorder-play-button").click();

--- a/src/components/recorder/recorder-header.tsx
+++ b/src/components/recorder/recorder-header.tsx
@@ -324,20 +324,29 @@ function RecorderSaveButton({
     error: <CircleAlertIcon className="size-3.5" />,
   }[status];
   return (
-    <Button
-      aria-label={label}
-      title={label}
-      aria-disabled={!canSave}
-      onClick={canSave ? onSave : undefined}
-      className={cn(
-        "size-8 border-transparent bg-transparent hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        status === "saved" && "text-neutral-500",
-        status === "unsaved" && "text-neutral-300",
-        status === "saving" && "text-neutral-400",
-        status === "error" && "text-red-400 hover:text-red-300",
-      )}
-    >
-      {icon}
-    </Button>
+    <div className="group/save relative">
+      <Button
+        aria-label={label}
+        aria-describedby="recorder-save-tooltip"
+        aria-disabled={!canSave}
+        onClick={canSave ? onSave : undefined}
+        className={cn(
+          "size-8 border-transparent bg-transparent hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+          status === "saved" && "text-neutral-500",
+          status === "unsaved" && "text-neutral-300",
+          status === "saving" && "text-neutral-400",
+          status === "error" && "text-red-400 hover:text-red-300",
+        )}
+      >
+        {icon}
+      </Button>
+      <span
+        id="recorder-save-tooltip"
+        role="tooltip"
+        className="pointer-events-none absolute top-full left-1/2 z-50 mt-2 -translate-x-1/2 rounded-md border border-neutral-700 bg-neutral-900 px-2 py-1 text-xs font-normal whitespace-nowrap text-neutral-100 opacity-0 shadow-lg transition-opacity delay-0 duration-100 group-focus-within/save:opacity-100 group-hover/save:delay-200 group-hover/save:opacity-100"
+      >
+        {label}
+      </span>
+    </div>
   );
 }

--- a/src/components/recorder/recorder-header.tsx
+++ b/src/components/recorder/recorder-header.tsx
@@ -343,7 +343,7 @@ function RecorderSaveButton({
       <span
         id="recorder-save-tooltip"
         role="tooltip"
-        className="pointer-events-none absolute top-full left-1/2 z-50 mt-2 -translate-x-1/2 rounded-md border border-neutral-700 bg-neutral-900 px-2 py-1 text-xs font-normal whitespace-nowrap text-neutral-100 opacity-0 shadow-lg transition-opacity delay-0 duration-100 group-focus-within/save:opacity-100 group-hover/save:delay-200 group-hover/save:opacity-100"
+        className="pointer-events-none absolute top-full left-1/2 z-50 mt-2 -translate-x-1/2 rounded-md border border-neutral-700 bg-neutral-900 px-2 py-1 text-xs font-normal whitespace-nowrap text-neutral-100 opacity-0 shadow-lg transition-opacity duration-200 group-focus-within/save:opacity-100 group-hover/save:opacity-100"
       >
         {label}
       </span>


### PR DESCRIPTION
The recorder save indicator communicates both persistence state and whether clicking it will save or retry, but its native title feedback is slow and platform-dependent.

This PR replaces the native title with a local status tooltip that appears after a short hover delay and immediately on keyboard focus, while preserving the existing accessible state labels.