### PR TITLE
fix: snap recorder timeline seeking

### DIFF
--- a/e2e/fake-audio/recorder-keyboard.test.ts
+++ b/e2e/fake-audio/recorder-keyboard.test.ts
@@ -13,16 +13,16 @@ test("snaps recorder timeline seeking to the selected grid", async ({
   const pixelsPerBeat = 80;
   const position = page.getByTestId("recorder-position");
 
-  // The default 1/16 grid has four subdivisions per beat. Clicking at 0.9375
-  // beats is closer to beat 1 than its adjacent 0.75-beat grid point.
-  await seekRecorderByPixels(page, pixelsPerBeat * 0.9375);
+  // The default 1/16 grid has four subdivisions per beat, so 0.9 beats snaps
+  // to beat 1 rather than the adjacent 0.75-beat grid point.
+  await seekRecorderByPixels(page, pixelsPerBeat * 0.9);
   await expect(position).toHaveText("01|02 - 00:00.500");
 
-  // On the 1/4 grid, the same kind of click before the half-beat threshold
-  // rounds back to beat 0 rather than seeking to the raw pointer position.
+  // On the 1/4 grid, 0.4 beats rounds back to beat 0 rather than seeking to
+  // the raw pointer position.
   await page.getByRole("button", { name: "1/16" }).click();
   await page.getByRole("menuitemradio", { name: "1/4" }).click();
-  await seekRecorderByPixels(page, pixelsPerBeat * 0.4375);
+  await seekRecorderByPixels(page, pixelsPerBeat * 0.4);
   await expect(position).toHaveText("01|01 - 00:00.000");
 });
 

--- a/e2e/fake-audio/recorder-keyboard.test.ts
+++ b/e2e/fake-audio/recorder-keyboard.test.ts
@@ -10,13 +10,19 @@ test("snaps recorder timeline seeking to the selected grid", async ({
 }) => {
   await createRecorderProject(page);
 
+  const pixelsPerBeat = 80;
   const position = page.getByTestId("recorder-position");
-  await seekRecorderByPixels(page, 75);
+
+  // The default 1/16 grid has four subdivisions per beat. Clicking at 0.9375
+  // beats is closer to beat 1 than its adjacent 0.75-beat grid point.
+  await seekRecorderByPixels(page, pixelsPerBeat * 0.9375);
   await expect(position).toHaveText("01|02 - 00:00.500");
 
+  // On the 1/4 grid, the same kind of click before the half-beat threshold
+  // rounds back to beat 0 rather than seeking to the raw pointer position.
   await page.getByRole("button", { name: "1/16" }).click();
   await page.getByRole("menuitemradio", { name: "1/4" }).click();
-  await seekRecorderByPixels(page, 35);
+  await seekRecorderByPixels(page, pixelsPerBeat * 0.4375);
   await expect(position).toHaveText("01|01 - 00:00.000");
 });
 

--- a/e2e/fake-audio/recorder-keyboard.test.ts
+++ b/e2e/fake-audio/recorder-keyboard.test.ts
@@ -1,5 +1,24 @@
 import { expect, test } from "@playwright/test";
-import { createRecorderProject, enableInput } from "./recorder-helpers";
+import {
+  createRecorderProject,
+  enableInput,
+  seekRecorderByPixels,
+} from "./recorder-helpers";
+
+test("snaps recorder timeline seeking to the selected grid", async ({
+  page,
+}) => {
+  await createRecorderProject(page);
+
+  const position = page.getByTestId("recorder-position");
+  await seekRecorderByPixels(page, 75);
+  await expect(position).toHaveText("01|02 - 00:00.500");
+
+  await page.getByRole("button", { name: "1/16" }).click();
+  await page.getByRole("menuitemradio", { name: "1/4" }).click();
+  await seekRecorderByPixels(page, 35);
+  await expect(position).toHaveText("01|01 - 00:00.000");
+});
 
 test("seeks the recorder by five seconds with arrow keys", async ({ page }) => {
   await createRecorderProject(page);

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -9,6 +9,7 @@ import { useState } from "react";
 import { usePointerDrag } from "../../hooks/use-pointer-drag";
 import { usePointerGesture } from "../../hooks/use-pointer-gesture";
 import { AudioView } from "../../lib/audio-view";
+import { snapToGrid } from "../../lib/music";
 import type {
   RecorderRuntimeState,
   ReferenceVideoState,
@@ -149,10 +150,13 @@ function TimelineRuler({
       })}
       onPointerDown={(event) => {
         const rect = event.currentTarget.getBoundingClientRect();
-        const beat = Math.max(
-          0,
-          (event.clientX - rect.left) / pixelsPerBeat + viewportStartBeat,
-        );
+        const beat = getSnappedPointerBeat({
+          clientX: event.clientX,
+          rect,
+          pixelsPerBeat,
+          subdivisionsPerBeat,
+          viewportStartBeat,
+        });
         onSeek(beatsToSeconds(beat, tempo));
       }}
     >
@@ -243,10 +247,13 @@ export function TakeTimelineLane({
       })}
       onPointerDown={(event) => {
         const rect = event.currentTarget.getBoundingClientRect();
-        const beat = Math.max(
-          0,
-          (event.clientX - rect.left) / pixelsPerBeat + viewportStartBeat,
-        );
+        const beat = getSnappedPointerBeat({
+          clientX: event.clientX,
+          rect,
+          pixelsPerBeat,
+          subdivisionsPerBeat,
+          viewportStartBeat,
+        });
         onSeek(beatsToSeconds(beat, tempo));
       }}
     >
@@ -367,10 +374,13 @@ export function TimelineLane({
       })}
       onPointerDown={(event) => {
         const rect = event.currentTarget.getBoundingClientRect();
-        const beat = Math.max(
-          0,
-          (event.clientX - rect.left) / pixelsPerBeat + viewportStartBeat,
-        );
+        const beat = getSnappedPointerBeat({
+          clientX: event.clientX,
+          rect,
+          pixelsPerBeat,
+          subdivisionsPerBeat,
+          viewportStartBeat,
+        });
         onSeek(beatsToSeconds(beat, tempo));
       }}
     >
@@ -487,10 +497,13 @@ export function ReferenceTimelineRow({
         })}
         onPointerDown={(event) => {
           const rect = event.currentTarget.getBoundingClientRect();
-          const beat = Math.max(
-            0,
-            (event.clientX - rect.left) / pixelsPerBeat + viewportStartBeat,
-          );
+          const beat = getSnappedPointerBeat({
+            clientX: event.clientX,
+            rect,
+            pixelsPerBeat,
+            subdivisionsPerBeat,
+            viewportStartBeat,
+          });
           onSeek(beatsToSeconds(beat, tempo));
         }}
       >
@@ -739,4 +752,21 @@ function getTimelineGridStyle({
     viewportStartBeat,
     subdivisionsPerBeat,
   });
+}
+
+function getSnappedPointerBeat({
+  clientX,
+  rect,
+  pixelsPerBeat,
+  subdivisionsPerBeat,
+  viewportStartBeat,
+}: {
+  clientX: number;
+  rect: DOMRect;
+  pixelsPerBeat: number;
+  subdivisionsPerBeat: number;
+  viewportStartBeat: number;
+}): number {
+  const beat = (clientX - rect.left) / pixelsPerBeat + viewportStartBeat;
+  return Math.max(0, snapToGrid(beat, 1 / subdivisionsPerBeat));
 }


### PR DESCRIPTION
The recorder grid selector controls its visible timeline subdivisions, but click-to-seek currently ignores that grid while the MIDI editor snaps equivalent interactions.

This PR snaps recorder ruler and track-lane seeking to the selected grid division through one shared pointer conversion path.