### PR TITLE
fix: reduce capture arm emphasis

### DIFF
--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -249,11 +249,11 @@ export function CaptureTrackRow({
             onClick={onInputToggle}
             className={
               inputActive
-                ? "size-7 border-red-600 bg-red-700 text-white hover:bg-red-600"
+                ? "size-7 border-red-500/60 bg-red-500/25 text-red-300 hover:bg-red-500/35"
                 : "size-7 border-neutral-600 text-neutral-300 hover:bg-neutral-700"
             }
-            title={inputActive ? "Disable input" : "Enable input"}
-            aria-label={inputActive ? "Disable input" : "Enable input"}
+            title={inputActive ? "Disarm capture" : "Arm capture"}
+            aria-label={inputActive ? "Disarm capture" : "Arm capture"}
             aria-pressed={inputActive}
           >
             R


### PR DESCRIPTION
The Capture track's armed state currently uses the same solid red emphasis as active recording, so a persistent preparatory state competes with the transport record control.

This PR gives the armed R button a subdued translucent red treatment that matches the track M/S toggles while reserving solid red for recording in progress. It also labels the action as arm/disarm capture to distinguish it from recording itself.