### PR TITLE
feat: prototype recorder punch range UI

### DIFF
--- a/e2e/fake-audio/recorder-loop-range.test.ts
+++ b/e2e/fake-audio/recorder-loop-range.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { expect, test } from "@playwright/test";
-import { createRecorderProject, dragBy } from "./recorder-helpers";
+import {
+  createRecorderProject,
+  dragBy,
+  seekRecorderByPixels,
+} from "./recorder-helpers";
 
 test("creates and edits a persisted loop range", async ({ page }) => {
   await createRecorderProject(page);
@@ -41,9 +45,7 @@ test("creates and edits a persisted loop range", async ({ page }) => {
   const movedBox = await range.boundingBox();
   assert(movedBox);
   expect(movedBox.x).toBeCloseTo(initialBox.x + 80, -1);
-  await range.click({
-    position: { x: movedBox.width * 0.75, y: movedBox.height - 4 },
-  });
+  await seekRecorderByPixels(page, 320);
   await expect(position).toHaveText(/^02\|01 /);
 
   // Disabling playback keeps the edited range available for later use.

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -10,6 +10,7 @@ import {
 import { exportRecorderProjectArchive } from "../../lib/recorder/project-archive";
 import { RecorderRuntime } from "../../lib/recorder/runtime";
 import { formatTimeWithMilliseconds } from "../../lib/time-format";
+import { secondsToBeats } from "../../lib/timeline";
 import { encodeWav } from "../../lib/wav";
 import { parseTimeSignature } from "../../types";
 import { Dialog } from "../ui/dialog";
@@ -197,6 +198,7 @@ export function Recorder({ projectId }: { projectId: string }) {
         isExporting={exportProjectMutation.isPending}
         autoScrollEnabled={timeline.autoScrollEnabled}
         metronomeEnabled={state.metronomeEnabled}
+        punchEnabled={state.punchRange !== undefined}
         position={state.position}
         tempo={timeline.tempo}
         timeSignature={timeline.timeSignature}
@@ -211,6 +213,20 @@ export function Recorder({ projectId }: { projectId: string }) {
         onAutoScrollChange={timeline.setAutoScrollEnabled}
         onTempoChange={(tempo) => runtime.setTempo(tempo)}
         onMetronomeChange={(enabled) => runtime.setMetronomeEnabled(enabled)}
+        onPunchEnabledChange={(enabled) => {
+          if (!enabled) {
+            runtime.clearPunchRange();
+            return;
+          }
+          const positionBeat = secondsToBeats(state.position, state.tempo);
+          const startBeat =
+            Math.floor(positionBeat / timeline.beatsPerBar) *
+            timeline.beatsPerBar;
+          runtime.setPunchRange({
+            startBeat,
+            endBeat: startBeat + timeline.beatsPerBar,
+          });
+        }}
         onTimeSignatureChange={(timeSignature) =>
           runtime.setTimeSignature(parseTimeSignature(timeSignature))
         }
@@ -246,10 +262,14 @@ export function Recorder({ projectId }: { projectId: string }) {
               viewportStartBeat={timeline.viewportStartBeat}
               tempo={timeline.tempo}
               timelineWidth={timeline.viewportWidth}
+              punchRange={state.punchRange}
               isAddingAudio={addAudioMutation.isPending}
               onAddAudioTrack={() => runtime.addAudioTrack()}
               onAddAudioFile={(file) => addAudioMutation.mutate(file)}
               onSeek={(position) => runtime.seek(position)}
+              onPunchRangeChange={(punchRange) =>
+                runtime.setPunchRange(punchRange)
+              }
             />
             {state.referenceVideo && (
               <ReferenceTimelineRow

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -198,7 +198,7 @@ export function Recorder({ projectId }: { projectId: string }) {
         isExporting={exportProjectMutation.isPending}
         autoScrollEnabled={timeline.autoScrollEnabled}
         metronomeEnabled={state.metronomeEnabled}
-        punchEnabled={state.punchRange !== undefined}
+        punch={state.punch}
         position={state.position}
         tempo={timeline.tempo}
         timeSignature={timeline.timeSignature}
@@ -214,17 +214,20 @@ export function Recorder({ projectId }: { projectId: string }) {
         onTempoChange={(tempo) => runtime.setTempo(tempo)}
         onMetronomeChange={(enabled) => runtime.setMetronomeEnabled(enabled)}
         onPunchEnabledChange={(enabled) => {
-          if (!enabled) {
-            runtime.clearPunchRange();
-            return;
-          }
           const positionBeat = secondsToBeats(state.position, state.tempo);
           const startBeat =
             Math.floor(positionBeat / timeline.beatsPerBar) *
             timeline.beatsPerBar;
-          runtime.setPunchRange({
-            startBeat,
-            endBeat: startBeat + timeline.beatsPerBar,
+          runtime.setPunch({
+            enabled,
+            range:
+              state.punch.range ??
+              (enabled
+                ? {
+                    startBeat,
+                    endBeat: startBeat + timeline.beatsPerBar,
+                  }
+                : undefined),
           });
         }}
         onTimeSignatureChange={(timeSignature) =>
@@ -262,13 +265,15 @@ export function Recorder({ projectId }: { projectId: string }) {
               viewportStartBeat={timeline.viewportStartBeat}
               tempo={timeline.tempo}
               timelineWidth={timeline.viewportWidth}
-              punchRange={state.punchRange}
+              punch={state.punch}
+              punchEditingDisabled={isRecording || isProcessing}
               isAddingAudio={addAudioMutation.isPending}
               onAddAudioTrack={() => runtime.addAudioTrack()}
               onAddAudioFile={(file) => addAudioMutation.mutate(file)}
               onSeek={(position) => runtime.seek(position)}
-              onPunchRangeChange={(punchRange) =>
-                runtime.setPunchRange(punchRange)
+              onPunchRangeChange={(range) => runtime.setPunch({ range })}
+              onPunchRangeClear={() =>
+                runtime.setPunch({ range: undefined, enabled: false })
               }
             />
             {state.referenceVideo && (

--- a/src/components/recorder/recorder-header.tsx
+++ b/src/components/recorder/recorder-header.tsx
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import { useDraftInput } from "../../hooks/use-draft-input";
 import { useTapTempo } from "../../hooks/use-tap-tempo";
+import type { RecorderRuntimeState } from "../../lib/recorder/runtime";
 import { routes } from "../../lib/routes";
 import { formatTimeWithMilliseconds } from "../../lib/time-format";
 import {
@@ -49,7 +50,7 @@ export function RecorderHeader({
   isRecording,
   isExporting,
   metronomeEnabled,
-  punchEnabled,
+  punch,
   position,
   tempo,
   timeSignature,
@@ -79,7 +80,7 @@ export function RecorderHeader({
   isRecording: boolean;
   isExporting: boolean;
   metronomeEnabled: boolean;
-  punchEnabled: boolean;
+  punch: RecorderRuntimeState["punch"];
   position: number;
   tempo: number;
   timeSignature: TimeSignature;
@@ -102,6 +103,7 @@ export function RecorderHeader({
   mixerOpen: boolean;
 }) {
   const timeSignatureValue = `${timeSignature.numerator}/${timeSignature.denominator}`;
+  const { enabled: punchEnabled, range: punchRange } = punch;
   const tempoInput = useDraftInput({
     value: tempo,
     onCommit: onTempoChange,
@@ -187,7 +189,7 @@ export function RecorderHeader({
         data-testid="recorder-punch-toggle"
         onClick={() => onPunchEnabledChange(!punchEnabled)}
         aria-pressed={punchEnabled}
-        title="Toggle punch range"
+        title={punchRange ? "Toggle punch recording" : "Create punch range"}
         className={cn(
           "h-9 gap-1.5 px-2.5 text-xs font-medium",
           punchEnabled

--- a/src/components/recorder/recorder-header.tsx
+++ b/src/components/recorder/recorder-header.tsx
@@ -11,6 +11,7 @@ import {
   MoreVerticalIcon,
   PauseIcon,
   PlayIcon,
+  Repeat2Icon,
   SaveCheckIcon,
   SaveIcon,
   VideoIcon,
@@ -48,6 +49,7 @@ export function RecorderHeader({
   isRecording,
   isExporting,
   metronomeEnabled,
+  punchEnabled,
   position,
   tempo,
   timeSignature,
@@ -61,6 +63,7 @@ export function RecorderHeader({
   onAutoScrollChange,
   onTempoChange,
   onMetronomeChange,
+  onPunchEnabledChange,
   onTimeSignatureChange,
   onGridDivisionChange,
   onExportProject,
@@ -76,6 +79,7 @@ export function RecorderHeader({
   isRecording: boolean;
   isExporting: boolean;
   metronomeEnabled: boolean;
+  punchEnabled: boolean;
   position: number;
   tempo: number;
   timeSignature: TimeSignature;
@@ -89,6 +93,7 @@ export function RecorderHeader({
   onAutoScrollChange: (enabled: boolean) => void;
   onTempoChange: (tempo: number) => void;
   onMetronomeChange: (enabled: boolean) => void;
+  onPunchEnabledChange: (enabled: boolean) => void;
   onTimeSignatureChange: (value: string) => void;
   onGridDivisionChange: (value: GridDivision) => void;
   onExportProject: () => void;
@@ -177,6 +182,21 @@ export function RecorderHeader({
         )}
       >
         <LocateFixedIcon className="size-5" />
+      </Button>
+      <Button
+        data-testid="recorder-punch-toggle"
+        onClick={() => onPunchEnabledChange(!punchEnabled)}
+        aria-pressed={punchEnabled}
+        title="Toggle punch range"
+        className={cn(
+          "h-9 gap-1.5 px-2.5 text-xs font-medium",
+          punchEnabled
+            ? "bg-amber-500/20 text-amber-300 hover:bg-amber-500/25"
+            : "text-neutral-300 hover:bg-neutral-700/50 hover:text-neutral-100",
+        )}
+      >
+        <Repeat2Icon className="size-4" />
+        Punch
       </Button>
       <output
         data-testid="recorder-position"

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -269,17 +269,19 @@ function LoopRange({
         enabled
           ? "border-violet-300 bg-violet-400/20 text-violet-100"
           : "border-violet-400/70 bg-violet-400/10 text-violet-300",
-        "cursor-grab active:cursor-grabbing",
       )}
       style={{
         left: (range.startBeat - viewportStartBeat) * pixelsPerBeat,
         width: (range.endBeat - range.startBeat) * pixelsPerBeat,
       }}
     >
-      <span className="absolute left-1 top-1 font-sans text-[9px] font-semibold uppercase tracking-wide">
+      <span
+        ref={dragRef}
+        className="absolute left-1 top-1 z-10 cursor-grab font-sans text-[9px] font-semibold uppercase tracking-wide active:cursor-grabbing"
+        title="Move loop range"
+      >
         Loop
       </span>
-      <div ref={dragRef} className="absolute inset-0" />
       <div
         ref={startRef}
         className="absolute inset-y-0 -left-1 w-2 cursor-ew-resize"

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -4,13 +4,14 @@ import {
   PlusIcon,
   UploadIcon,
   Trash2Icon,
+  XIcon,
 } from "lucide-react";
 import { useState } from "react";
 import { usePointerDrag } from "../../hooks/use-pointer-drag";
 import { usePointerGesture } from "../../hooks/use-pointer-gesture";
 import { AudioView } from "../../lib/audio-view";
 import type {
-  PunchRange,
+  RecorderPunchRange,
   RecorderRuntimeState,
   ReferenceVideoState,
 } from "../../lib/recorder/runtime";
@@ -48,8 +49,10 @@ export function TimelineHeader({
   onAddAudioTrack,
   onAddAudioFile,
   onSeek,
-  punchRange,
+  punch,
+  punchEditingDisabled,
   onPunchRangeChange,
+  onPunchRangeClear,
 }: {
   beatsPerBar: number;
   pixelsPerBeat: number;
@@ -61,8 +64,10 @@ export function TimelineHeader({
   onAddAudioTrack: () => void;
   onAddAudioFile: (file: File) => void;
   onSeek: (position: number) => void;
-  punchRange?: PunchRange;
-  onPunchRangeChange: (range: PunchRange) => void;
+  punch: RecorderRuntimeState["punch"];
+  punchEditingDisabled: boolean;
+  onPunchRangeChange: (range: RecorderPunchRange) => void;
+  onPunchRangeClear: () => void;
 }) {
   return (
     <div className="sticky top-0 z-40 grid h-10 grid-cols-[15rem_1fr] border-b border-neutral-700 bg-neutral-800">
@@ -108,8 +113,10 @@ export function TimelineHeader({
         subdivisionsPerBeat={subdivisionsPerBeat}
         timelineWidth={timelineWidth}
         onSeek={onSeek}
-        punchRange={punchRange}
+        punch={punch}
+        punchEditingDisabled={punchEditingDisabled}
         onPunchRangeChange={onPunchRangeChange}
+        onPunchRangeClear={onPunchRangeClear}
       />
     </div>
   );
@@ -123,8 +130,10 @@ function TimelineRuler({
   subdivisionsPerBeat,
   timelineWidth,
   onSeek,
-  punchRange,
+  punch,
+  punchEditingDisabled,
   onPunchRangeChange,
+  onPunchRangeClear,
 }: {
   beatsPerBar: number;
   pixelsPerBeat: number;
@@ -133,8 +142,10 @@ function TimelineRuler({
   subdivisionsPerBeat: number;
   timelineWidth: number;
   onSeek: (position: number) => void;
-  punchRange?: PunchRange;
-  onPunchRangeChange: (range: PunchRange) => void;
+  punch: RecorderRuntimeState["punch"];
+  punchEditingDisabled: boolean;
+  onPunchRangeChange: (range: RecorderPunchRange) => void;
+  onPunchRangeClear: () => void;
 }) {
   const labelEveryBars = getVisibleBarInterval({
     barWidth: beatsPerBar * pixelsPerBeat,
@@ -148,62 +159,6 @@ function TimelineRuler({
     Math.ceil(
       (viewportStartBeat + visibleBeats - firstLabelBeat) / labelEveryBeats,
     ) + 1;
-  const snapBeat = (beat: number) =>
-    Math.round(beat * subdivisionsPerBeat) / subdivisionsPerBeat;
-  const rangeRef = usePointerDrag({
-    onStart: (event) => ({
-      startX: event.clientX,
-      range: punchRange!,
-    }),
-    onMove: (event, drag) => {
-      const duration = drag.range.endBeat - drag.range.startBeat;
-      const startBeat = Math.max(
-        0,
-        snapBeat(
-          drag.range.startBeat + (event.clientX - drag.startX) / pixelsPerBeat,
-        ),
-      );
-      onPunchRangeChange({ startBeat, endBeat: startBeat + duration });
-    },
-  });
-  const startRef = usePointerDrag({
-    onStart: (event) => ({
-      range: punchRange!,
-      ruler: (event.currentTarget as HTMLElement).parentElement!,
-    }),
-    onMove: (event, drag) => {
-      const rect = drag.ruler.getBoundingClientRect();
-      const startBeat = Math.max(
-        0,
-        snapBeat(
-          (event.clientX - rect.left) / pixelsPerBeat + viewportStartBeat,
-        ),
-      );
-      onPunchRangeChange({
-        startBeat: Math.min(
-          startBeat,
-          drag.range.endBeat - 1 / subdivisionsPerBeat,
-        ),
-        endBeat: drag.range.endBeat,
-      });
-    },
-  });
-  const endRef = usePointerDrag({
-    onStart: (event) => ({
-      range: punchRange!,
-      ruler: (event.currentTarget as HTMLElement).parentElement!,
-    }),
-    onMove: (event, drag) => {
-      const rect = drag.ruler.getBoundingClientRect();
-      const endBeat = Math.max(
-        drag.range.startBeat + 1 / subdivisionsPerBeat,
-        snapBeat(
-          (event.clientX - rect.left) / pixelsPerBeat + viewportStartBeat,
-        ),
-      );
-      onPunchRangeChange({ startBeat: drag.range.startBeat, endBeat });
-    },
-  });
   return (
     <div
       data-testid="recorder-timeline-ruler"
@@ -223,33 +178,17 @@ function TimelineRuler({
         onSeek(beatsToSeconds(beat, tempo));
       }}
     >
-      {punchRange && (
-        <div
-          data-testid="recorder-punch-range"
-          ref={rangeRef}
-          className="absolute inset-y-0 cursor-grab border-x border-amber-400 bg-amber-400/20 text-amber-200 active:cursor-grabbing"
-          style={{
-            left: (punchRange.startBeat - viewportStartBeat) * pixelsPerBeat,
-            width: (punchRange.endBeat - punchRange.startBeat) * pixelsPerBeat,
-          }}
-          onPointerDown={(event) => event.stopPropagation()}
-        >
-          <div
-            ref={startRef}
-            data-testid="recorder-punch-start"
-            className="absolute inset-y-0 left-0 w-2 -translate-x-1/2 cursor-ew-resize bg-amber-400"
-          />
-          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-            <span className="rounded bg-neutral-900/80 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider">
-              Punch
-            </span>
-          </div>
-          <div
-            ref={endRef}
-            data-testid="recorder-punch-end"
-            className="absolute inset-y-0 right-0 w-2 translate-x-1/2 cursor-ew-resize bg-amber-400"
-          />
-        </div>
+      {punch.range && (
+        <PunchRange
+          range={punch.range}
+          enabled={punch.enabled}
+          disabled={punchEditingDisabled}
+          pixelsPerBeat={pixelsPerBeat}
+          subdivisionsPerBeat={subdivisionsPerBeat}
+          viewportStartBeat={viewportStartBeat}
+          onChange={onPunchRangeChange}
+          onClear={onPunchRangeClear}
+        />
       )}
       {Array.from({ length: Math.max(0, labelCount) }, (_, index) => {
         const beat = firstLabelBeat + index * labelEveryBeats;
@@ -265,6 +204,133 @@ function TimelineRuler({
       })}
     </div>
   );
+}
+
+function PunchRange({
+  range,
+  enabled,
+  disabled,
+  pixelsPerBeat,
+  subdivisionsPerBeat,
+  viewportStartBeat,
+  onChange,
+  onClear,
+}: {
+  range: RecorderPunchRange;
+  enabled: boolean;
+  disabled: boolean;
+  pixelsPerBeat: number;
+  subdivisionsPerBeat: number;
+  viewportStartBeat: number;
+  onChange: (range: RecorderPunchRange) => void;
+  onClear: () => void;
+}) {
+  const minimumLength = 1 / subdivisionsPerBeat;
+  const dragRef = usePointerGesture({
+    onStart: (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      return range;
+    },
+    onClick: () => {},
+    onDragStart: () => {},
+    onDragMove: (_event, { data, deltaX }) => {
+      const delta = snapBeat(deltaX / pixelsPerBeat, subdivisionsPerBeat);
+      const startBeat = Math.max(0, data.startBeat + delta);
+      onChange({
+        startBeat,
+        endBeat: startBeat + data.endBeat - data.startBeat,
+      });
+    },
+  });
+  const startRef = usePointerGesture({
+    onStart: (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      return range;
+    },
+    onClick: () => {},
+    onDragStart: () => {},
+    onDragMove: (_event, { data, deltaX }) => {
+      const delta = snapBeat(deltaX / pixelsPerBeat, subdivisionsPerBeat);
+      onChange({
+        ...data,
+        startBeat: Math.max(
+          0,
+          Math.min(data.endBeat - minimumLength, data.startBeat + delta),
+        ),
+      });
+    },
+  });
+  const endRef = usePointerGesture({
+    onStart: (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      return range;
+    },
+    onClick: () => {},
+    onDragStart: () => {},
+    onDragMove: (_event, { data, deltaX }) => {
+      const delta = snapBeat(deltaX / pixelsPerBeat, subdivisionsPerBeat);
+      onChange({
+        ...data,
+        endBeat: Math.max(data.startBeat + minimumLength, data.endBeat + delta),
+      });
+    },
+  });
+  return (
+    <div
+      data-testid="recorder-punch-range"
+      className={cn(
+        "absolute inset-y-0 z-10 border-x select-none",
+        enabled
+          ? "border-amber-300 bg-amber-400/20 text-amber-100"
+          : "border-amber-400/70 bg-amber-400/10 text-amber-300",
+        disabled
+          ? "cursor-default opacity-60"
+          : "cursor-grab active:cursor-grabbing",
+      )}
+      style={{
+        left: (range.startBeat - viewportStartBeat) * pixelsPerBeat,
+        width: (range.endBeat - range.startBeat) * pixelsPerBeat,
+      }}
+    >
+      <span className="absolute left-1 top-1 font-sans text-[9px] font-semibold uppercase tracking-wide">
+        Punch
+      </span>
+      {!disabled && (
+        <>
+          <div ref={dragRef} className="absolute inset-0" />
+          <div
+            ref={startRef}
+            data-testid="recorder-punch-start"
+            className="absolute inset-y-0 -left-1 w-2 cursor-ew-resize"
+          />
+          <div
+            ref={endRef}
+            data-testid="recorder-punch-end"
+            className="absolute inset-y-0 -right-1 w-2 cursor-ew-resize"
+          />
+          <button
+            type="button"
+            title="Clear punch range"
+            data-testid="recorder-punch-clear"
+            className="absolute right-0.5 top-0.5 grid size-4 place-items-center rounded hover:bg-amber-200/20"
+            onClick={(event) => {
+              event.stopPropagation();
+              onClear();
+            }}
+          >
+            <XIcon className="size-3" />
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+function snapBeat(beat: number, subdivisionsPerBeat: number): number {
+  return Math.round(beat * subdivisionsPerBeat) / subdivisionsPerBeat;
 }
 
 type RecorderTimelineClip = {

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -10,6 +10,7 @@ import { usePointerDrag } from "../../hooks/use-pointer-drag";
 import { usePointerGesture } from "../../hooks/use-pointer-gesture";
 import { AudioView } from "../../lib/audio-view";
 import type {
+  PunchRange,
   RecorderRuntimeState,
   ReferenceVideoState,
 } from "../../lib/recorder/runtime";
@@ -47,6 +48,8 @@ export function TimelineHeader({
   onAddAudioTrack,
   onAddAudioFile,
   onSeek,
+  punchRange,
+  onPunchRangeChange,
 }: {
   beatsPerBar: number;
   pixelsPerBeat: number;
@@ -58,6 +61,8 @@ export function TimelineHeader({
   onAddAudioTrack: () => void;
   onAddAudioFile: (file: File) => void;
   onSeek: (position: number) => void;
+  punchRange?: PunchRange;
+  onPunchRangeChange: (range: PunchRange) => void;
 }) {
   return (
     <div className="sticky top-0 z-40 grid h-10 grid-cols-[15rem_1fr] border-b border-neutral-700 bg-neutral-800">
@@ -103,6 +108,8 @@ export function TimelineHeader({
         subdivisionsPerBeat={subdivisionsPerBeat}
         timelineWidth={timelineWidth}
         onSeek={onSeek}
+        punchRange={punchRange}
+        onPunchRangeChange={onPunchRangeChange}
       />
     </div>
   );
@@ -116,6 +123,8 @@ function TimelineRuler({
   subdivisionsPerBeat,
   timelineWidth,
   onSeek,
+  punchRange,
+  onPunchRangeChange,
 }: {
   beatsPerBar: number;
   pixelsPerBeat: number;
@@ -124,6 +133,8 @@ function TimelineRuler({
   subdivisionsPerBeat: number;
   timelineWidth: number;
   onSeek: (position: number) => void;
+  punchRange?: PunchRange;
+  onPunchRangeChange: (range: PunchRange) => void;
 }) {
   const labelEveryBars = getVisibleBarInterval({
     barWidth: beatsPerBar * pixelsPerBeat,
@@ -137,6 +148,62 @@ function TimelineRuler({
     Math.ceil(
       (viewportStartBeat + visibleBeats - firstLabelBeat) / labelEveryBeats,
     ) + 1;
+  const snapBeat = (beat: number) =>
+    Math.round(beat * subdivisionsPerBeat) / subdivisionsPerBeat;
+  const rangeRef = usePointerDrag({
+    onStart: (event) => ({
+      startX: event.clientX,
+      range: punchRange!,
+    }),
+    onMove: (event, drag) => {
+      const duration = drag.range.endBeat - drag.range.startBeat;
+      const startBeat = Math.max(
+        0,
+        snapBeat(
+          drag.range.startBeat + (event.clientX - drag.startX) / pixelsPerBeat,
+        ),
+      );
+      onPunchRangeChange({ startBeat, endBeat: startBeat + duration });
+    },
+  });
+  const startRef = usePointerDrag({
+    onStart: (event) => ({
+      range: punchRange!,
+      ruler: (event.currentTarget as HTMLElement).parentElement!,
+    }),
+    onMove: (event, drag) => {
+      const rect = drag.ruler.getBoundingClientRect();
+      const startBeat = Math.max(
+        0,
+        snapBeat(
+          (event.clientX - rect.left) / pixelsPerBeat + viewportStartBeat,
+        ),
+      );
+      onPunchRangeChange({
+        startBeat: Math.min(
+          startBeat,
+          drag.range.endBeat - 1 / subdivisionsPerBeat,
+        ),
+        endBeat: drag.range.endBeat,
+      });
+    },
+  });
+  const endRef = usePointerDrag({
+    onStart: (event) => ({
+      range: punchRange!,
+      ruler: (event.currentTarget as HTMLElement).parentElement!,
+    }),
+    onMove: (event, drag) => {
+      const rect = drag.ruler.getBoundingClientRect();
+      const endBeat = Math.max(
+        drag.range.startBeat + 1 / subdivisionsPerBeat,
+        snapBeat(
+          (event.clientX - rect.left) / pixelsPerBeat + viewportStartBeat,
+        ),
+      );
+      onPunchRangeChange({ startBeat: drag.range.startBeat, endBeat });
+    },
+  });
   return (
     <div
       data-testid="recorder-timeline-ruler"
@@ -156,6 +223,34 @@ function TimelineRuler({
         onSeek(beatsToSeconds(beat, tempo));
       }}
     >
+      {punchRange && (
+        <div
+          data-testid="recorder-punch-range"
+          ref={rangeRef}
+          className="absolute inset-y-0 cursor-grab border-x border-amber-400 bg-amber-400/20 text-amber-200 active:cursor-grabbing"
+          style={{
+            left: (punchRange.startBeat - viewportStartBeat) * pixelsPerBeat,
+            width: (punchRange.endBeat - punchRange.startBeat) * pixelsPerBeat,
+          }}
+          onPointerDown={(event) => event.stopPropagation()}
+        >
+          <div
+            ref={startRef}
+            data-testid="recorder-punch-start"
+            className="absolute inset-y-0 left-0 w-2 -translate-x-1/2 cursor-ew-resize bg-amber-400"
+          />
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <span className="rounded bg-neutral-900/80 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider">
+              Punch
+            </span>
+          </div>
+          <div
+            ref={endRef}
+            data-testid="recorder-punch-end"
+            className="absolute inset-y-0 right-0 w-2 translate-x-1/2 cursor-ew-resize bg-amber-400"
+          />
+        </div>
+      )}
       {Array.from({ length: Math.max(0, labelCount) }, (_, index) => {
         const beat = firstLabelBeat + index * labelEveryBeats;
         return (

--- a/src/lib/recorder/persistence.ts
+++ b/src/lib/recorder/persistence.ts
@@ -21,9 +21,12 @@ export interface SerializedRecorderRuntimeState {
   // Optional for recorder projects saved before mixer support.
   masterGain?: number;
   metronomeGain?: number;
-  punchRange?: {
-    startBeat: number;
-    endBeat: number;
+  punch?: {
+    range?: {
+      startBeat: number;
+      endBeat: number;
+    };
+    enabled: boolean;
   };
   tempo: number;
   timeSignature: {
@@ -118,7 +121,7 @@ export function serializeRecorderRuntimeState(
     latencyCompensation: state.latencyCompensation,
     masterGain: state.masterGain,
     metronomeGain: state.metronomeGain,
-    punchRange: state.punchRange,
+    punch: state.punch,
     tempo: state.tempo,
     timeSignature: state.timeSignature,
     referenceVideo: state.referenceVideo,
@@ -192,28 +195,11 @@ export function deserializeRecorderRuntimeState({
     latencyCompensation: project.latencyCompensation,
     masterGain: project.masterGain ?? 1,
     metronomeGain: project.metronomeGain ?? 0.5,
-    punchRange: parsePunchRange(project.punchRange),
+    punch: project.punch ?? { enabled: false },
     tempo: project.tempo,
     timeSignature: project.timeSignature,
     referenceVideo: project.referenceVideo,
   };
-}
-
-function parsePunchRange(
-  range: SerializedRecorderRuntimeState["punchRange"],
-): SerializedRecorderRuntimeState["punchRange"] {
-  if (!range) {
-    return undefined;
-  }
-  if (
-    !Number.isFinite(range.startBeat) ||
-    !Number.isFinite(range.endBeat) ||
-    range.startBeat < 0 ||
-    range.endBeat <= range.startBeat
-  ) {
-    throw new Error("Recorder project has an invalid punch range.");
-  }
-  return range;
 }
 
 function serializeAudioBuffer(buffer: AudioBuffer): RecorderPcm {

--- a/src/lib/recorder/persistence.ts
+++ b/src/lib/recorder/persistence.ts
@@ -21,6 +21,10 @@ export interface SerializedRecorderRuntimeState {
   // Optional for recorder projects saved before mixer support.
   masterGain?: number;
   metronomeGain?: number;
+  punchRange?: {
+    startBeat: number;
+    endBeat: number;
+  };
   tempo: number;
   timeSignature: {
     numerator: number;
@@ -114,6 +118,7 @@ export function serializeRecorderRuntimeState(
     latencyCompensation: state.latencyCompensation,
     masterGain: state.masterGain,
     metronomeGain: state.metronomeGain,
+    punchRange: state.punchRange,
     tempo: state.tempo,
     timeSignature: state.timeSignature,
     referenceVideo: state.referenceVideo,
@@ -187,10 +192,28 @@ export function deserializeRecorderRuntimeState({
     latencyCompensation: project.latencyCompensation,
     masterGain: project.masterGain ?? 1,
     metronomeGain: project.metronomeGain ?? 0.5,
+    punchRange: parsePunchRange(project.punchRange),
     tempo: project.tempo,
     timeSignature: project.timeSignature,
     referenceVideo: project.referenceVideo,
   };
+}
+
+function parsePunchRange(
+  range: SerializedRecorderRuntimeState["punchRange"],
+): SerializedRecorderRuntimeState["punchRange"] {
+  if (!range) {
+    return undefined;
+  }
+  if (
+    !Number.isFinite(range.startBeat) ||
+    !Number.isFinite(range.endBeat) ||
+    range.startBeat < 0 ||
+    range.endBeat <= range.startBeat
+  ) {
+    throw new Error("Recorder project has an invalid punch range.");
+  }
+  return range;
 }
 
 function serializeAudioBuffer(buffer: AudioBuffer): RecorderPcm {

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -54,6 +54,11 @@ interface RecordingTrackState {
   nextTakeNumber: number;
 }
 
+export interface PunchRange {
+  startBeat: number;
+  endBeat: number;
+}
+
 interface PendingRecordingState extends Pick<
   TakeState,
   "id" | "number" | "duration" | "timelineOffset"
@@ -77,6 +82,7 @@ export interface RecorderRuntimeState {
   tempo: number;
   timeSignature: TimeSignature;
   metronomeEnabled: boolean;
+  punchRange?: PunchRange;
   referenceVideo?: ReferenceVideoState;
   masterGain: number;
   metronomeGain: number;
@@ -100,6 +106,7 @@ export type PersistableRecorderRuntimeState = Pick<
   | "timeSignature"
   | "masterGain"
   | "metronomeGain"
+  | "punchRange"
   | "audioTracks"
   | "recordingTrack"
   | "latencyCompensation"
@@ -677,6 +684,22 @@ export class RecorderRuntime {
     this.syncMetronomeGain();
   }
 
+  setPunchRange(punchRange: PunchRange): void {
+    if (
+      !Number.isFinite(punchRange.startBeat) ||
+      !Number.isFinite(punchRange.endBeat) ||
+      punchRange.startBeat < 0 ||
+      punchRange.endBeat <= punchRange.startBeat
+    ) {
+      throw new Error("Punch range is invalid.");
+    }
+    this.store.update({ punchRange });
+  }
+
+  clearPunchRange(): void {
+    this.store.update({ punchRange: undefined });
+  }
+
   setMetronomeGain(metronomeGain: number): void {
     this.store.update({ metronomeGain });
     this.syncMetronomeGain();
@@ -866,6 +889,7 @@ export class RecorderRuntime {
           timeSignature: state.timeSignature,
           masterGain: state.masterGain,
           metronomeGain: state.metronomeGain,
+          punchRange: state.punchRange,
           audioTracks: state.audioTracks,
           recordingTrack: state.recordingTrack,
           latencyCompensation: state.latencyCompensation,

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -54,7 +54,7 @@ interface RecordingTrackState {
   nextTakeNumber: number;
 }
 
-export interface PunchRange {
+export interface RecorderPunchRange {
   startBeat: number;
   endBeat: number;
 }
@@ -82,7 +82,10 @@ export interface RecorderRuntimeState {
   tempo: number;
   timeSignature: TimeSignature;
   metronomeEnabled: boolean;
-  punchRange?: PunchRange;
+  punch: {
+    range?: RecorderPunchRange;
+    enabled: boolean;
+  };
   referenceVideo?: ReferenceVideoState;
   masterGain: number;
   metronomeGain: number;
@@ -106,7 +109,7 @@ export type PersistableRecorderRuntimeState = Pick<
   | "timeSignature"
   | "masterGain"
   | "metronomeGain"
-  | "punchRange"
+  | "punch"
   | "audioTracks"
   | "recordingTrack"
   | "latencyCompensation"
@@ -134,6 +137,7 @@ export function createDefaultRecorderRuntimeState(): RecorderRuntimeState {
     tempo: 120,
     timeSignature: DEFAULT_TIME_SIGNATURE,
     metronomeEnabled: false,
+    punch: { enabled: false },
     masterGain: 1,
     metronomeGain: 0.5,
     audioTracks: [],
@@ -684,20 +688,10 @@ export class RecorderRuntime {
     this.syncMetronomeGain();
   }
 
-  setPunchRange(punchRange: PunchRange): void {
-    if (
-      !Number.isFinite(punchRange.startBeat) ||
-      !Number.isFinite(punchRange.endBeat) ||
-      punchRange.startBeat < 0 ||
-      punchRange.endBeat <= punchRange.startBeat
-    ) {
-      throw new Error("Punch range is invalid.");
-    }
-    this.store.update({ punchRange });
-  }
-
-  clearPunchRange(): void {
-    this.store.update({ punchRange: undefined });
+  setPunch(update: Partial<RecorderRuntimeState["punch"]>): void {
+    this.store.update({
+      punch: { ...this.store.get().punch, ...update },
+    });
   }
 
   setMetronomeGain(metronomeGain: number): void {
@@ -889,7 +883,7 @@ export class RecorderRuntime {
           timeSignature: state.timeSignature,
           masterGain: state.masterGain,
           metronomeGain: state.metronomeGain,
-          punchRange: state.punchRange,
+          punch: state.punch,
           audioTracks: state.audioTracks,
           recordingTrack: state.recordingTrack,
           latencyCompensation: state.latencyCompensation,


### PR DESCRIPTION
- related to https://github.com/hi-ogawa/toy-midi/issues/420

This PR prototypes the punch-range UI and runtime API shape before recording behavior is connected. Punch can be toggled from the recorder header, starts as a one-bar range around the current position, and can be moved or resized on the timeline ruler with grid snapping. Disabling Punch retains and dims the range, while a separate ruler action clears it.

The range is persisted with the recorder project, but it does not yet affect capture, take trims, playback, or transport. Loop range behavior remains out of scope.