### PR TITLE
feat: seek recorder with arrow keys

### DIFF
--- a/e2e/fake-audio/recorder-keyboard.test.ts
+++ b/e2e/fake-audio/recorder-keyboard.test.ts
@@ -5,23 +5,7 @@ test("seeks the recorder by five seconds with arrow keys", async ({ page }) => {
   await createRecorderProject(page);
 
   const position = page.getByTestId("recorder-position");
-  for (let index = 0; index < 6; index++) {
-    await page.keyboard.press("ArrowRight");
-  }
-  const ruler = page.getByTestId("recorder-timeline-ruler");
-  const playhead = page.locator(".bg-sky-400");
-  const [rulerBox, playheadBox] = await Promise.all([
-    ruler.boundingBox(),
-    playhead.boundingBox(),
-  ]);
-  expect(rulerBox).not.toBeNull();
-  expect(playheadBox).not.toBeNull();
-  expect(playheadBox!.x).toBeGreaterThanOrEqual(rulerBox!.x);
-  expect(playheadBox!.x).toBeLessThanOrEqual(rulerBox!.x + rulerBox!.width);
-
-  for (let index = 0; index < 5; index++) {
-    await page.keyboard.press("ArrowLeft");
-  }
+  await page.keyboard.press("ArrowRight");
   await expect(position).toHaveText("03|03 - 00:05.000");
 
   await page.keyboard.press("ArrowLeft");

--- a/e2e/fake-audio/recorder-keyboard.test.ts
+++ b/e2e/fake-audio/recorder-keyboard.test.ts
@@ -4,6 +4,7 @@ import { createRecorderProject, enableInput } from "./recorder-helpers";
 test("seeks the recorder by five seconds with arrow keys", async ({ page }) => {
   await createRecorderProject(page);
 
+  // Plain arrows move in five-second steps and clamp at the timeline start.
   const position = page.getByTestId("recorder-position");
   await page.keyboard.press("ArrowRight");
   await expect(position).toHaveText("03|03 - 00:05.000");
@@ -13,19 +14,15 @@ test("seeks the recorder by five seconds with arrow keys", async ({ page }) => {
   await page.keyboard.press("ArrowLeft");
   await expect(position).toHaveText("01|01 - 00:00.000");
 
+  // Focused text controls retain their native arrow-key behavior.
   const tempoInput = page.getByTestId("recorder-tempo-input");
   await tempoInput.focus();
   await page.keyboard.press("ArrowRight");
   await expect(position).toHaveText("01|01 - 00:00.000");
-});
 
-test("keeps playing after seeking and ignores arrows while recording", async ({
-  page,
-}) => {
-  await createRecorderProject(page);
-
+  // Seeking during playback restarts participants and keeps the transport rolling.
+  await tempoInput.blur();
   const playButton = page.getByTestId("recorder-play-button");
-  const position = page.getByTestId("recorder-position");
   await playButton.click();
   await expect(playButton).toHaveAttribute("aria-pressed", "true");
   await page.keyboard.press("ArrowRight");
@@ -33,6 +30,7 @@ test("keeps playing after seeking and ignores arrows while recording", async ({
   await playButton.click();
   await expect(position).toContainText(/00:0[5-9]\.|00:[1-5]\d\./);
 
+  // Recording owns transport timing, so arrows cannot seek an active capture.
   await enableInput(page);
   const recordButton = page.getByTestId("recorder-record-button");
   await recordButton.click();

--- a/e2e/fake-audio/recorder-keyboard.test.ts
+++ b/e2e/fake-audio/recorder-keyboard.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+import { createRecorderProject, enableInput } from "./recorder-helpers";
+
+test("seeks the recorder by five seconds with arrow keys", async ({ page }) => {
+  await createRecorderProject(page);
+
+  const position = page.getByTestId("recorder-position");
+  for (let index = 0; index < 6; index++) {
+    await page.keyboard.press("ArrowRight");
+  }
+  const ruler = page.getByTestId("recorder-timeline-ruler");
+  const playhead = page.locator(".bg-sky-400");
+  const [rulerBox, playheadBox] = await Promise.all([
+    ruler.boundingBox(),
+    playhead.boundingBox(),
+  ]);
+  expect(rulerBox).not.toBeNull();
+  expect(playheadBox).not.toBeNull();
+  expect(playheadBox!.x).toBeGreaterThanOrEqual(rulerBox!.x);
+  expect(playheadBox!.x).toBeLessThanOrEqual(rulerBox!.x + rulerBox!.width);
+
+  for (let index = 0; index < 5; index++) {
+    await page.keyboard.press("ArrowLeft");
+  }
+  await expect(position).toHaveText("03|03 - 00:05.000");
+
+  await page.keyboard.press("ArrowLeft");
+  await expect(position).toHaveText("01|01 - 00:00.000");
+  await page.keyboard.press("ArrowLeft");
+  await expect(position).toHaveText("01|01 - 00:00.000");
+
+  const tempoInput = page.getByTestId("recorder-tempo-input");
+  await tempoInput.focus();
+  await page.keyboard.press("ArrowRight");
+  await expect(position).toHaveText("01|01 - 00:00.000");
+});
+
+test("keeps playing after seeking and ignores arrows while recording", async ({
+  page,
+}) => {
+  await createRecorderProject(page);
+
+  const playButton = page.getByTestId("recorder-play-button");
+  const position = page.getByTestId("recorder-position");
+  await playButton.click();
+  await expect(playButton).toHaveAttribute("aria-pressed", "true");
+  await page.keyboard.press("ArrowRight");
+  await expect(position).not.toHaveText("01|01 - 00:00.000");
+  await expect(playButton).toHaveAttribute("aria-pressed", "true");
+  await playButton.click();
+
+  await enableInput(page);
+  const recordButton = page.getByTestId("recorder-record-button");
+  await recordButton.click();
+  await expect(recordButton).toHaveAttribute("aria-pressed", "true");
+  await page.keyboard.press("ArrowRight");
+  await expect(position).not.toContainText("00:05.");
+  await recordButton.click();
+});

--- a/e2e/fake-audio/recorder-keyboard.test.ts
+++ b/e2e/fake-audio/recorder-keyboard.test.ts
@@ -29,9 +29,9 @@ test("keeps playing after seeking and ignores arrows while recording", async ({
   await playButton.click();
   await expect(playButton).toHaveAttribute("aria-pressed", "true");
   await page.keyboard.press("ArrowRight");
-  await expect(position).not.toHaveText("01|01 - 00:00.000");
   await expect(playButton).toHaveAttribute("aria-pressed", "true");
   await playButton.click();
+  await expect(position).toContainText(/00:0[5-9]\.|00:[1-5]\d\./);
 
   await enableInput(page);
   const recordButton = page.getByTestId("recorder-record-button");

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -146,7 +146,7 @@ export function Recorder({ projectId }: { projectId: string }) {
       }
       return;
     }
-    if (isShortcutTextInputTarget(event.target)) {
+    if (isShortcutTextInputTarget(event.target) || event.repeat) {
       return;
     }
     const seekDirection = matchKeyboardEvent(event, "ArrowLeft")
@@ -158,9 +158,6 @@ export function Recorder({ projectId }: { projectId: string }) {
       event.preventDefault();
       const position = Math.max(0, state.position + seekDirection * 5);
       runtime.seek(position);
-      return;
-    }
-    if (event.repeat) {
       return;
     }
     if (matchKeyboardEvent(event, "Escape") && clipInteraction.hasSelection) {

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -146,7 +146,22 @@ export function Recorder({ projectId }: { projectId: string }) {
       }
       return;
     }
-    if (isShortcutTextInputTarget(event.target) || event.repeat) {
+    if (isShortcutTextInputTarget(event.target)) {
+      return;
+    }
+    const seekDirection = matchKeyboardEvent(event, "ArrowLeft")
+      ? -1
+      : matchKeyboardEvent(event, "ArrowRight")
+        ? 1
+        : 0;
+    if (seekDirection !== 0 && !isRecording && !isProcessing) {
+      event.preventDefault();
+      const position = Math.max(0, state.position + seekDirection * 5);
+      runtime.seek(position);
+      timeline.revealPosition(position);
+      return;
+    }
+    if (event.repeat) {
       return;
     }
     if (matchKeyboardEvent(event, "Escape") && clipInteraction.hasSelection) {

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -158,7 +158,6 @@ export function Recorder({ projectId }: { projectId: string }) {
       event.preventDefault();
       const position = Math.max(0, state.position + seekDirection * 5);
       runtime.seek(position);
-      timeline.revealPosition(position);
       return;
     }
     if (event.repeat) {

--- a/src/components/recorder/use-recorder-timeline.ts
+++ b/src/components/recorder/use-recorder-timeline.ts
@@ -65,6 +65,16 @@ export function useRecorderTimeline({
     );
   }
 
+  function revealPosition(position: number) {
+    const playheadBeat = secondsToBeats(position, tempo);
+    const visibleBeats = viewportWidth / pixelsPerBeat;
+    if (playheadBeat < viewportStartBeat) {
+      setViewportStartBeat(Math.max(0, playheadBeat - visibleBeats * 0.1));
+    } else if (viewportStartBeat + visibleBeats < playheadBeat) {
+      setViewportStartBeat(Math.max(0, playheadBeat - visibleBeats * 0.9));
+    }
+  }
+
   const viewportRef = useCallback(
     (viewport: HTMLDivElement | null) => {
       if (!viewport) {
@@ -111,6 +121,7 @@ export function useRecorderTimeline({
     gridDivision,
     pixelsPerBeat,
     playheadX,
+    revealPosition,
     viewportStartBeat,
     setGridDivision,
     subdivisionsPerBeat,

--- a/src/components/recorder/use-recorder-timeline.ts
+++ b/src/components/recorder/use-recorder-timeline.ts
@@ -65,16 +65,6 @@ export function useRecorderTimeline({
     );
   }
 
-  function revealPosition(position: number) {
-    const playheadBeat = secondsToBeats(position, tempo);
-    const visibleBeats = viewportWidth / pixelsPerBeat;
-    if (playheadBeat < viewportStartBeat) {
-      setViewportStartBeat(Math.max(0, playheadBeat - visibleBeats * 0.1));
-    } else if (viewportStartBeat + visibleBeats < playheadBeat) {
-      setViewportStartBeat(Math.max(0, playheadBeat - visibleBeats * 0.9));
-    }
-  }
-
   const viewportRef = useCallback(
     (viewport: HTMLDivElement | null) => {
       if (!viewport) {
@@ -121,7 +111,6 @@ export function useRecorderTimeline({
     gridDivision,
     pixelsPerBeat,
     playheadX,
-    revealPosition,
     viewportStartBeat,
     setGridDivision,
     subdivisionsPerBeat,

--- a/src/lib/keyboard.test.ts
+++ b/src/lib/keyboard.test.ts
@@ -78,6 +78,28 @@ describe("parseShortcut", () => {
         },
       }
     `);
+    expect(parseShortcut("ArrowLeft")).toMatchInlineSnapshot(`
+      {
+        "code": "ArrowLeft",
+        "key": "ArrowLeft",
+        "modifiers": {
+          "alt": false,
+          "ctrl": false,
+          "shift": false,
+        },
+      }
+    `);
+    expect(parseShortcut("ArrowRight")).toMatchInlineSnapshot(`
+      {
+        "code": "ArrowRight",
+        "key": "ArrowRight",
+        "modifiers": {
+          "alt": false,
+          "ctrl": false,
+          "shift": false,
+        },
+      }
+    `);
   });
 
   it("invalid", () => {

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -21,6 +21,8 @@ const SPECIAL_KEYS: Record<string, { code: string; key: string }> = {
   Space: { code: "Space", key: " " },
   Escape: { code: "Escape", key: "Escape" },
   Enter: { code: "Enter", key: "Enter" },
+  ArrowLeft: { code: "ArrowLeft", key: "ArrowLeft" },
+  ArrowRight: { code: "ArrowRight", key: "ArrowRight" },
   ArrowUp: { code: "ArrowUp", key: "ArrowUp" },
   ArrowDown: { code: "ArrowDown", key: "ArrowDown" },
   Delete: { code: "Delete", key: "Delete" },


### PR DESCRIPTION
The recorder needs a quick way to replay nearby passages without precisely clicking the timeline. Five-second jumps match the listening and practice workflow better than tying basic navigation to the editing grid.

This PR makes plain Left and Right seek the recorder by five seconds, including during playback. It preserves native input behavior and ignores seeking during capture, processing, and repeated keydown events.