### PR TITLE
fix: speed up recorder project export

### DIFF
--- a/src/lib/recorder/project-archive.ts
+++ b/src/lib/recorder/project-archive.ts
@@ -170,7 +170,7 @@ function writeProjectPcm(
       bytes.set(
         new Uint8Array(channel.buffer, channel.byteOffset, channel.byteLength),
       );
-      zip.file(channelPath, bytes);
+      zip.file(channelPath, bytes, { compression: "STORE" });
       return channelPath;
     }),
   };


### PR DESCRIPTION
- follows https://github.com/hi-ogawa/toy-midi/pull/155

Recorder project export spends most of its time deflating raw float PCM, while the resulting archives only shrink modestly. Equivalent JSZip benchmarks on two real projects showed:

| Raw PCM | DEFLATE time | STORE time | Speedup | DEFLATE size | STORE size |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 188 MiB | 15.2 s | 0.65 s | 23x | 159 MiB | 188 MiB |
| 283 MiB | 25.4 s | 0.97 s | 26x | 217 MiB | 283 MiB |

This PR stores recorder PCM entries without compression while retaining DEFLATE for the small metadata entries. This makes project export substantially faster at the cost of larger project files.