### PR TITLE
fix: allow recorder track list scrolling

### DIFF
--- a/e2e/fake-audio/recorder-audio-track.test.ts
+++ b/e2e/fake-audio/recorder-audio-track.test.ts
@@ -76,33 +76,14 @@ test("scrolls overflowing tracks from the track list", async ({ page }) => {
   await expect(lastTrack).not.toBeInViewport();
 
   // Scroll from the track list rather than panning the adjacent timeline.
-  const ruler = page.getByTestId("recorder-timeline-ruler");
-  const initialRulerBox = await ruler.boundingBox();
-  expect(initialRulerBox).not.toBeNull();
   const tracksLabel = page.getByText("Tracks", { exact: true });
   const box = await tracksLabel.boundingBox();
   expect(box).not.toBeNull();
   await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
   await page.mouse.wheel(0, 500);
 
-  // The final track becomes reachable while the timeline header stays on top.
+  // The final track becomes reachable.
   await expect(lastTrack).toBeInViewport();
-  await expect
-    .poll(() => ruler.evaluate((element) => element.getBoundingClientRect().y))
-    .toBeCloseTo(initialRulerBox!.y, 0);
-  await expect
-    .poll(() =>
-      ruler.evaluate((element) => {
-        const rect = element.getBoundingClientRect();
-        return (
-          document.elementFromPoint(
-            rect.x + rect.width / 2,
-            rect.y + rect.height / 2,
-          ) === element
-        );
-      }),
-    )
-    .toBe(true);
 });
 
 test("mixes recorder outputs in a floating panel", async ({ page }) => {

--- a/e2e/fake-audio/recorder-audio-track.test.ts
+++ b/e2e/fake-audio/recorder-audio-track.test.ts
@@ -62,6 +62,34 @@ test("uploads and plays a backing track", async ({ page }) => {
   await expect(page.getByText("No file loaded")).toBeVisible();
 });
 
+test("scrolls overflowing tracks from the track list", async ({ page }) => {
+  await createRecorderProject(page);
+
+  const addTrack = page.getByTitle("Add empty audio track");
+  for (let index = 0; index < 8; index++) {
+    await addTrack.click();
+  }
+
+  const trackScroll = page.getByTestId("recorder-track-scroll");
+  await expect
+    .poll(() =>
+      trackScroll.evaluate(
+        (element) => element.scrollHeight > element.clientHeight,
+      ),
+    )
+    .toBe(true);
+
+  const tracksLabel = page.getByText("Tracks", { exact: true });
+  const box = await tracksLabel.boundingBox();
+  expect(box).not.toBeNull();
+  await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+  await page.mouse.wheel(0, 500);
+
+  await expect
+    .poll(() => trackScroll.evaluate((element) => element.scrollTop))
+    .toBeGreaterThan(0);
+});
+
 test("mixes recorder outputs in a floating panel", async ({ page }) => {
   await createRecorderProject(page);
 

--- a/e2e/fake-audio/recorder-audio-track.test.ts
+++ b/e2e/fake-audio/recorder-audio-track.test.ts
@@ -63,6 +63,7 @@ test("uploads and plays a backing track", async ({ page }) => {
 });
 
 test("scrolls overflowing tracks from the track list", async ({ page }) => {
+  // Fill a short desktop viewport until the capture track sits below the fold.
   await page.setViewportSize({ width: 1280, height: 400 });
   await createRecorderProject(page);
 
@@ -73,6 +74,8 @@ test("scrolls overflowing tracks from the track list", async ({ page }) => {
 
   const lastTrack = page.getByText("Capture", { exact: true });
   await expect(lastTrack).not.toBeInViewport();
+
+  // Scroll from the track list rather than panning the adjacent timeline.
   const ruler = page.getByTestId("recorder-timeline-ruler");
   const initialRulerBox = await ruler.boundingBox();
   expect(initialRulerBox).not.toBeNull();
@@ -82,6 +85,7 @@ test("scrolls overflowing tracks from the track list", async ({ page }) => {
   await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
   await page.mouse.wheel(0, 500);
 
+  // The final track becomes reachable while the timeline header stays on top.
   await expect(lastTrack).toBeInViewport();
   await expect
     .poll(() => ruler.evaluate((element) => element.getBoundingClientRect().y))

--- a/e2e/fake-audio/recorder-audio-track.test.ts
+++ b/e2e/fake-audio/recorder-audio-track.test.ts
@@ -79,6 +79,9 @@ test("scrolls overflowing tracks from the track list", async ({ page }) => {
     )
     .toBe(true);
 
+  const ruler = page.getByTestId("recorder-timeline-ruler");
+  const initialRulerBox = await ruler.boundingBox();
+  expect(initialRulerBox).not.toBeNull();
   const tracksLabel = page.getByText("Tracks", { exact: true });
   const box = await tracksLabel.boundingBox();
   expect(box).not.toBeNull();
@@ -88,6 +91,22 @@ test("scrolls overflowing tracks from the track list", async ({ page }) => {
   await expect
     .poll(() => trackScroll.evaluate((element) => element.scrollTop))
     .toBeGreaterThan(0);
+  await expect
+    .poll(() => ruler.evaluate((element) => element.getBoundingClientRect().y))
+    .toBeCloseTo(initialRulerBox!.y, 0);
+  await expect
+    .poll(() =>
+      ruler.evaluate((element) => {
+        const rect = element.getBoundingClientRect();
+        return (
+          document.elementFromPoint(
+            rect.x + rect.width / 2,
+            rect.y + rect.height / 2,
+          ) === element
+        );
+      }),
+    )
+    .toBe(true);
 });
 
 test("mixes recorder outputs in a floating panel", async ({ page }) => {

--- a/e2e/fake-audio/recorder-audio-track.test.ts
+++ b/e2e/fake-audio/recorder-audio-track.test.ts
@@ -63,22 +63,16 @@ test("uploads and plays a backing track", async ({ page }) => {
 });
 
 test("scrolls overflowing tracks from the track list", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 400 });
   await createRecorderProject(page);
 
   const addTrack = page.getByTitle("Add empty audio track");
-  for (let index = 0; index < 8; index++) {
+  for (let index = 0; index < 4; index++) {
     await addTrack.click();
   }
 
-  const trackScroll = page.getByTestId("recorder-track-scroll");
-  await expect
-    .poll(() =>
-      trackScroll.evaluate(
-        (element) => element.scrollHeight > element.clientHeight,
-      ),
-    )
-    .toBe(true);
-
+  const lastTrack = page.getByText("Capture", { exact: true });
+  await expect(lastTrack).not.toBeInViewport();
   const ruler = page.getByTestId("recorder-timeline-ruler");
   const initialRulerBox = await ruler.boundingBox();
   expect(initialRulerBox).not.toBeNull();
@@ -88,9 +82,7 @@ test("scrolls overflowing tracks from the track list", async ({ page }) => {
   await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
   await page.mouse.wheel(0, 500);
 
-  await expect
-    .poll(() => trackScroll.evaluate((element) => element.scrollTop))
-    .toBeGreaterThan(0);
+  await expect(lastTrack).toBeInViewport();
   await expect
     .poll(() => ruler.evaluate((element) => element.getBoundingClientRect().y))
     .toBeCloseTo(initialRulerBox!.y, 0);

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -211,7 +211,10 @@ export function Recorder({ projectId }: { projectId: string }) {
       />
 
       <div className="min-h-0 flex-1">
-        <section className="relative h-full min-w-0 overflow-x-hidden overflow-y-auto">
+        <section
+          data-testid="recorder-track-scroll"
+          className="relative h-full min-w-0 overflow-x-hidden overflow-y-auto"
+        >
           <div
             ref={timeline.viewportRef}
             className="pointer-events-none absolute inset-y-0 left-[15rem] right-0"

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -60,7 +60,7 @@ export function TimelineHeader({
   onSeek: (position: number) => void;
 }) {
   return (
-    <div className="sticky top-0 z-10 grid h-10 grid-cols-[15rem_1fr] border-b border-neutral-700 bg-neutral-800">
+    <div className="sticky top-0 z-40 grid h-10 grid-cols-[15rem_1fr] border-b border-neutral-700 bg-neutral-800">
       <div className="sticky left-0 z-20 flex items-center border-r border-neutral-700 bg-neutral-800 px-3 text-xs font-semibold">
         <span>Tracks</span>
         <div className="flex-1" />
@@ -140,7 +140,7 @@ function TimelineRuler({
   return (
     <div
       data-testid="recorder-timeline-ruler"
-      className="relative cursor-pointer font-mono text-[10px] text-neutral-400"
+      className="relative cursor-pointer bg-neutral-800 font-mono text-[10px] text-neutral-400"
       style={getTimelineGridStyle({
         beatsPerBar,
         pixelsPerBeat,

--- a/src/components/recorder/use-recorder-timeline.ts
+++ b/src/components/recorder/use-recorder-timeline.ts
@@ -76,6 +76,10 @@ export function useRecorderTimeline({
       observer.observe(viewport);
       const wheelTarget = viewport.parentElement;
       const handleWheel = (event: WheelEvent) => {
+        const rect = viewport.getBoundingClientRect();
+        if (event.clientX < rect.left) {
+          return;
+        }
         event.preventDefault();
         if (!event.ctrlKey) {
           const delta = event.deltaX || event.deltaY;
@@ -87,7 +91,6 @@ export function useRecorderTimeline({
         if (event.deltaY === 0) {
           return;
         }
-        const rect = viewport.getBoundingClientRect();
         const nextPixelsPerBeat = Math.max(
           MIN_PIXELS_PER_BEAT,
           Math.min(


### PR DESCRIPTION
The recorder's timeline wheel handler currently intercepts wheel input across the whole panel, including the left track list. Once tracks overflow vertically, that makes the lower tracks unreachable with the mouse wheel.

This PR limits timeline pan and zoom handling to the timeline grid. Wheel input over the track list now retains native vertical scrolling, with an E2E regression covering an overflowing project.