### PR TITLE
feat: loop recorder transport playback

### DIFF
--- a/e2e/fake-audio/recorder-loop-range.test.ts
+++ b/e2e/fake-audio/recorder-loop-range.test.ts
@@ -23,11 +23,17 @@ test("creates and edits a persisted loop range", async ({ page }) => {
   await playButton.click();
   await expect(playButton).toHaveAttribute("aria-pressed", "true");
   await expect
-    .poll(async () => position.textContent())
-    .toMatch(/^01\|0[1-4] - 00:0[0-2]\./);
+    .poll(async () => position.textContent(), {
+      intervals: [50],
+      timeout: 1_500,
+    })
+    .toMatch(/^01\|0[34] /);
   await expect
-    .poll(async () => position.textContent())
-    .toMatch(/^01\|01 - 00:00\./);
+    .poll(async () => position.textContent(), {
+      intervals: [50],
+      timeout: 1_500,
+    })
+    .toMatch(/^01\|0[12] /);
   await playButton.click();
 
   // The range can be repositioned directly on the timeline ruler.

--- a/e2e/fake-audio/recorder-loop-range.test.ts
+++ b/e2e/fake-audio/recorder-loop-range.test.ts
@@ -15,6 +15,18 @@ test("creates and edits a persisted loop range", async ({ page }) => {
   const initialBox = await range.boundingBox();
   expect(initialBox).not.toBeNull();
 
+  const playButton = page.getByTestId("recorder-play-button");
+  const position = page.getByTestId("recorder-position");
+  await playButton.click();
+  await expect(playButton).toHaveAttribute("aria-pressed", "true");
+  await expect
+    .poll(async () => position.textContent())
+    .toMatch(/^01\|0[1-4] - 00:0[0-2]\./);
+  await expect
+    .poll(async () => position.textContent())
+    .toMatch(/^01\|01 - 00:00\./);
+  await playButton.click();
+
   await dragBy(page, range, 80, { anchorXOffset: initialBox!.width / 2 });
   const movedBox = await range.boundingBox();
   expect(movedBox).not.toBeNull();

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -2,6 +2,7 @@ import { DEFAULT_TIME_SIGNATURE, type TimeSignature } from "../../types.ts";
 import { createStore, shallowEqual } from "../../utils/store.ts";
 import { type AudioView, createAudioView } from "../audio-view.ts";
 import { clamp } from "../music.ts";
+import { beatsToSeconds } from "../timeline.ts";
 import type { YouTubePlayerApi } from "../youtube.ts";
 import { AudioBufferPlayback } from "./audio-buffer-playback.ts";
 import { CaptureInput } from "./capture-input.ts";
@@ -671,6 +672,7 @@ export class RecorderRuntime {
   setTempo(tempo: number): void {
     this.store.update({ tempo });
     this.metronome?.setTempo(tempo);
+    this.syncLoopRange();
   }
 
   setMasterGain(masterGain: number): void {
@@ -702,10 +704,12 @@ export class RecorderRuntime {
       throw new Error("Recorder loop range is invalid.");
     }
     this.store.update({ loopRange });
+    this.syncLoopRange();
   }
 
   clearLoopRange(): void {
     this.store.update({ loopRange: undefined, loopEnabled: false });
+    this.syncLoopRange();
   }
 
   setLoopEnabled(loopEnabled: boolean): void {
@@ -713,6 +717,7 @@ export class RecorderRuntime {
       throw new Error("Set a recorder loop range before enabling it.");
     }
     this.store.update({ loopEnabled });
+    this.syncLoopRange();
   }
 
   setTimeSignature(timeSignature: TimeSignature): void {
@@ -885,6 +890,7 @@ export class RecorderRuntime {
     this.transport!.seek(0);
     this.metronome!.setTempo(project.tempo);
     this.metronome!.setTimeSignature(project.timeSignature);
+    this.syncLoopRange();
     this.masterOutput!.gain.value = project.masterGain;
     this.syncMetronomeGain();
     this.syncTrackMix();
@@ -922,6 +928,7 @@ export class RecorderRuntime {
       this.syncMetronomeGain();
       this.metronome.setTempo(this.store.get().tempo);
       this.metronome.setTimeSignature(this.store.get().timeSignature);
+      this.syncLoopRange();
       this.transport.store.subscribe(() => {
         const { position, isPlaying } = this.transport!.store.get();
         this.store.update({ isPlaying, position });
@@ -953,6 +960,19 @@ export class RecorderRuntime {
   private syncMetronomeGain(): void {
     const state = this.store.get();
     this.metronome?.setGain(state.metronomeEnabled ? state.metronomeGain : 0);
+  }
+
+  private syncLoopRange(): void {
+    const state = this.store.get();
+    const loopRange = state.loopEnabled ? state.loopRange : undefined;
+    this.transport?.setLoopRange(
+      loopRange
+        ? {
+            start: beatsToSeconds(loopRange.startBeat, state.tempo),
+            end: beatsToSeconds(loopRange.endBeat, state.tempo),
+          }
+        : undefined,
+    );
   }
 
   private finishRecording(stopFrame: number): void {

--- a/src/lib/recorder/transport.ts
+++ b/src/lib/recorder/transport.ts
@@ -68,9 +68,7 @@ export class AudioContextTransport {
       this.loopRange && currentPosition >= this.loopRange.end
         ? this.loopRange.start
         : currentPosition;
-    this.store.update({ position });
     this.startParticipants(position);
-    this.store.update({ isPlaying: true });
     this.startTicking();
   }
 
@@ -155,7 +153,6 @@ export class AudioContextTransport {
       participant.stop();
     }
     this.startParticipants(position);
-    this.store.update({ position });
   }
 
   private startParticipants(position: number): void {
@@ -163,6 +160,7 @@ export class AudioContextTransport {
       contextTime: this.context.currentTime + PLAYBACK_LEAD_SECONDS,
       position,
     };
+    this.store.update({ position, isPlaying: true });
     for (const participant of this.participants) {
       participant.start();
     }

--- a/src/lib/recorder/transport.ts
+++ b/src/lib/recorder/transport.ts
@@ -145,6 +145,8 @@ export class AudioContextTransport {
   }
 
   private normalizeLoopPosition(position: number): number {
+    // Allow preroll before loop-in and starts within the loop, but a playhead at
+    // or after loop-out begins again from loop-in.
     if (this.loopRange && position >= this.loopRange.end) {
       return this.loopRange.start;
     }

--- a/src/lib/recorder/transport.ts
+++ b/src/lib/recorder/transport.ts
@@ -139,6 +139,10 @@ export class AudioContextTransport {
     this.disposeTicking = startAnimationFrameLoop(() => {
       const position = this.getPublishedPlaybackPosition();
       if (this.loopRange && position >= this.loopRange.end) {
+        // Looping currently follows the UI tick and restarts participants with
+        // fresh scheduling lead, so it is not a gapless audio-clock boundary.
+        // Gapless Web Audio playback would schedule each participant's next
+        // segment ahead of loop-out and use animation frames only for position.
         this.restartParticipants(this.loopRange.start);
         return;
       }

--- a/src/lib/recorder/transport.ts
+++ b/src/lib/recorder/transport.ts
@@ -20,6 +20,11 @@ type PlaybackAnchor = {
   position: number;
 };
 
+type LoopRange = {
+  start: number;
+  end: number;
+};
+
 /**
  * Owns recorder position and synchronizes registered playback objects to one
  * AudioContext timeline.
@@ -38,6 +43,7 @@ export class AudioContextTransport {
   playbackAnchor?: PlaybackAnchor;
   private readonly participants = new Set<TransportParticipant>();
   private disposeTicking?: () => void;
+  private loopRange?: LoopRange;
 
   constructor(readonly context: AudioContext) {}
 
@@ -55,13 +61,9 @@ export class AudioContextTransport {
     if (this.store.get().isPlaying) {
       return;
     }
-    this.playbackAnchor = {
-      contextTime: this.context.currentTime + PLAYBACK_LEAD_SECONDS,
-      position: this.store.get().position,
-    };
-    for (const participant of this.participants) {
-      participant.start();
-    }
+    const position = this.normalizeLoopPosition(this.store.get().position);
+    this.store.update({ position });
+    this.startParticipants(position);
     this.store.update({ isPlaying: true });
     this.startTicking();
   }
@@ -93,6 +95,17 @@ export class AudioContextTransport {
     }
   }
 
+  setLoopRange(loopRange?: LoopRange): void {
+    this.loopRange = loopRange;
+    if (
+      loopRange &&
+      this.store.get().isPlaying &&
+      this.getPublishedPlaybackPosition() >= loopRange.end
+    ) {
+      this.restartParticipants(loopRange.start);
+    }
+  }
+
   /**
    * Converts an absolute AudioContext time to published playback position while
    * excluding the scheduling lead before the playback anchor.
@@ -120,10 +133,40 @@ export class AudioContextTransport {
       return;
     }
     this.disposeTicking = startAnimationFrameLoop(() => {
+      const position = this.getPublishedPlaybackPosition();
+      if (this.loopRange && position >= this.loopRange.end) {
+        this.restartParticipants(this.loopRange.start);
+        return;
+      }
       this.store.update({
-        position: this.getPublishedPlaybackPosition(),
+        position,
       });
     });
+  }
+
+  private normalizeLoopPosition(position: number): number {
+    if (this.loopRange && position >= this.loopRange.end) {
+      return this.loopRange.start;
+    }
+    return position;
+  }
+
+  private restartParticipants(position: number): void {
+    for (const participant of this.participants) {
+      participant.stop();
+    }
+    this.startParticipants(position);
+    this.store.update({ position });
+  }
+
+  private startParticipants(position: number): void {
+    this.playbackAnchor = {
+      contextTime: this.context.currentTime + PLAYBACK_LEAD_SECONDS,
+      position,
+    };
+    for (const participant of this.participants) {
+      participant.start();
+    }
   }
 
   /** Stops publishing position updates. */

--- a/src/lib/recorder/transport.ts
+++ b/src/lib/recorder/transport.ts
@@ -61,7 +61,13 @@ export class AudioContextTransport {
     if (this.store.get().isPlaying) {
       return;
     }
-    const position = this.normalizeLoopPosition(this.store.get().position);
+    const currentPosition = this.store.get().position;
+    // Allow preroll before loop-in and starts within the loop, but a playhead at
+    // or after loop-out begins again from loop-in.
+    const position =
+      this.loopRange && currentPosition >= this.loopRange.end
+        ? this.loopRange.start
+        : currentPosition;
     this.store.update({ position });
     this.startParticipants(position);
     this.store.update({ isPlaying: true });
@@ -142,15 +148,6 @@ export class AudioContextTransport {
         position,
       });
     });
-  }
-
-  private normalizeLoopPosition(position: number): number {
-    // Allow preroll before loop-in and starts within the loop, but a playhead at
-    // or after loop-out begins again from loop-in.
-    if (this.loopRange && position >= this.loopRange.end) {
-      return this.loopRange.start;
-    }
-    return position;
   }
 
   private restartParticipants(position: number): void {


### PR DESCRIPTION
- part of https://github.com/hi-ogawa/toy-midi/issues/420

This PR connects the persisted loop range to recorder playback. The runtime converts its beat range into transport time, while the transport restarts all playback participants from loop-in against one shared audio anchor when it reaches loop-out.

Recording behavior remains unchanged and loop recording is still out of scope.