### PR TITLE
feat: prototype recorder loop range UI

### DIFF
--- a/e2e/fake-audio/recorder-loop-range.test.ts
+++ b/e2e/fake-audio/recorder-loop-range.test.ts
@@ -17,7 +17,7 @@ test("creates and edits a persisted loop range", async ({ page }) => {
   expect(initialBox).not.toBeNull();
 
   // The range can be repositioned directly on the timeline ruler.
-  await dragBy(page, range, 80, { anchorXOffset: initialBox!.width / 2 });
+  await dragBy(page, range, 80);
   const movedBox = await range.boundingBox();
   expect(movedBox).not.toBeNull();
   expect(movedBox!.x).toBeCloseTo(initialBox!.x + 80, -1);

--- a/e2e/fake-audio/recorder-loop-range.test.ts
+++ b/e2e/fake-audio/recorder-loop-range.test.ts
@@ -9,21 +9,25 @@ test("creates and edits a persisted loop range", async ({ page }) => {
   await expect(toggle).toHaveAttribute("aria-pressed", "false");
   await expect(range).toHaveCount(0);
 
+  // First activation creates and enables a loop range at the current bar.
   await toggle.click();
   await expect(toggle).toHaveAttribute("aria-pressed", "true");
   await expect(range).toBeVisible();
   const initialBox = await range.boundingBox();
   expect(initialBox).not.toBeNull();
 
+  // The range can be repositioned directly on the timeline ruler.
   await dragBy(page, range, 80, { anchorXOffset: initialBox!.width / 2 });
   const movedBox = await range.boundingBox();
   expect(movedBox).not.toBeNull();
   expect(movedBox!.x).toBeCloseTo(initialBox!.x + 80, -1);
 
+  // Disabling playback keeps the edited range available for later use.
   await toggle.click();
   await expect(toggle).toHaveAttribute("aria-pressed", "false");
   await expect(range).toBeVisible();
 
+  // The disabled range and its timeline placement persist with the project.
   await page.getByRole("button", { name: /Unsaved changes/ }).click();
   await expect(
     page.getByRole("button", { name: "All changes saved" }),
@@ -35,6 +39,7 @@ test("creates and edits a persisted loop range", async ({ page }) => {
   expect(restoredBox).not.toBeNull();
   expect(restoredBox!.x).toBeCloseTo(movedBox!.x, -1);
 
+  // Clearing removes the range and returns the loop feature to its empty state.
   await page.getByTestId("recorder-loop-clear").click();
   await expect(range).toHaveCount(0);
 });

--- a/e2e/fake-audio/recorder-loop-range.test.ts
+++ b/e2e/fake-audio/recorder-loop-range.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+import { createRecorderProject, dragBy } from "./recorder-helpers";
+
+test("creates and edits a persisted loop range", async ({ page }) => {
+  await createRecorderProject(page);
+
+  const toggle = page.getByTestId("recorder-loop-toggle");
+  const range = page.getByTestId("recorder-loop-range");
+  await expect(toggle).toHaveAttribute("aria-pressed", "false");
+  await expect(range).toHaveCount(0);
+
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-pressed", "true");
+  await expect(range).toBeVisible();
+  const initialBox = await range.boundingBox();
+  expect(initialBox).not.toBeNull();
+
+  await dragBy(page, range, 80, { anchorXOffset: initialBox!.width / 2 });
+  const movedBox = await range.boundingBox();
+  expect(movedBox).not.toBeNull();
+  expect(movedBox!.x).toBeCloseTo(initialBox!.x + 80, -1);
+
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-pressed", "false");
+  await expect(range).toBeVisible();
+
+  await page.getByRole("button", { name: /Unsaved changes/ }).click();
+  await expect(
+    page.getByRole("button", { name: "All changes saved" }),
+  ).toBeVisible();
+  await page.reload();
+  await expect(toggle).toHaveAttribute("aria-pressed", "false");
+  await expect(range).toBeVisible();
+  const restoredBox = await range.boundingBox();
+  expect(restoredBox).not.toBeNull();
+  expect(restoredBox!.x).toBeCloseTo(movedBox!.x, -1);
+
+  await page.getByTestId("recorder-loop-clear").click();
+  await expect(range).toHaveCount(0);
+});

--- a/e2e/fake-audio/recorder-loop-range.test.ts
+++ b/e2e/fake-audio/recorder-loop-range.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import { expect, test } from "@playwright/test";
 import { createRecorderProject, dragBy } from "./recorder-helpers";
 
@@ -14,13 +15,13 @@ test("creates and edits a persisted loop range", async ({ page }) => {
   await expect(toggle).toHaveAttribute("aria-pressed", "true");
   await expect(range).toBeVisible();
   const initialBox = await range.boundingBox();
-  expect(initialBox).not.toBeNull();
+  assert(initialBox);
 
   // The range can be repositioned directly on the timeline ruler.
   await dragBy(page, range, 80);
   const movedBox = await range.boundingBox();
-  expect(movedBox).not.toBeNull();
-  expect(movedBox!.x).toBeCloseTo(initialBox!.x + 80, -1);
+  assert(movedBox);
+  expect(movedBox.x).toBeCloseTo(initialBox.x + 80, -1);
 
   // Disabling playback keeps the edited range available for later use.
   await toggle.click();
@@ -36,8 +37,8 @@ test("creates and edits a persisted loop range", async ({ page }) => {
   await expect(toggle).toHaveAttribute("aria-pressed", "false");
   await expect(range).toBeVisible();
   const restoredBox = await range.boundingBox();
-  expect(restoredBox).not.toBeNull();
-  expect(restoredBox!.x).toBeCloseTo(movedBox!.x, -1);
+  assert(restoredBox);
+  expect(restoredBox.x).toBeCloseTo(movedBox.x, -1);
 
   // Clearing removes the range and returns the loop feature to its empty state.
   await page.getByTestId("recorder-loop-clear").click();

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -273,7 +273,6 @@ export function Recorder({ projectId }: { projectId: string }) {
               onAddAudioFile={(file) => addAudioMutation.mutate(file)}
               onSeek={(position) => runtime.seek(position)}
               loop={state.loop}
-              loopEditingDisabled={isRecording || isProcessing}
               onLoopRangeChange={(range) => runtime.setLoop({ range })}
               onLoopRangeClear={() =>
                 runtime.setLoop({ range: undefined, enabled: false })

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -10,6 +10,7 @@ import {
 import { exportRecorderProjectArchive } from "../../lib/recorder/project-archive";
 import { RecorderRuntime } from "../../lib/recorder/runtime";
 import { formatTimeWithMilliseconds } from "../../lib/time-format";
+import { secondsToBeats } from "../../lib/timeline";
 import { encodeWav } from "../../lib/wav";
 import { parseTimeSignature } from "../../types";
 import { Dialog } from "../ui/dialog";
@@ -197,6 +198,8 @@ export function Recorder({ projectId }: { projectId: string }) {
         isExporting={exportProjectMutation.isPending}
         autoScrollEnabled={timeline.autoScrollEnabled}
         metronomeEnabled={state.metronomeEnabled}
+        loopEnabled={state.loopEnabled}
+        loopAvailable={Boolean(state.loopRange)}
         position={state.position}
         tempo={timeline.tempo}
         timeSignature={timeline.timeSignature}
@@ -211,6 +214,22 @@ export function Recorder({ projectId }: { projectId: string }) {
         onAutoScrollChange={timeline.setAutoScrollEnabled}
         onTempoChange={(tempo) => runtime.setTempo(tempo)}
         onMetronomeChange={(enabled) => runtime.setMetronomeEnabled(enabled)}
+        onLoopEnabledChange={(enabled) => {
+          if (enabled && !state.loopRange) {
+            const startBeat = Math.max(
+              0,
+              Math.floor(
+                secondsToBeats(state.position, state.tempo) /
+                  timeline.beatsPerBar,
+              ) * timeline.beatsPerBar,
+            );
+            runtime.setLoopRange({
+              startBeat,
+              endBeat: startBeat + timeline.beatsPerBar,
+            });
+          }
+          runtime.setLoopEnabled(enabled);
+        }}
         onTimeSignatureChange={(timeSignature) =>
           runtime.setTimeSignature(parseTimeSignature(timeSignature))
         }
@@ -250,6 +269,11 @@ export function Recorder({ projectId }: { projectId: string }) {
               onAddAudioTrack={() => runtime.addAudioTrack()}
               onAddAudioFile={(file) => addAudioMutation.mutate(file)}
               onSeek={(position) => runtime.seek(position)}
+              loopRange={state.loopRange}
+              loopEnabled={state.loopEnabled}
+              loopEditingDisabled={isRecording || isProcessing}
+              onLoopRangeChange={(range) => runtime.setLoopRange(range)}
+              onLoopRangeClear={() => runtime.clearLoopRange()}
             />
             {state.referenceVideo && (
               <ReferenceTimelineRow

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -198,8 +198,8 @@ export function Recorder({ projectId }: { projectId: string }) {
         isExporting={exportProjectMutation.isPending}
         autoScrollEnabled={timeline.autoScrollEnabled}
         metronomeEnabled={state.metronomeEnabled}
-        loopEnabled={state.loopEnabled}
-        loopAvailable={Boolean(state.loopRange)}
+        loopEnabled={state.loop.enabled}
+        loopAvailable={Boolean(state.loop.range)}
         position={state.position}
         tempo={timeline.tempo}
         timeSignature={timeline.timeSignature}
@@ -215,7 +215,7 @@ export function Recorder({ projectId }: { projectId: string }) {
         onTempoChange={(tempo) => runtime.setTempo(tempo)}
         onMetronomeChange={(enabled) => runtime.setMetronomeEnabled(enabled)}
         onLoopEnabledChange={(enabled) => {
-          if (enabled && !state.loopRange) {
+          if (enabled && !state.loop.range) {
             const startBeat = Math.max(
               0,
               Math.floor(
@@ -269,8 +269,8 @@ export function Recorder({ projectId }: { projectId: string }) {
               onAddAudioTrack={() => runtime.addAudioTrack()}
               onAddAudioFile={(file) => addAudioMutation.mutate(file)}
               onSeek={(position) => runtime.seek(position)}
-              loopRange={state.loopRange}
-              loopEnabled={state.loopEnabled}
+              loopRange={state.loop.range}
+              loopEnabled={state.loop.enabled}
               loopEditingDisabled={isRecording || isProcessing}
               onLoopRangeChange={(range) => runtime.setLoopRange(range)}
               onLoopRangeClear={() => runtime.clearLoopRange()}

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -10,7 +10,6 @@ import {
 import { exportRecorderProjectArchive } from "../../lib/recorder/project-archive";
 import { RecorderRuntime } from "../../lib/recorder/runtime";
 import { formatTimeWithMilliseconds } from "../../lib/time-format";
-import { secondsToBeats } from "../../lib/timeline";
 import { encodeWav } from "../../lib/wav";
 import { parseTimeSignature } from "../../types";
 import { Dialog } from "../ui/dialog";
@@ -213,26 +212,7 @@ export function Recorder({ projectId }: { projectId: string }) {
         onAutoScrollChange={timeline.setAutoScrollEnabled}
         onTempoChange={(tempo) => runtime.setTempo(tempo)}
         onMetronomeChange={(enabled) => runtime.setMetronomeEnabled(enabled)}
-        onLoopEnabledChange={(enabled) => {
-          const startBeat = Math.max(
-            0,
-            Math.floor(
-              secondsToBeats(state.position, state.tempo) /
-                timeline.beatsPerBar,
-            ) * timeline.beatsPerBar,
-          );
-          runtime.setLoop({
-            enabled,
-            range:
-              state.loop.range ??
-              (enabled
-                ? {
-                    startBeat,
-                    endBeat: startBeat + timeline.beatsPerBar,
-                  }
-                : undefined),
-          });
-        }}
+        onLoopChange={(update) => runtime.setLoop(update)}
         onTimeSignatureChange={(timeSignature) =>
           runtime.setTimeSignature(parseTimeSignature(timeSignature))
         }

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -198,8 +198,7 @@ export function Recorder({ projectId }: { projectId: string }) {
         isExporting={exportProjectMutation.isPending}
         autoScrollEnabled={timeline.autoScrollEnabled}
         metronomeEnabled={state.metronomeEnabled}
-        loopEnabled={state.loop.enabled}
-        loopAvailable={Boolean(state.loop.range)}
+        loop={state.loop}
         position={state.position}
         tempo={timeline.tempo}
         timeSignature={timeline.timeSignature}
@@ -273,8 +272,7 @@ export function Recorder({ projectId }: { projectId: string }) {
               onAddAudioTrack={() => runtime.addAudioTrack()}
               onAddAudioFile={(file) => addAudioMutation.mutate(file)}
               onSeek={(position) => runtime.seek(position)}
-              loopRange={state.loop.range}
-              loopEnabled={state.loop.enabled}
+              loop={state.loop}
               loopEditingDisabled={isRecording || isProcessing}
               onLoopRangeChange={(range) => runtime.setLoop({ range })}
               onLoopRangeClear={() =>

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -215,20 +215,24 @@ export function Recorder({ projectId }: { projectId: string }) {
         onTempoChange={(tempo) => runtime.setTempo(tempo)}
         onMetronomeChange={(enabled) => runtime.setMetronomeEnabled(enabled)}
         onLoopEnabledChange={(enabled) => {
-          if (enabled && !state.loop.range) {
-            const startBeat = Math.max(
-              0,
-              Math.floor(
-                secondsToBeats(state.position, state.tempo) /
-                  timeline.beatsPerBar,
-              ) * timeline.beatsPerBar,
-            );
-            runtime.setLoopRange({
-              startBeat,
-              endBeat: startBeat + timeline.beatsPerBar,
-            });
-          }
-          runtime.setLoopEnabled(enabled);
+          const startBeat = Math.max(
+            0,
+            Math.floor(
+              secondsToBeats(state.position, state.tempo) /
+                timeline.beatsPerBar,
+            ) * timeline.beatsPerBar,
+          );
+          runtime.setLoop({
+            enabled,
+            range:
+              state.loop.range ??
+              (enabled
+                ? {
+                    startBeat,
+                    endBeat: startBeat + timeline.beatsPerBar,
+                  }
+                : undefined),
+          });
         }}
         onTimeSignatureChange={(timeSignature) =>
           runtime.setTimeSignature(parseTimeSignature(timeSignature))
@@ -272,8 +276,10 @@ export function Recorder({ projectId }: { projectId: string }) {
               loopRange={state.loop.range}
               loopEnabled={state.loop.enabled}
               loopEditingDisabled={isRecording || isProcessing}
-              onLoopRangeChange={(range) => runtime.setLoopRange(range)}
-              onLoopRangeClear={() => runtime.clearLoopRange()}
+              onLoopRangeChange={(range) => runtime.setLoop({ range })}
+              onLoopRangeClear={() =>
+                runtime.setLoop({ range: undefined, enabled: false })
+              }
             />
             {state.referenceVideo && (
               <ReferenceTimelineRow

--- a/src/components/recorder/recorder-header.tsx
+++ b/src/components/recorder/recorder-header.tsx
@@ -105,8 +105,6 @@ export function RecorderHeader({
   mixerOpen: boolean;
 }) {
   const timeSignatureValue = `${timeSignature.numerator}/${timeSignature.denominator}`;
-  const { enabled: loopEnabled, range: loopRange } = loop;
-  const beatsPerBar = getBeatsPerBar(timeSignature);
   const tempoInput = useDraftInput({
     value: tempo,
     onCommit: onTempoChange,
@@ -165,26 +163,25 @@ export function RecorderHeader({
       <Button
         data-testid="recorder-loop-toggle"
         onClick={() => {
-          const enabled = !loopEnabled;
-          const startBeat = Math.max(
-            0,
+          const enabled = !loop.enabled;
+          const beatsPerBar = getBeatsPerBar(timeSignature);
+          const startBeat =
             Math.floor(secondsToBeats(position, tempo) / beatsPerBar) *
-              beatsPerBar,
-          );
+            beatsPerBar;
           onLoopChange({
             enabled,
             range:
-              loopRange ??
+              loop.range ??
               (enabled
                 ? { startBeat, endBeat: startBeat + beatsPerBar }
                 : undefined),
           });
         }}
-        aria-pressed={loopEnabled}
-        title={loopRange ? "Toggle loop playback" : "Create loop range"}
+        aria-pressed={loop.enabled}
+        title={loop.range ? "Toggle loop playback" : "Create loop range"}
         className={cn(
           "size-9",
-          loopEnabled
+          loop.enabled
             ? "bg-violet-500/20 text-violet-200 hover:bg-violet-500/30"
             : "text-neutral-300 hover:bg-neutral-700/50 hover:text-neutral-100",
         )}

--- a/src/components/recorder/recorder-header.tsx
+++ b/src/components/recorder/recorder-header.tsx
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import { useDraftInput } from "../../hooks/use-draft-input";
 import { useTapTempo } from "../../hooks/use-tap-tempo";
+import type { RecorderRuntimeState } from "../../lib/recorder/runtime";
 import { routes } from "../../lib/routes";
 import { formatTimeWithMilliseconds } from "../../lib/time-format";
 import {
@@ -49,8 +50,7 @@ export function RecorderHeader({
   isRecording,
   isExporting,
   metronomeEnabled,
-  loopEnabled,
-  loopAvailable,
+  loop,
   position,
   tempo,
   timeSignature,
@@ -80,8 +80,7 @@ export function RecorderHeader({
   isRecording: boolean;
   isExporting: boolean;
   metronomeEnabled: boolean;
-  loopEnabled: boolean;
-  loopAvailable: boolean;
+  loop: RecorderRuntimeState["loop"];
   position: number;
   tempo: number;
   timeSignature: TimeSignature;
@@ -104,6 +103,7 @@ export function RecorderHeader({
   mixerOpen: boolean;
 }) {
   const timeSignatureValue = `${timeSignature.numerator}/${timeSignature.denominator}`;
+  const { enabled: loopEnabled, range: loopRange } = loop;
   const tempoInput = useDraftInput({
     value: tempo,
     onCommit: onTempoChange,
@@ -163,7 +163,7 @@ export function RecorderHeader({
         data-testid="recorder-loop-toggle"
         onClick={() => onLoopEnabledChange(!loopEnabled)}
         aria-pressed={loopEnabled}
-        title={loopAvailable ? "Toggle loop playback" : "Create loop range"}
+        title={loopRange ? "Toggle loop playback" : "Create loop range"}
         className={cn(
           "size-9",
           loopEnabled

--- a/src/components/recorder/recorder-header.tsx
+++ b/src/components/recorder/recorder-header.tsx
@@ -24,6 +24,8 @@ import { routes } from "../../lib/routes";
 import { formatTimeWithMilliseconds } from "../../lib/time-format";
 import {
   formatBarBeatAtTime,
+  getBeatsPerBar,
+  secondsToBeats,
   type GridDivision,
   GRID_DIVISIONS,
 } from "../../lib/timeline";
@@ -64,7 +66,7 @@ export function RecorderHeader({
   onAutoScrollChange,
   onTempoChange,
   onMetronomeChange,
-  onLoopEnabledChange,
+  onLoopChange,
   onTimeSignatureChange,
   onGridDivisionChange,
   onExportProject,
@@ -94,7 +96,7 @@ export function RecorderHeader({
   onAutoScrollChange: (enabled: boolean) => void;
   onTempoChange: (tempo: number) => void;
   onMetronomeChange: (enabled: boolean) => void;
-  onLoopEnabledChange: (enabled: boolean) => void;
+  onLoopChange: (update: Partial<RecorderLoopState>) => void;
   onTimeSignatureChange: (value: string) => void;
   onGridDivisionChange: (value: GridDivision) => void;
   onExportProject: () => void;
@@ -104,6 +106,7 @@ export function RecorderHeader({
 }) {
   const timeSignatureValue = `${timeSignature.numerator}/${timeSignature.denominator}`;
   const { enabled: loopEnabled, range: loopRange } = loop;
+  const beatsPerBar = getBeatsPerBar(timeSignature);
   const tempoInput = useDraftInput({
     value: tempo,
     onCommit: onTempoChange,
@@ -161,7 +164,22 @@ export function RecorderHeader({
       <div className="mx-1 h-5 w-px bg-neutral-600" />
       <Button
         data-testid="recorder-loop-toggle"
-        onClick={() => onLoopEnabledChange(!loopEnabled)}
+        onClick={() => {
+          const enabled = !loopEnabled;
+          const startBeat = Math.max(
+            0,
+            Math.floor(secondsToBeats(position, tempo) / beatsPerBar) *
+              beatsPerBar,
+          );
+          onLoopChange({
+            enabled,
+            range:
+              loopRange ??
+              (enabled
+                ? { startBeat, endBeat: startBeat + beatsPerBar }
+                : undefined),
+          });
+        }}
         aria-pressed={loopEnabled}
         title={loopRange ? "Toggle loop playback" : "Create loop range"}
         className={cn(

--- a/src/components/recorder/recorder-header.tsx
+++ b/src/components/recorder/recorder-header.tsx
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import { useDraftInput } from "../../hooks/use-draft-input";
 import { useTapTempo } from "../../hooks/use-tap-tempo";
+import { snapToGrid } from "../../lib/music";
 import type { RecorderLoopState } from "../../lib/recorder/runtime";
 import { routes } from "../../lib/routes";
 import { formatTimeWithMilliseconds } from "../../lib/time-format";
@@ -165,9 +166,11 @@ export function RecorderHeader({
         onClick={() => {
           const enabled = !loop.enabled;
           const beatsPerBar = getBeatsPerBar(timeSignature);
-          const startBeat =
-            Math.floor(secondsToBeats(position, tempo) / beatsPerBar) *
-            beatsPerBar;
+          const startBeat = snapToGrid(
+            secondsToBeats(position, tempo),
+            beatsPerBar,
+            { floor: true },
+          );
           onLoopChange({
             enabled,
             range:

--- a/src/components/recorder/recorder-header.tsx
+++ b/src/components/recorder/recorder-header.tsx
@@ -7,6 +7,7 @@ import {
   HouseIcon,
   LoaderCircleIcon,
   LocateFixedIcon,
+  Repeat2Icon,
   Mic2Icon,
   MoreVerticalIcon,
   PauseIcon,
@@ -48,6 +49,8 @@ export function RecorderHeader({
   isRecording,
   isExporting,
   metronomeEnabled,
+  loopEnabled,
+  loopAvailable,
   position,
   tempo,
   timeSignature,
@@ -61,6 +64,7 @@ export function RecorderHeader({
   onAutoScrollChange,
   onTempoChange,
   onMetronomeChange,
+  onLoopEnabledChange,
   onTimeSignatureChange,
   onGridDivisionChange,
   onExportProject,
@@ -76,6 +80,8 @@ export function RecorderHeader({
   isRecording: boolean;
   isExporting: boolean;
   metronomeEnabled: boolean;
+  loopEnabled: boolean;
+  loopAvailable: boolean;
   position: number;
   tempo: number;
   timeSignature: TimeSignature;
@@ -89,6 +95,7 @@ export function RecorderHeader({
   onAutoScrollChange: (enabled: boolean) => void;
   onTempoChange: (tempo: number) => void;
   onMetronomeChange: (enabled: boolean) => void;
+  onLoopEnabledChange: (enabled: boolean) => void;
   onTimeSignatureChange: (value: string) => void;
   onGridDivisionChange: (value: GridDivision) => void;
   onExportProject: () => void;
@@ -152,6 +159,20 @@ export function RecorderHeader({
         )}
       </Button>
       <div className="mx-1 h-5 w-px bg-neutral-600" />
+      <Button
+        data-testid="recorder-loop-toggle"
+        onClick={() => onLoopEnabledChange(!loopEnabled)}
+        aria-pressed={loopEnabled}
+        title={loopAvailable ? "Toggle loop playback" : "Create loop range"}
+        className={cn(
+          "size-9",
+          loopEnabled
+            ? "bg-violet-500/20 text-violet-200 hover:bg-violet-500/30"
+            : "text-neutral-300 hover:bg-neutral-700/50 hover:text-neutral-100",
+        )}
+      >
+        <Repeat2Icon className="size-5" />
+      </Button>
       <Button
         onClick={() => onMetronomeChange(!metronomeEnabled)}
         aria-pressed={metronomeEnabled}

--- a/src/components/recorder/recorder-header.tsx
+++ b/src/components/recorder/recorder-header.tsx
@@ -19,7 +19,7 @@ import {
 } from "lucide-react";
 import { useDraftInput } from "../../hooks/use-draft-input";
 import { useTapTempo } from "../../hooks/use-tap-tempo";
-import type { RecorderRuntimeState } from "../../lib/recorder/runtime";
+import type { RecorderLoopState } from "../../lib/recorder/runtime";
 import { routes } from "../../lib/routes";
 import { formatTimeWithMilliseconds } from "../../lib/time-format";
 import {
@@ -80,7 +80,7 @@ export function RecorderHeader({
   isRecording: boolean;
   isExporting: boolean;
   metronomeEnabled: boolean;
-  loop: RecorderRuntimeState["loop"];
+  loop: RecorderLoopState;
   position: number;
   tempo: number;
   timeSignature: TimeSignature;

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -10,7 +10,7 @@ import { useState } from "react";
 import { usePointerDrag } from "../../hooks/use-pointer-drag";
 import { usePointerGesture } from "../../hooks/use-pointer-gesture";
 import { AudioView } from "../../lib/audio-view";
-import { snapToGrid } from "../../lib/music";
+import { clamp, snapToGrid } from "../../lib/music";
 import type {
   RecorderRuntimeState,
   RecorderLoopRange,
@@ -257,9 +257,10 @@ function LoopRange({
       const delta = snapToGrid(deltaX / pixelsPerBeat, 1 / subdivisionsPerBeat);
       onChange({
         ...data,
-        startBeat: Math.max(
+        startBeat: clamp(
+          data.startBeat + delta,
           0,
-          Math.min(data.endBeat - minimumLength, data.startBeat + delta),
+          data.endBeat - minimumLength,
         ),
       });
     },

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -10,6 +10,7 @@ import { useState } from "react";
 import { usePointerDrag } from "../../hooks/use-pointer-drag";
 import { usePointerGesture } from "../../hooks/use-pointer-gesture";
 import { AudioView } from "../../lib/audio-view";
+import { snapToGrid } from "../../lib/music";
 import type {
   RecorderRuntimeState,
   RecorderLoopRange,
@@ -236,7 +237,7 @@ function LoopRange({
     onClick: () => {},
     onDragStart: () => {},
     onDragMove: (_event, { data, deltaX }) => {
-      const delta = snapBeat(deltaX / pixelsPerBeat, subdivisionsPerBeat);
+      const delta = snapToGrid(deltaX / pixelsPerBeat, 1 / subdivisionsPerBeat);
       const startBeat = Math.max(0, data.startBeat + delta);
       onChange({
         startBeat,
@@ -253,7 +254,7 @@ function LoopRange({
     onClick: () => {},
     onDragStart: () => {},
     onDragMove: (_event, { data, deltaX }) => {
-      const delta = snapBeat(deltaX / pixelsPerBeat, subdivisionsPerBeat);
+      const delta = snapToGrid(deltaX / pixelsPerBeat, 1 / subdivisionsPerBeat);
       onChange({
         ...data,
         startBeat: Math.max(
@@ -272,7 +273,7 @@ function LoopRange({
     onClick: () => {},
     onDragStart: () => {},
     onDragMove: (_event, { data, deltaX }) => {
-      const delta = snapBeat(deltaX / pixelsPerBeat, subdivisionsPerBeat);
+      const delta = snapToGrid(deltaX / pixelsPerBeat, 1 / subdivisionsPerBeat);
       onChange({
         ...data,
         endBeat: Math.max(data.startBeat + minimumLength, data.endBeat + delta),
@@ -326,10 +327,6 @@ function LoopRange({
       )}
     </div>
   );
-}
-
-function snapBeat(beat: number, subdivisionsPerBeat: number): number {
-  return Math.round(beat * subdivisionsPerBeat) / subdivisionsPerBeat;
 }
 
 type RecorderTimelineClip = {

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -234,8 +234,6 @@ function LoopRange({
       event.stopPropagation();
       return range;
     },
-    onClick: () => {},
-    onDragStart: () => {},
     onDragMove: (_event, { data, deltaX }) => {
       const delta = snapToGrid(deltaX / pixelsPerBeat, 1 / subdivisionsPerBeat);
       const startBeat = Math.max(0, data.startBeat + delta);
@@ -251,8 +249,6 @@ function LoopRange({
       event.stopPropagation();
       return range;
     },
-    onClick: () => {},
-    onDragStart: () => {},
     onDragMove: (_event, { data, deltaX }) => {
       const delta = snapToGrid(deltaX / pixelsPerBeat, 1 / subdivisionsPerBeat);
       onChange({
@@ -271,8 +267,6 @@ function LoopRange({
       event.stopPropagation();
       return range;
     },
-    onClick: () => {},
-    onDragStart: () => {},
     onDragMove: (_event, { data, deltaX }) => {
       const delta = snapToGrid(deltaX / pixelsPerBeat, 1 / subdivisionsPerBeat);
       onChange({

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -4,6 +4,7 @@ import {
   PlusIcon,
   UploadIcon,
   Trash2Icon,
+  XIcon,
 } from "lucide-react";
 import { useState } from "react";
 import { usePointerDrag } from "../../hooks/use-pointer-drag";
@@ -11,6 +12,7 @@ import { usePointerGesture } from "../../hooks/use-pointer-gesture";
 import { AudioView } from "../../lib/audio-view";
 import type {
   RecorderRuntimeState,
+  RecorderLoopRange,
   ReferenceVideoState,
 } from "../../lib/recorder/runtime";
 import { formatTimeMinutes } from "../../lib/time-format";
@@ -47,6 +49,11 @@ export function TimelineHeader({
   onAddAudioTrack,
   onAddAudioFile,
   onSeek,
+  loopRange,
+  loopEnabled,
+  loopEditingDisabled,
+  onLoopRangeChange,
+  onLoopRangeClear,
 }: {
   beatsPerBar: number;
   pixelsPerBeat: number;
@@ -58,6 +65,11 @@ export function TimelineHeader({
   onAddAudioTrack: () => void;
   onAddAudioFile: (file: File) => void;
   onSeek: (position: number) => void;
+  loopRange?: RecorderLoopRange;
+  loopEnabled: boolean;
+  loopEditingDisabled: boolean;
+  onLoopRangeChange: (range: RecorderLoopRange) => void;
+  onLoopRangeClear: () => void;
 }) {
   return (
     <div className="sticky top-0 z-40 grid h-10 grid-cols-[15rem_1fr] border-b border-neutral-700 bg-neutral-800">
@@ -103,6 +115,11 @@ export function TimelineHeader({
         subdivisionsPerBeat={subdivisionsPerBeat}
         timelineWidth={timelineWidth}
         onSeek={onSeek}
+        loopRange={loopRange}
+        loopEnabled={loopEnabled}
+        loopEditingDisabled={loopEditingDisabled}
+        onLoopRangeChange={onLoopRangeChange}
+        onLoopRangeClear={onLoopRangeClear}
       />
     </div>
   );
@@ -116,6 +133,11 @@ function TimelineRuler({
   subdivisionsPerBeat,
   timelineWidth,
   onSeek,
+  loopRange,
+  loopEnabled,
+  loopEditingDisabled,
+  onLoopRangeChange,
+  onLoopRangeClear,
 }: {
   beatsPerBar: number;
   pixelsPerBeat: number;
@@ -124,6 +146,11 @@ function TimelineRuler({
   subdivisionsPerBeat: number;
   timelineWidth: number;
   onSeek: (position: number) => void;
+  loopRange?: RecorderLoopRange;
+  loopEnabled: boolean;
+  loopEditingDisabled: boolean;
+  onLoopRangeChange: (range: RecorderLoopRange) => void;
+  onLoopRangeClear: () => void;
 }) {
   const labelEveryBars = getVisibleBarInterval({
     barWidth: beatsPerBar * pixelsPerBeat,
@@ -156,6 +183,18 @@ function TimelineRuler({
         onSeek(beatsToSeconds(beat, tempo));
       }}
     >
+      {loopRange && (
+        <LoopRange
+          range={loopRange}
+          enabled={loopEnabled}
+          disabled={loopEditingDisabled}
+          pixelsPerBeat={pixelsPerBeat}
+          subdivisionsPerBeat={subdivisionsPerBeat}
+          viewportStartBeat={viewportStartBeat}
+          onChange={onLoopRangeChange}
+          onClear={onLoopRangeClear}
+        />
+      )}
       {Array.from({ length: Math.max(0, labelCount) }, (_, index) => {
         const beat = firstLabelBeat + index * labelEveryBeats;
         return (
@@ -170,6 +209,146 @@ function TimelineRuler({
       })}
     </div>
   );
+}
+
+function LoopRange({
+  range,
+  enabled,
+  disabled,
+  pixelsPerBeat,
+  subdivisionsPerBeat,
+  viewportStartBeat,
+  onChange,
+  onClear,
+}: {
+  range: RecorderLoopRange;
+  enabled: boolean;
+  disabled: boolean;
+  pixelsPerBeat: number;
+  subdivisionsPerBeat: number;
+  viewportStartBeat: number;
+  onChange: (range: RecorderLoopRange) => void;
+  onClear: () => void;
+}) {
+  const minimumLength = 1 / subdivisionsPerBeat;
+  const dragRef = usePointerDrag({
+    onStart: (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if ((event.target as HTMLElement).closest("button")) {
+        return { startClientX: event.clientX, range, ignore: true };
+      }
+      return { startClientX: event.clientX, range, ignore: false };
+    },
+    onMove: (event, drag) => {
+      if (drag.ignore) {
+        return;
+      }
+      const delta = snapBeat(
+        (event.clientX - drag.startClientX) / pixelsPerBeat,
+        subdivisionsPerBeat,
+      );
+      const startBeat = Math.max(0, drag.range.startBeat + delta);
+      onChange({
+        startBeat,
+        endBeat: startBeat + drag.range.endBeat - drag.range.startBeat,
+      });
+    },
+  });
+  const startRef = usePointerDrag({
+    onStart: (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      return { startClientX: event.clientX, range };
+    },
+    onMove: (event, drag) => {
+      const delta = snapBeat(
+        (event.clientX - drag.startClientX) / pixelsPerBeat,
+        subdivisionsPerBeat,
+      );
+      onChange({
+        ...drag.range,
+        startBeat: Math.max(
+          0,
+          Math.min(
+            drag.range.endBeat - minimumLength,
+            drag.range.startBeat + delta,
+          ),
+        ),
+      });
+    },
+  });
+  const endRef = usePointerDrag({
+    onStart: (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      return { startClientX: event.clientX, range };
+    },
+    onMove: (event, drag) => {
+      const delta = snapBeat(
+        (event.clientX - drag.startClientX) / pixelsPerBeat,
+        subdivisionsPerBeat,
+      );
+      onChange({
+        ...drag.range,
+        endBeat: Math.max(
+          drag.range.startBeat + minimumLength,
+          drag.range.endBeat + delta,
+        ),
+      });
+    },
+  });
+  return (
+    <div
+      data-testid="recorder-loop-range"
+      className={cn(
+        "absolute inset-y-0 z-10 border-x select-none",
+        enabled
+          ? "border-violet-300 bg-violet-400/20 text-violet-100"
+          : "border-violet-400/70 bg-violet-400/10 text-violet-300",
+        disabled
+          ? "cursor-default opacity-60"
+          : "cursor-grab active:cursor-grabbing",
+      )}
+      style={{
+        left: (range.startBeat - viewportStartBeat) * pixelsPerBeat,
+        width: (range.endBeat - range.startBeat) * pixelsPerBeat,
+      }}
+    >
+      <span className="absolute left-1 top-1 font-sans text-[9px] font-semibold uppercase tracking-wide">
+        Loop
+      </span>
+      {!disabled && (
+        <>
+          <div ref={dragRef} className="absolute inset-0" />
+          <div
+            ref={startRef}
+            className="absolute inset-y-0 -left-1 w-2 cursor-ew-resize"
+          />
+          <div
+            ref={endRef}
+            className="absolute inset-y-0 -right-1 w-2 cursor-ew-resize"
+          />
+          <button
+            type="button"
+            title="Clear loop range"
+            data-testid="recorder-loop-clear"
+            className="absolute right-0.5 top-0.5 grid size-4 place-items-center rounded hover:bg-violet-200/20"
+            onClick={(event) => {
+              event.stopPropagation();
+              onClear();
+            }}
+          >
+            <XIcon className="size-3" />
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+function snapBeat(beat: number, subdivisionsPerBeat: number): number {
+  return Math.round(beat * subdivisionsPerBeat) / subdivisionsPerBeat;
 }
 
 type RecorderTimelineClip = {

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -52,7 +52,6 @@ export function TimelineHeader({
   onAddAudioFile,
   onSeek,
   loop,
-  loopEditingDisabled,
   onLoopRangeChange,
   onLoopRangeClear,
 }: {
@@ -67,7 +66,6 @@ export function TimelineHeader({
   onAddAudioFile: (file: File) => void;
   onSeek: (position: number) => void;
   loop: RecorderLoopState;
-  loopEditingDisabled: boolean;
   onLoopRangeChange: (range: RecorderLoopRange) => void;
   onLoopRangeClear: () => void;
 }) {
@@ -116,7 +114,6 @@ export function TimelineHeader({
         timelineWidth={timelineWidth}
         onSeek={onSeek}
         loop={loop}
-        loopEditingDisabled={loopEditingDisabled}
         onLoopRangeChange={onLoopRangeChange}
         onLoopRangeClear={onLoopRangeClear}
       />
@@ -133,7 +130,6 @@ function TimelineRuler({
   timelineWidth,
   onSeek,
   loop,
-  loopEditingDisabled,
   onLoopRangeChange,
   onLoopRangeClear,
 }: {
@@ -145,7 +141,6 @@ function TimelineRuler({
   timelineWidth: number;
   onSeek: (position: number) => void;
   loop: RecorderLoopState;
-  loopEditingDisabled: boolean;
   onLoopRangeChange: (range: RecorderLoopRange) => void;
   onLoopRangeClear: () => void;
 }) {
@@ -184,7 +179,6 @@ function TimelineRuler({
         <LoopRange
           range={loop.range}
           enabled={loop.enabled}
-          disabled={loopEditingDisabled}
           pixelsPerBeat={pixelsPerBeat}
           subdivisionsPerBeat={subdivisionsPerBeat}
           viewportStartBeat={viewportStartBeat}
@@ -211,7 +205,6 @@ function TimelineRuler({
 function LoopRange({
   range,
   enabled,
-  disabled,
   pixelsPerBeat,
   subdivisionsPerBeat,
   viewportStartBeat,
@@ -220,7 +213,6 @@ function LoopRange({
 }: {
   range: RecorderLoopRange;
   enabled: boolean;
-  disabled: boolean;
   pixelsPerBeat: number;
   subdivisionsPerBeat: number;
   viewportStartBeat: number;
@@ -283,9 +275,7 @@ function LoopRange({
         enabled
           ? "border-violet-300 bg-violet-400/20 text-violet-100"
           : "border-violet-400/70 bg-violet-400/10 text-violet-300",
-        disabled
-          ? "cursor-default opacity-60"
-          : "cursor-grab active:cursor-grabbing",
+        "cursor-grab active:cursor-grabbing",
       )}
       style={{
         left: (range.startBeat - viewportStartBeat) * pixelsPerBeat,
@@ -295,31 +285,27 @@ function LoopRange({
       <span className="absolute left-1 top-1 font-sans text-[9px] font-semibold uppercase tracking-wide">
         Loop
       </span>
-      {!disabled && (
-        <>
-          <div ref={dragRef} className="absolute inset-0" />
-          <div
-            ref={startRef}
-            className="absolute inset-y-0 -left-1 w-2 cursor-ew-resize"
-          />
-          <div
-            ref={endRef}
-            className="absolute inset-y-0 -right-1 w-2 cursor-ew-resize"
-          />
-          <button
-            type="button"
-            title="Clear loop range"
-            data-testid="recorder-loop-clear"
-            className="absolute right-0.5 top-0.5 grid size-4 place-items-center rounded hover:bg-violet-200/20"
-            onClick={(event) => {
-              event.stopPropagation();
-              onClear();
-            }}
-          >
-            <XIcon className="size-3" />
-          </button>
-        </>
-      )}
+      <div ref={dragRef} className="absolute inset-0" />
+      <div
+        ref={startRef}
+        className="absolute inset-y-0 -left-1 w-2 cursor-ew-resize"
+      />
+      <div
+        ref={endRef}
+        className="absolute inset-y-0 -right-1 w-2 cursor-ew-resize"
+      />
+      <button
+        type="button"
+        title="Clear loop range"
+        data-testid="recorder-loop-clear"
+        className="absolute right-0.5 top-0.5 grid size-4 place-items-center rounded hover:bg-violet-200/20"
+        onClick={(event) => {
+          event.stopPropagation();
+          onClear();
+        }}
+      >
+        <XIcon className="size-3" />
+      </button>
     </div>
   );
 }

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -49,8 +49,7 @@ export function TimelineHeader({
   onAddAudioTrack,
   onAddAudioFile,
   onSeek,
-  loopRange,
-  loopEnabled,
+  loop,
   loopEditingDisabled,
   onLoopRangeChange,
   onLoopRangeClear,
@@ -65,8 +64,7 @@ export function TimelineHeader({
   onAddAudioTrack: () => void;
   onAddAudioFile: (file: File) => void;
   onSeek: (position: number) => void;
-  loopRange?: RecorderLoopRange;
-  loopEnabled: boolean;
+  loop: RecorderRuntimeState["loop"];
   loopEditingDisabled: boolean;
   onLoopRangeChange: (range: RecorderLoopRange) => void;
   onLoopRangeClear: () => void;
@@ -115,8 +113,7 @@ export function TimelineHeader({
         subdivisionsPerBeat={subdivisionsPerBeat}
         timelineWidth={timelineWidth}
         onSeek={onSeek}
-        loopRange={loopRange}
-        loopEnabled={loopEnabled}
+        loop={loop}
         loopEditingDisabled={loopEditingDisabled}
         onLoopRangeChange={onLoopRangeChange}
         onLoopRangeClear={onLoopRangeClear}
@@ -133,8 +130,7 @@ function TimelineRuler({
   subdivisionsPerBeat,
   timelineWidth,
   onSeek,
-  loopRange,
-  loopEnabled,
+  loop,
   loopEditingDisabled,
   onLoopRangeChange,
   onLoopRangeClear,
@@ -146,8 +142,7 @@ function TimelineRuler({
   subdivisionsPerBeat: number;
   timelineWidth: number;
   onSeek: (position: number) => void;
-  loopRange?: RecorderLoopRange;
-  loopEnabled: boolean;
+  loop: RecorderRuntimeState["loop"];
   loopEditingDisabled: boolean;
   onLoopRangeChange: (range: RecorderLoopRange) => void;
   onLoopRangeClear: () => void;
@@ -183,10 +178,10 @@ function TimelineRuler({
         onSeek(beatsToSeconds(beat, tempo));
       }}
     >
-      {loopRange && (
+      {loop.range && (
         <LoopRange
-          range={loopRange}
-          enabled={loopEnabled}
+          range={loop.range}
+          enabled={loop.enabled}
           disabled={loopEditingDisabled}
           pixelsPerBeat={pixelsPerBeat}
           subdivisionsPerBeat={subdivisionsPerBeat}

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -231,70 +231,55 @@ function LoopRange({
   onClear: () => void;
 }) {
   const minimumLength = 1 / subdivisionsPerBeat;
-  const dragRef = usePointerDrag({
+  const dragRef = usePointerGesture({
     onStart: (event) => {
       event.preventDefault();
       event.stopPropagation();
-      if ((event.target as HTMLElement).closest("button")) {
-        return { startClientX: event.clientX, range, ignore: true };
-      }
-      return { startClientX: event.clientX, range, ignore: false };
+      return range;
     },
-    onMove: (event, drag) => {
-      if (drag.ignore) {
-        return;
-      }
-      const delta = snapBeat(
-        (event.clientX - drag.startClientX) / pixelsPerBeat,
-        subdivisionsPerBeat,
-      );
-      const startBeat = Math.max(0, drag.range.startBeat + delta);
+    onClick: () => {},
+    onDragStart: () => {},
+    onDragMove: (_event, { data, deltaX }) => {
+      const delta = snapBeat(deltaX / pixelsPerBeat, subdivisionsPerBeat);
+      const startBeat = Math.max(0, data.startBeat + delta);
       onChange({
         startBeat,
-        endBeat: startBeat + drag.range.endBeat - drag.range.startBeat,
+        endBeat: startBeat + data.endBeat - data.startBeat,
       });
     },
   });
-  const startRef = usePointerDrag({
+  const startRef = usePointerGesture({
     onStart: (event) => {
       event.preventDefault();
       event.stopPropagation();
-      return { startClientX: event.clientX, range };
+      return range;
     },
-    onMove: (event, drag) => {
-      const delta = snapBeat(
-        (event.clientX - drag.startClientX) / pixelsPerBeat,
-        subdivisionsPerBeat,
-      );
+    onClick: () => {},
+    onDragStart: () => {},
+    onDragMove: (_event, { data, deltaX }) => {
+      const delta = snapBeat(deltaX / pixelsPerBeat, subdivisionsPerBeat);
       onChange({
-        ...drag.range,
+        ...data,
         startBeat: Math.max(
           0,
-          Math.min(
-            drag.range.endBeat - minimumLength,
-            drag.range.startBeat + delta,
-          ),
+          Math.min(data.endBeat - minimumLength, data.startBeat + delta),
         ),
       });
     },
   });
-  const endRef = usePointerDrag({
+  const endRef = usePointerGesture({
     onStart: (event) => {
       event.preventDefault();
       event.stopPropagation();
-      return { startClientX: event.clientX, range };
+      return range;
     },
-    onMove: (event, drag) => {
-      const delta = snapBeat(
-        (event.clientX - drag.startClientX) / pixelsPerBeat,
-        subdivisionsPerBeat,
-      );
+    onClick: () => {},
+    onDragStart: () => {},
+    onDragMove: (_event, { data, deltaX }) => {
+      const delta = snapBeat(deltaX / pixelsPerBeat, subdivisionsPerBeat);
       onChange({
-        ...drag.range,
-        endBeat: Math.max(
-          drag.range.startBeat + minimumLength,
-          drag.range.endBeat + delta,
-        ),
+        ...data,
+        endBeat: Math.max(data.startBeat + minimumLength, data.endBeat + delta),
       });
     },
   });

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -13,6 +13,7 @@ import { AudioView } from "../../lib/audio-view";
 import type {
   RecorderRuntimeState,
   RecorderLoopRange,
+  RecorderLoopState,
   ReferenceVideoState,
 } from "../../lib/recorder/runtime";
 import { formatTimeMinutes } from "../../lib/time-format";
@@ -64,7 +65,7 @@ export function TimelineHeader({
   onAddAudioTrack: () => void;
   onAddAudioFile: (file: File) => void;
   onSeek: (position: number) => void;
-  loop: RecorderRuntimeState["loop"];
+  loop: RecorderLoopState;
   loopEditingDisabled: boolean;
   onLoopRangeChange: (range: RecorderLoopRange) => void;
   onLoopRangeClear: () => void;
@@ -142,7 +143,7 @@ function TimelineRuler({
   subdivisionsPerBeat: number;
   timelineWidth: number;
   onSeek: (position: number) => void;
-  loop: RecorderRuntimeState["loop"];
+  loop: RecorderLoopState;
   loopEditingDisabled: boolean;
   onLoopRangeChange: (range: RecorderLoopRange) => void;
   onLoopRangeClear: () => void;

--- a/src/hooks/use-pointer-gesture.ts
+++ b/src/hooks/use-pointer-gesture.ts
@@ -6,8 +6,8 @@ import {
 
 export function usePointerGesture<T>(options: PointerGestureOptions<T>) {
   const onStart = useEffectEvent(options.onStart);
-  const onClick = useEffectEvent(options.onClick);
-  const onDragStart = useEffectEvent(options.onDragStart);
+  const onClick = useEffectEvent(options.onClick ?? (() => {}));
+  const onDragStart = useEffectEvent(options.onDragStart ?? (() => {}));
   const onDragMove = useEffectEvent(options.onDragMove);
   const onDragEnd = useEffectEvent(options.onDragEnd ?? (() => {}));
   const onCancel = useEffectEvent(options.onCancel ?? (() => {}));

--- a/src/lib/recorder/persistence.ts
+++ b/src/lib/recorder/persistence.ts
@@ -21,6 +21,11 @@ export interface SerializedRecorderRuntimeState {
   // Optional for recorder projects saved before mixer support.
   masterGain?: number;
   metronomeGain?: number;
+  loopRange?: {
+    startBeat: number;
+    endBeat: number;
+  };
+  loopEnabled?: boolean;
   tempo: number;
   timeSignature: {
     numerator: number;
@@ -114,6 +119,8 @@ export function serializeRecorderRuntimeState(
     latencyCompensation: state.latencyCompensation,
     masterGain: state.masterGain,
     metronomeGain: state.metronomeGain,
+    loopRange: state.loopRange,
+    loopEnabled: state.loopEnabled,
     tempo: state.tempo,
     timeSignature: state.timeSignature,
     referenceVideo: state.referenceVideo,
@@ -187,10 +194,29 @@ export function deserializeRecorderRuntimeState({
     latencyCompensation: project.latencyCompensation,
     masterGain: project.masterGain ?? 1,
     metronomeGain: project.metronomeGain ?? 0.5,
+    loopRange: deserializeLoopRange(project.loopRange),
+    loopEnabled: project.loopEnabled ?? false,
     tempo: project.tempo,
     timeSignature: project.timeSignature,
     referenceVideo: project.referenceVideo,
   };
+}
+
+function deserializeLoopRange(
+  loopRange: SerializedRecorderRuntimeState["loopRange"],
+): SerializedRecorderRuntimeState["loopRange"] {
+  if (!loopRange) {
+    return undefined;
+  }
+  if (
+    !Number.isFinite(loopRange.startBeat) ||
+    !Number.isFinite(loopRange.endBeat) ||
+    loopRange.startBeat < 0 ||
+    loopRange.endBeat <= loopRange.startBeat
+  ) {
+    throw new Error("Recorder project has an invalid loop range.");
+  }
+  return loopRange;
 }
 
 function serializeAudioBuffer(buffer: AudioBuffer): RecorderPcm {

--- a/src/lib/recorder/persistence.ts
+++ b/src/lib/recorder/persistence.ts
@@ -21,11 +21,13 @@ export interface SerializedRecorderRuntimeState {
   // Optional for recorder projects saved before mixer support.
   masterGain?: number;
   metronomeGain?: number;
-  loopRange?: {
-    startBeat: number;
-    endBeat: number;
+  loop?: {
+    range?: {
+      startBeat: number;
+      endBeat: number;
+    };
+    enabled: boolean;
   };
-  loopEnabled?: boolean;
   tempo: number;
   timeSignature: {
     numerator: number;
@@ -119,8 +121,7 @@ export function serializeRecorderRuntimeState(
     latencyCompensation: state.latencyCompensation,
     masterGain: state.masterGain,
     metronomeGain: state.metronomeGain,
-    loopRange: state.loopRange,
-    loopEnabled: state.loopEnabled,
+    loop: state.loop,
     tempo: state.tempo,
     timeSignature: state.timeSignature,
     referenceVideo: state.referenceVideo,
@@ -194,8 +195,7 @@ export function deserializeRecorderRuntimeState({
     latencyCompensation: project.latencyCompensation,
     masterGain: project.masterGain ?? 1,
     metronomeGain: project.metronomeGain ?? 0.5,
-    loopRange: project.loopRange,
-    loopEnabled: project.loopEnabled ?? false,
+    loop: project.loop ?? { enabled: false },
     tempo: project.tempo,
     timeSignature: project.timeSignature,
     referenceVideo: project.referenceVideo,

--- a/src/lib/recorder/persistence.ts
+++ b/src/lib/recorder/persistence.ts
@@ -194,29 +194,12 @@ export function deserializeRecorderRuntimeState({
     latencyCompensation: project.latencyCompensation,
     masterGain: project.masterGain ?? 1,
     metronomeGain: project.metronomeGain ?? 0.5,
-    loopRange: deserializeLoopRange(project.loopRange),
+    loopRange: project.loopRange,
     loopEnabled: project.loopEnabled ?? false,
     tempo: project.tempo,
     timeSignature: project.timeSignature,
     referenceVideo: project.referenceVideo,
   };
-}
-
-function deserializeLoopRange(
-  loopRange: SerializedRecorderRuntimeState["loopRange"],
-): SerializedRecorderRuntimeState["loopRange"] {
-  if (!loopRange) {
-    return undefined;
-  }
-  if (
-    !Number.isFinite(loopRange.startBeat) ||
-    !Number.isFinite(loopRange.endBeat) ||
-    loopRange.startBeat < 0 ||
-    loopRange.endBeat <= loopRange.startBeat
-  ) {
-    throw new Error("Recorder project has an invalid loop range.");
-  }
-  return loopRange;
 }
 
 function serializeAudioBuffer(buffer: AudioBuffer): RecorderPcm {

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -693,14 +693,6 @@ export class RecorderRuntime {
   }
 
   setLoopRange(loopRange: RecorderLoopRange): void {
-    if (
-      !Number.isFinite(loopRange.startBeat) ||
-      !Number.isFinite(loopRange.endBeat) ||
-      loopRange.startBeat < 0 ||
-      loopRange.endBeat <= loopRange.startBeat
-    ) {
-      throw new Error("Recorder loop range is invalid.");
-    }
     this.store.update({ loopRange });
   }
 

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -59,6 +59,11 @@ export interface RecorderLoopRange {
   endBeat: number;
 }
 
+export interface RecorderLoopState {
+  range?: RecorderLoopRange;
+  enabled: boolean;
+}
+
 interface PendingRecordingState extends Pick<
   TakeState,
   "id" | "number" | "duration" | "timelineOffset"
@@ -82,10 +87,7 @@ export interface RecorderRuntimeState {
   tempo: number;
   timeSignature: TimeSignature;
   metronomeEnabled: boolean;
-  loop: {
-    range?: RecorderLoopRange;
-    enabled: boolean;
-  };
+  loop: RecorderLoopState;
   referenceVideo?: ReferenceVideoState;
   masterGain: number;
   metronomeGain: number;
@@ -693,7 +695,7 @@ export class RecorderRuntime {
     this.syncMetronomeGain();
   }
 
-  setLoop(update: Partial<RecorderRuntimeState["loop"]>): void {
+  setLoop(update: Partial<RecorderLoopState>): void {
     this.store.update({
       loop: { ...this.store.get().loop, ...update },
     });

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -82,8 +82,10 @@ export interface RecorderRuntimeState {
   tempo: number;
   timeSignature: TimeSignature;
   metronomeEnabled: boolean;
-  loopRange?: RecorderLoopRange;
-  loopEnabled: boolean;
+  loop: {
+    range?: RecorderLoopRange;
+    enabled: boolean;
+  };
   referenceVideo?: ReferenceVideoState;
   masterGain: number;
   metronomeGain: number;
@@ -107,8 +109,7 @@ export type PersistableRecorderRuntimeState = Pick<
   | "timeSignature"
   | "masterGain"
   | "metronomeGain"
-  | "loopRange"
-  | "loopEnabled"
+  | "loop"
   | "audioTracks"
   | "recordingTrack"
   | "latencyCompensation"
@@ -136,7 +137,7 @@ export function createDefaultRecorderRuntimeState(): RecorderRuntimeState {
     tempo: 120,
     timeSignature: DEFAULT_TIME_SIGNATURE,
     metronomeEnabled: false,
-    loopEnabled: false,
+    loop: { enabled: false },
     masterGain: 1,
     metronomeGain: 0.5,
     audioTracks: [],
@@ -693,18 +694,21 @@ export class RecorderRuntime {
   }
 
   setLoopRange(loopRange: RecorderLoopRange): void {
-    this.store.update({ loopRange });
+    this.store.update({
+      loop: { ...this.store.get().loop, range: loopRange },
+    });
   }
 
   clearLoopRange(): void {
-    this.store.update({ loopRange: undefined, loopEnabled: false });
+    this.store.update({ loop: { enabled: false } });
   }
 
   setLoopEnabled(loopEnabled: boolean): void {
-    if (loopEnabled && !this.store.get().loopRange) {
+    const loop = this.store.get().loop;
+    if (loopEnabled && !loop.range) {
       throw new Error("Set a recorder loop range before enabling it.");
     }
-    this.store.update({ loopEnabled });
+    this.store.update({ loop: { ...loop, enabled: loopEnabled } });
   }
 
   setTimeSignature(timeSignature: TimeSignature): void {
@@ -891,8 +895,7 @@ export class RecorderRuntime {
           timeSignature: state.timeSignature,
           masterGain: state.masterGain,
           metronomeGain: state.metronomeGain,
-          loopRange: state.loopRange,
-          loopEnabled: state.loopEnabled,
+          loop: state.loop,
           audioTracks: state.audioTracks,
           recordingTrack: state.recordingTrack,
           latencyCompensation: state.latencyCompensation,

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -54,6 +54,11 @@ interface RecordingTrackState {
   nextTakeNumber: number;
 }
 
+export interface RecorderLoopRange {
+  startBeat: number;
+  endBeat: number;
+}
+
 interface PendingRecordingState extends Pick<
   TakeState,
   "id" | "number" | "duration" | "timelineOffset"
@@ -77,6 +82,8 @@ export interface RecorderRuntimeState {
   tempo: number;
   timeSignature: TimeSignature;
   metronomeEnabled: boolean;
+  loopRange?: RecorderLoopRange;
+  loopEnabled: boolean;
   referenceVideo?: ReferenceVideoState;
   masterGain: number;
   metronomeGain: number;
@@ -100,6 +107,8 @@ export type PersistableRecorderRuntimeState = Pick<
   | "timeSignature"
   | "masterGain"
   | "metronomeGain"
+  | "loopRange"
+  | "loopEnabled"
   | "audioTracks"
   | "recordingTrack"
   | "latencyCompensation"
@@ -127,6 +136,7 @@ export function createDefaultRecorderRuntimeState(): RecorderRuntimeState {
     tempo: 120,
     timeSignature: DEFAULT_TIME_SIGNATURE,
     metronomeEnabled: false,
+    loopEnabled: false,
     masterGain: 1,
     metronomeGain: 0.5,
     audioTracks: [],
@@ -682,6 +692,29 @@ export class RecorderRuntime {
     this.syncMetronomeGain();
   }
 
+  setLoopRange(loopRange: RecorderLoopRange): void {
+    if (
+      !Number.isFinite(loopRange.startBeat) ||
+      !Number.isFinite(loopRange.endBeat) ||
+      loopRange.startBeat < 0 ||
+      loopRange.endBeat <= loopRange.startBeat
+    ) {
+      throw new Error("Recorder loop range is invalid.");
+    }
+    this.store.update({ loopRange });
+  }
+
+  clearLoopRange(): void {
+    this.store.update({ loopRange: undefined, loopEnabled: false });
+  }
+
+  setLoopEnabled(loopEnabled: boolean): void {
+    if (loopEnabled && !this.store.get().loopRange) {
+      throw new Error("Set a recorder loop range before enabling it.");
+    }
+    this.store.update({ loopEnabled });
+  }
+
   setTimeSignature(timeSignature: TimeSignature): void {
     this.store.update({ timeSignature });
     this.metronome?.setTimeSignature(timeSignature);
@@ -866,6 +899,8 @@ export class RecorderRuntime {
           timeSignature: state.timeSignature,
           masterGain: state.masterGain,
           metronomeGain: state.metronomeGain,
+          loopRange: state.loopRange,
+          loopEnabled: state.loopEnabled,
           audioTracks: state.audioTracks,
           recordingTrack: state.recordingTrack,
           latencyCompensation: state.latencyCompensation,

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -693,22 +693,10 @@ export class RecorderRuntime {
     this.syncMetronomeGain();
   }
 
-  setLoopRange(loopRange: RecorderLoopRange): void {
+  setLoop(update: Partial<RecorderRuntimeState["loop"]>): void {
     this.store.update({
-      loop: { ...this.store.get().loop, range: loopRange },
+      loop: { ...this.store.get().loop, ...update },
     });
-  }
-
-  clearLoopRange(): void {
-    this.store.update({ loop: { enabled: false } });
-  }
-
-  setLoopEnabled(loopEnabled: boolean): void {
-    const loop = this.store.get().loop;
-    if (loopEnabled && !loop.range) {
-      throw new Error("Set a recorder loop range before enabling it.");
-    }
-    this.store.update({ loop: { ...loop, enabled: loopEnabled } });
   }
 
   setTimeSignature(timeSignature: TimeSignature): void {

--- a/src/utils/pointer-gesture.ts
+++ b/src/utils/pointer-gesture.ts
@@ -9,8 +9,8 @@ export type PointerGesture<T> = {
 export type PointerGestureOptions<T> = {
   threshold?: number;
   onStart: (event: PointerEvent) => T;
-  onClick: (event: PointerEvent, gesture: PointerGesture<T>) => void;
-  onDragStart: (event: PointerEvent, gesture: PointerGesture<T>) => void;
+  onClick?: (event: PointerEvent, gesture: PointerGesture<T>) => void;
+  onDragStart?: (event: PointerEvent, gesture: PointerGesture<T>) => void;
   onDragMove: (event: PointerEvent, gesture: PointerGesture<T>) => void;
   onDragEnd?: (event: PointerEvent, gesture: PointerGesture<T>) => void;
   onCancel?: (
@@ -60,7 +60,7 @@ export function listenPointerGesture<T>({
         gesture.deltaX ** 2 + gesture.deltaY ** 2 >= threshold ** 2
       ) {
         state.dragged = true;
-        onDragStart(event, gesture);
+        onDragStart?.(event, gesture);
       }
       if (state.dragged) {
         onDragMove(event, gesture);
@@ -71,7 +71,7 @@ export function listenPointerGesture<T>({
       if (state.dragged) {
         onDragEnd?.(event, gesture);
       } else {
-        onClick(event, gesture);
+        onClick?.(event, gesture);
       }
     },
     onCancel: (event, state) => {


### PR DESCRIPTION
- related to https://github.com/hi-ogawa/toy-midi/issues/420
- [explain-diff artifact](https://gisthost.github.io/?e62e4d95225a5e6d33d06475d1d6bf7e/toy-midi-pr-424-explain-diff.html)

Loop playback can be useful independently as a quick practice tool, but the timeline interaction and transport control need to settle before wiring playback behavior.

This PR prototypes that contract with persisted beat-based loop state, runtime APIs, a transport-header toggle, and a grid-snapped ruler range that can be moved, resized, disabled, or cleared. It intentionally does not integrate the range with the transport yet, so playback and recording behavior remain unchanged.