### PR TITLE
fix: correct YouTube reference playback drift

### DIFF
--- a/src/lib/recorder/youtube-player-playback.ts
+++ b/src/lib/recorder/youtube-player-playback.ts
@@ -14,11 +14,11 @@ export class YouTubePlayerPlayback {
   private readonly duration: number;
   private timelineStart = 0;
   private mode?: PlaybackMode;
+  private readonly unsubscribe: () => void;
   private readonly correctDriftThrottled = throttle(
     (expectedTime: number) => this.correctDrift(expectedTime),
     DRIFT_CHECK_INTERVAL_MS,
   );
-  private readonly unsubscribe: () => void;
 
   constructor({
     transport,

--- a/src/lib/recorder/youtube-player-playback.ts
+++ b/src/lib/recorder/youtube-player-playback.ts
@@ -1,10 +1,11 @@
+import { throttle } from "../../utils/timing.ts";
 import { clamp } from "../music.ts";
 import type { YouTubePlayerApi } from "../youtube.ts";
 import type { AudioContextTransport } from "./transport.ts";
 
 type PlaybackMode = "paused" | "before" | "playing" | "after";
 
-const DRIFT_CHECK_INTERVAL_SECONDS = 1;
+const DRIFT_CHECK_INTERVAL_MS = 1_000;
 const DRIFT_TOLERANCE_SECONDS = 0.25;
 
 export class YouTubePlayerPlayback {
@@ -13,7 +14,10 @@ export class YouTubePlayerPlayback {
   private readonly duration: number;
   private timelineStart = 0;
   private mode?: PlaybackMode;
-  private lastDriftCheckPosition?: number;
+  private readonly correctDriftThrottled = throttle(
+    (expectedTime: number) => this.correctDrift(expectedTime),
+    DRIFT_CHECK_INTERVAL_MS,
+  );
   private readonly unsubscribe: () => void;
 
   constructor({
@@ -33,7 +37,7 @@ export class YouTubePlayerPlayback {
 
   setTimelineStart(timelineStart: number): void {
     this.timelineStart = timelineStart;
-    this.lastDriftCheckPosition = this.transport.store.get().position;
+    this.mode = undefined;
     this.sync();
   }
 
@@ -47,7 +51,6 @@ export class YouTubePlayerPlayback {
     const expectedTime = transport.position - this.timelineStart;
     if (!transport.isPlaying) {
       this.mode = "paused";
-      this.lastDriftCheckPosition = transport.position;
       this.pause(clamp(expectedTime, 0, this.duration));
       return;
     }
@@ -60,15 +63,11 @@ export class YouTubePlayerPlayback {
           : "playing";
     if (mode === this.mode) {
       if (mode === "playing") {
-        this.correctDrift({
-          expectedTime,
-          transportPosition: transport.position,
-        });
+        this.correctDriftThrottled.run(expectedTime);
       }
       return;
     }
     this.mode = mode;
-    this.lastDriftCheckPosition = transport.position;
     switch (mode) {
       case "before": {
         this.pause(0);
@@ -85,21 +84,7 @@ export class YouTubePlayerPlayback {
     }
   }
 
-  private correctDrift({
-    expectedTime,
-    transportPosition,
-  }: {
-    expectedTime: number;
-    transportPosition: number;
-  }): void {
-    if (
-      this.lastDriftCheckPosition !== undefined &&
-      transportPosition - this.lastDriftCheckPosition <
-        DRIFT_CHECK_INTERVAL_SECONDS
-    ) {
-      return;
-    }
-    this.lastDriftCheckPosition = transportPosition;
+  private correctDrift(expectedTime: number): void {
     if (
       Math.abs(this.player.getCurrentTime() - expectedTime) >
       DRIFT_TOLERANCE_SECONDS
@@ -109,11 +94,13 @@ export class YouTubePlayerPlayback {
   }
 
   private play(position: number): void {
+    this.correctDriftThrottled.reset();
     this.player.seekTo(position, true);
     this.player.playVideo();
   }
 
   private pause(position: number): void {
+    this.correctDriftThrottled.reset();
     this.player.seekTo(position, true);
     this.player.pauseVideo();
   }

--- a/src/lib/recorder/youtube-player-playback.ts
+++ b/src/lib/recorder/youtube-player-playback.ts
@@ -4,12 +4,16 @@ import type { AudioContextTransport } from "./transport.ts";
 
 type PlaybackMode = "paused" | "before" | "playing" | "after";
 
+const DRIFT_CHECK_INTERVAL_SECONDS = 1;
+const DRIFT_TOLERANCE_SECONDS = 0.25;
+
 export class YouTubePlayerPlayback {
   private readonly transport: AudioContextTransport;
   private readonly player: YouTubePlayerApi;
   private readonly duration: number;
   private timelineStart = 0;
   private mode?: PlaybackMode;
+  private lastDriftCheckPosition?: number;
   private readonly unsubscribe: () => void;
 
   constructor({
@@ -29,6 +33,7 @@ export class YouTubePlayerPlayback {
 
   setTimelineStart(timelineStart: number): void {
     this.timelineStart = timelineStart;
+    this.lastDriftCheckPosition = this.transport.store.get().position;
     this.sync();
   }
 
@@ -42,6 +47,7 @@ export class YouTubePlayerPlayback {
     const expectedTime = transport.position - this.timelineStart;
     if (!transport.isPlaying) {
       this.mode = "paused";
+      this.lastDriftCheckPosition = transport.position;
       this.pause(clamp(expectedTime, 0, this.duration));
       return;
     }
@@ -53,9 +59,16 @@ export class YouTubePlayerPlayback {
           ? "after"
           : "playing";
     if (mode === this.mode) {
+      if (mode === "playing") {
+        this.correctDrift({
+          expectedTime,
+          transportPosition: transport.position,
+        });
+      }
       return;
     }
     this.mode = mode;
+    this.lastDriftCheckPosition = transport.position;
     switch (mode) {
       case "before": {
         this.pause(0);
@@ -69,6 +82,29 @@ export class YouTubePlayerPlayback {
         this.pause(this.duration);
         break;
       }
+    }
+  }
+
+  private correctDrift({
+    expectedTime,
+    transportPosition,
+  }: {
+    expectedTime: number;
+    transportPosition: number;
+  }): void {
+    if (
+      this.lastDriftCheckPosition !== undefined &&
+      transportPosition - this.lastDriftCheckPosition <
+        DRIFT_CHECK_INTERVAL_SECONDS
+    ) {
+      return;
+    }
+    this.lastDriftCheckPosition = transportPosition;
+    if (
+      Math.abs(this.player.getCurrentTime() - expectedTime) >
+      DRIFT_TOLERANCE_SECONDS
+    ) {
+      this.player.seekTo(expectedTime, true);
     }
   }
 

--- a/src/lib/recorder/youtube-player-playback.ts
+++ b/src/lib/recorder/youtube-player-playback.ts
@@ -5,7 +5,7 @@ import type { AudioContextTransport } from "./transport.ts";
 
 type PlaybackMode = "paused" | "before" | "playing" | "after";
 
-const DRIFT_CHECK_INTERVAL_MS = 1_000;
+const DRIFT_CHECK_INTERVAL_SECONDS = 1;
 const DRIFT_TOLERANCE_SECONDS = 0.25;
 
 export class YouTubePlayerPlayback {
@@ -17,7 +17,7 @@ export class YouTubePlayerPlayback {
   private readonly unsubscribe: () => void;
   private readonly correctDriftThrottled = throttle(
     (expectedTime: number) => this.correctDrift(expectedTime),
-    DRIFT_CHECK_INTERVAL_MS,
+    DRIFT_CHECK_INTERVAL_SECONDS * 1_000,
   );
 
   constructor({

--- a/src/lib/youtube.ts
+++ b/src/lib/youtube.ts
@@ -4,6 +4,7 @@ export interface YouTubePlayerApi {
   mute(): void;
   unMute(): void;
   seekTo(seconds: number, allowSeekAhead: boolean): void;
+  getCurrentTime(): number;
   getDuration(): number;
   getVideoData(): { title?: string };
   destroy(): void;

--- a/src/utils/timing.ts
+++ b/src/utils/timing.ts
@@ -28,6 +28,28 @@ export function debounce(fn: () => void, ms: number) {
   return { schedule, cancel, flush };
 }
 
+export function throttle<Args extends unknown[]>(
+  fn: (...args: Args) => void,
+  ms: number,
+) {
+  let nextTime = -Infinity;
+
+  function run(...args: Args) {
+    const now = performance.now();
+    if (now < nextTime) {
+      return;
+    }
+    nextTime = now + ms;
+    fn(...args);
+  }
+
+  function reset() {
+    nextTime = performance.now() + ms;
+  }
+
+  return { run, reset };
+}
+
 export function startAnimationFrameLoop(
   callback: FrameRequestCallback,
 ): () => void {


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/toy-midi/issues/412

YouTube playback can drift from the recorder transport after startup because the media and AudioContext clocks run independently.

This PR samples the YouTube media clock around once per second while the reference is actively playing and seeks when drift exceeds 250 ms. Explicit mode transitions, seeks, and timeline offset changes reset the cadence so command latency does not immediately trigger another correction.