### PR TITLE
feat: route recorder metering through Faust

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -34,3 +34,7 @@ jobs:
       - run: pnpm build-wasm
 
       - run: pnpm exec pkg-pr-new publish --no-compact ./crates/bass-pitch-wasm
+
+      - run: pnpm -C crates/faust build
+
+      - run: pnpm exec pkg-pr-new publish --no-compact ./crates/faust

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -35,8 +35,6 @@ jobs:
 
       - run: pnpm exec pkg-pr-new publish --no-compact ./crates/bass-pitch-wasm
 
-      - run: sudo apt-get update && sudo apt-get install -y faust
-
-      - run: pnpm build-faust
+      - run: pnpm -C crates/faust build
 
       - run: pnpm exec pkg-pr-new publish --no-compact ./crates/faust

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -35,6 +35,8 @@ jobs:
 
       - run: pnpm exec pkg-pr-new publish --no-compact ./crates/bass-pitch-wasm
 
-      - run: pnpm -C crates/faust build
+      - run: sudo apt-get update && sudo apt-get install -y faust
+
+      - run: pnpm build-faust
 
       - run: pnpm exec pkg-pr-new publish --no-compact ./crates/faust

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -33,8 +33,6 @@ jobs:
 
       - run: pnpm build-wasm
 
-      - run: pnpm exec pkg-pr-new publish --no-compact ./crates/bass-pitch-wasm
-
       - run: pnpm -C crates/faust build
 
-      - run: pnpm exec pkg-pr-new publish --no-compact ./crates/faust
+      - run: pnpm exec pkg-pr-new publish --no-compact ./crates/bass-pitch-wasm ./crates/faust

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ test-results/
 target/
 crates/bass-pitch-wasm/pkg/
 crates/faust/pkg/
-crates/faust/generated/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist/
 test-results/
 target/
 crates/bass-pitch-wasm/pkg/
+crates/faust/pkg/
+crates/faust/generated/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
+name = "faust"
+version = "0.0.0"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,7 @@ checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 name = "faust"
 version = "0.0.0"
 dependencies = [
+ "libm",
  "wasm-bindgen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,6 @@ name = "faust"
 version = "0.0.0"
 dependencies = [
  "libm",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
 [workspace]
 resolver = "2"
-members = ["crates/bass-pitch", "crates/bass-pitch-wasm", "crates/pyin"]
+members = [
+  "crates/bass-pitch",
+  "crates/bass-pitch-wasm",
+  "crates/faust",
+  "crates/pyin",
+]

--- a/crates/faust/Cargo.toml
+++ b/crates/faust/Cargo.toml
@@ -8,4 +8,5 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
+libm = "0.2.16"
 wasm-bindgen = "0.2.114"

--- a/crates/faust/Cargo.toml
+++ b/crates/faust/Cargo.toml
@@ -9,4 +9,3 @@ crate-type = ["cdylib"]
 
 [dependencies]
 libm = "0.2.16"
-wasm-bindgen = "0.2.114"

--- a/crates/faust/Cargo.toml
+++ b/crates/faust/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "faust"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2.114"

--- a/crates/faust/build.sh
+++ b/crates/faust/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cargo build --release --target wasm32-unknown-unknown
+rm -rf pkg
+mkdir pkg
+cp ../../target/wasm32-unknown-unknown/release/faust.wasm pkg/faust.wasm
+
+wasm_base64="$(base64 -w 0 pkg/faust.wasm)"
+sed "s|__FAUST_WASM_BASE64__|$wasm_base64|" worklet.template.js > pkg/worklet.js

--- a/crates/faust/generated/capture-meter.rs
+++ b/crates/faust/generated/capture-meter.rs
@@ -1,0 +1,170 @@
+/* ------------------------------------------------------------
+name: "Capture Meter"
+Code generated with Faust 2.85.9 (https://faust.grame.fr)
+Compilation options: -lang rust -fpga-mem-th 4 -ct 1 -cn CaptureMeter -es 1 -mcd 16 -mdd 1024 -mdy 33 -single -ftz 0
+------------------------------------------------------------ */
+
+#[repr(C)]
+pub struct CaptureMeter {
+	fSampleRate: i32,
+}
+
+
+pub const FAUST_INPUTS: usize = 1;
+pub const FAUST_OUTPUTS: usize = 1;
+pub const FAUST_ACTIVES: usize = 0;
+pub const FAUST_PASSIVES: usize = 0;
+
+impl CaptureMeter {
+		
+	pub fn new() -> CaptureMeter { 
+		CaptureMeter {
+			fSampleRate: 0,
+		}
+	}
+	pub fn metadata(&self, m: &mut dyn Meta) { 
+		m.declare("compile_options", r"-lang rust -fpga-mem-th 4 -ct 1 -cn CaptureMeter -es 1 -mcd 16 -mdd 1024 -mdy 33 -single -ftz 0");
+		m.declare("description", r"Mono pass-through used to establish toy-midi's Faust build path.");
+		m.declare("filename", r"capture-meter.dsp");
+		m.declare("name", r"Capture Meter");
+	}
+
+	pub fn get_sample_rate(&self) -> i32 { self.fSampleRate as i32}
+	
+	pub fn class_init(sample_rate: i32) {
+		// Obtaining locks on 0 static var(s)
+	}
+	pub fn instance_reset_params(&mut self) {
+	}
+	pub fn instance_clear(&mut self) {
+	}
+	pub fn instance_constants(&mut self, sample_rate: i32) {
+		// Obtaining locks on 0 static var(s)
+		self.fSampleRate = sample_rate;
+	}
+	pub fn instance_init(&mut self, sample_rate: i32) {
+		self.instance_constants(sample_rate);
+		self.instance_reset_params();
+		self.instance_clear();
+	}
+	pub fn init(&mut self, sample_rate: i32) {
+		CaptureMeter::class_init(sample_rate);
+		self.instance_init(sample_rate);
+	}
+	
+	pub fn build_user_interface(&self, ui_interface: &mut dyn UI<FaustFloat>) {
+		Self::build_user_interface_static(ui_interface);
+	}
+	
+	pub fn build_user_interface_static(ui_interface: &mut dyn UI<FaustFloat>) {
+		ui_interface.open_vertical_box("Capture Meter");
+		ui_interface.close_box();
+	}
+	
+	pub fn get_param(&self, param: ParamIndex) -> Option<FaustFloat> {
+		match param.0 {
+			_ => None,
+		}
+	}
+	
+	pub fn set_param(&mut self, param: ParamIndex, value: FaustFloat) {
+		match param.0 {
+			_ => {}
+		}
+	}
+	
+	pub fn compute(
+		&mut self,
+		count: usize,
+		inputs: &[impl AsRef<[FaustFloat]>],
+		outputs: &mut[impl AsMut<[FaustFloat]>],
+	) {
+		
+		// Obtaining locks on 0 static var(s)
+		let [inputs0, .. ] = inputs.as_ref() else { panic!("wrong number of input buffers"); };
+		let inputs0 = inputs0.as_ref()[..count].iter();
+		let [outputs0, .. ] = outputs.as_mut() else { panic!("wrong number of output buffers"); };
+		let outputs0 = outputs0.as_mut()[..count].iter_mut();
+		let zipped_iterators = inputs0.zip(outputs0);
+		for (input0, output0) in zipped_iterators {
+			*output0 = (*input0) as F32 as FaustFloat;
+		}
+		
+	}
+
+}
+
+#[cfg(not(target_arch = "wasm32"))] // Compile ffi bindings only on non-wasm targets
+mod ffi {
+	use core::ffi::c_float;
+	// Conditionally compile the link attribute only on non-Windows platforms
+	#[cfg_attr(not(target_os = "windows"), link(name = "m"))]
+	unsafe extern "C" {
+		pub fn remainderf(from: c_float, to: c_float) -> c_float;
+		pub fn rintf(val: c_float) -> c_float;
+	}
+}
+fn remainderf(from: f32, to: f32) -> f32 {
+	#[cfg(not(target_arch = "wasm32"))] // non-wasm targets use ffi bindings
+	unsafe { ffi::remainderf(from, to) }
+	#[cfg(target_arch = "wasm32")] // wasm relies on libm
+	libm::remainderf(from, to)
+}
+fn rintf(val: f32) -> f32 {
+	#[cfg(not(target_arch = "wasm32"))] // non-wasm targets use ffi bindings
+	unsafe { ffi::rintf(val) }
+	#[cfg(target_arch = "wasm32")] // wasm relies on libm
+	libm::rintf(val)
+}
+
+impl FaustDsp for CaptureMeter {
+	type T = FaustFloat;
+	fn new() -> Self where Self: Sized {
+		Self::new()
+	}
+	fn metadata(&self, m: &mut dyn Meta) {
+		self.metadata(m)
+	}
+	fn get_sample_rate(&self) -> i32 {
+		self.get_sample_rate()
+	}
+	fn get_num_inputs(&self) -> i32 {
+		FAUST_INPUTS as i32
+	}
+	fn get_num_outputs(&self) -> i32 {
+		FAUST_OUTPUTS as i32
+	}
+	fn class_init(sample_rate: i32) where Self: Sized {
+		Self::class_init(sample_rate);
+	}
+	fn instance_reset_params(&mut self) {
+		self.instance_reset_params()
+	}
+	fn instance_clear(&mut self) {
+		self.instance_clear()
+	}
+	fn instance_constants(&mut self, sample_rate: i32) {
+		self.instance_constants(sample_rate)
+	}
+	fn instance_init(&mut self, sample_rate: i32) {
+		self.instance_init(sample_rate)
+	}
+	fn init(&mut self, sample_rate: i32) {
+		self.init(sample_rate)
+	}
+	fn build_user_interface(&self, ui_interface: &mut dyn UI<Self::T>) {
+		self.build_user_interface(ui_interface)
+	}
+	fn build_user_interface_static(ui_interface: &mut dyn UI<Self::T>) where Self: Sized {
+		Self::build_user_interface_static(ui_interface);
+	}
+	fn get_param(&self, param: ParamIndex) -> Option<Self::T> {
+		self.get_param(param)
+	}
+	fn set_param(&mut self, param: ParamIndex, value: Self::T) {
+		self.set_param(param, value)
+	}
+	fn compute(&mut self, count: i32, inputs: &[&[Self::T]], outputs: &mut [&mut [Self::T]]) {
+		self.compute(count as usize, inputs, outputs)
+	}
+}

--- a/crates/faust/package.json
+++ b/crates/faust/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hiogawa/faust",
+  "name": "@hiogawa/toy-midi-faust",
   "version": "0.0.0",
   "files": [
     "pkg"

--- a/crates/faust/package.json
+++ b/crates/faust/package.json
@@ -5,11 +5,10 @@
     "pkg"
   ],
   "type": "module",
-  "exports": "./pkg/faust.js",
-  "scripts": {
-    "build": "wasm-pack build . --target web --no-pack --release --out-name faust && rm -f pkg/.gitignore"
+  "exports": {
+    "./worklet": "./pkg/worklet.js"
   },
-  "devDependencies": {
-    "wasm-pack": "0.15.0"
+  "scripts": {
+    "build": "bash build.sh"
   }
 }

--- a/crates/faust/package.json
+++ b/crates/faust/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@hiogawa/faust",
+  "version": "0.0.0",
+  "files": [
+    "pkg"
+  ],
+  "type": "module",
+  "exports": "./pkg/faust.js",
+  "scripts": {
+    "build": "wasm-pack build . --target web --no-pack --release --out-name faust && rm -f pkg/.gitignore"
+  },
+  "devDependencies": {
+    "wasm-pack": "0.15.0"
+  }
+}

--- a/crates/faust/src/lib.rs
+++ b/crates/faust/src/lib.rs
@@ -1,55 +1,15 @@
-use wasm_bindgen::prelude::*;
-
-type F32 = f32;
-type FaustFloat = F32;
-
-#[derive(Copy, Clone)]
-pub struct ParamIndex(pub i32);
-
-pub trait FaustDsp {
-    type T;
-
-    fn new() -> Self
-    where
-        Self: Sized;
-    fn metadata(&self, meta: &mut dyn Meta);
-    fn get_sample_rate(&self) -> i32;
-    fn get_num_inputs(&self) -> i32;
-    fn get_num_outputs(&self) -> i32;
-    fn class_init(sample_rate: i32)
-    where
-        Self: Sized;
-    fn instance_reset_params(&mut self);
-    fn instance_clear(&mut self);
-    fn instance_constants(&mut self, sample_rate: i32);
-    fn instance_init(&mut self, sample_rate: i32);
-    fn init(&mut self, sample_rate: i32);
-    fn build_user_interface(&self, ui: &mut dyn UI<Self::T>);
-    fn build_user_interface_static(ui: &mut dyn UI<Self::T>)
-    where
-        Self: Sized;
-    fn get_param(&self, param: ParamIndex) -> Option<Self::T>;
-    fn set_param(&mut self, param: ParamIndex, value: Self::T);
-    fn compute(&mut self, count: i32, inputs: &[&[Self::T]], outputs: &mut [&mut [Self::T]]);
-}
-
-pub trait Meta {
-    fn declare(&mut self, key: &str, value: &str);
-}
-
-pub trait UI<T> {
-    fn open_vertical_box(&mut self, label: &str);
-    fn close_box(&mut self);
-}
+mod runtime;
 
 #[allow(dead_code, non_snake_case, unused_variables)]
-mod capture_meter {
-    use super::*;
+pub mod capture_meter {
+    use crate::runtime::*;
 
+    // Faust emits a source fragment that expects its host traits in scope.
     include!("../generated/capture-meter.rs");
 }
 
 use capture_meter::CaptureMeter;
+use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub fn process_capture_meter(input: &[f32], output: &mut [f32], sample_rate: i32) {

--- a/crates/faust/src/lib.rs
+++ b/crates/faust/src/lib.rs
@@ -1,6 +1,75 @@
 use wasm_bindgen::prelude::*;
 
+type F32 = f32;
+type FaustFloat = F32;
+
+#[derive(Copy, Clone)]
+pub struct ParamIndex(pub i32);
+
+pub trait FaustDsp {
+    type T;
+
+    fn new() -> Self
+    where
+        Self: Sized;
+    fn metadata(&self, meta: &mut dyn Meta);
+    fn get_sample_rate(&self) -> i32;
+    fn get_num_inputs(&self) -> i32;
+    fn get_num_outputs(&self) -> i32;
+    fn class_init(sample_rate: i32)
+    where
+        Self: Sized;
+    fn instance_reset_params(&mut self);
+    fn instance_clear(&mut self);
+    fn instance_constants(&mut self, sample_rate: i32);
+    fn instance_init(&mut self, sample_rate: i32);
+    fn init(&mut self, sample_rate: i32);
+    fn build_user_interface(&self, ui: &mut dyn UI<Self::T>);
+    fn build_user_interface_static(ui: &mut dyn UI<Self::T>)
+    where
+        Self: Sized;
+    fn get_param(&self, param: ParamIndex) -> Option<Self::T>;
+    fn set_param(&mut self, param: ParamIndex, value: Self::T);
+    fn compute(&mut self, count: i32, inputs: &[&[Self::T]], outputs: &mut [&mut [Self::T]]);
+}
+
+pub trait Meta {
+    fn declare(&mut self, key: &str, value: &str);
+}
+
+pub trait UI<T> {
+    fn open_vertical_box(&mut self, label: &str);
+    fn close_box(&mut self);
+}
+
+#[allow(dead_code, non_snake_case, unused_variables)]
+mod capture_meter {
+    use super::*;
+
+    include!("../generated/capture-meter.rs");
+}
+
+use capture_meter::CaptureMeter;
+
 #[wasm_bindgen]
-pub fn faust_version() -> String {
-    "2.85.9".into()
+pub fn process_capture_meter(input: &[f32], output: &mut [f32], sample_rate: i32) {
+    assert_eq!(input.len(), output.len());
+    let mut dsp = CaptureMeter::new();
+    dsp.init(sample_rate);
+    dsp.compute(input.len(), &[input], &mut [output]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capture_meter_passes_samples_through() {
+        let input = [-1.0, -0.25, 0.0, 0.5, 1.0];
+        let mut output = [0.0; 5];
+
+        process_capture_meter(&input, &mut output, 48_000);
+
+        assert_eq!(output, input);
+    }
 }

--- a/crates/faust/src/lib.rs
+++ b/crates/faust/src/lib.rs
@@ -1,7 +1,7 @@
 mod runtime;
 
 #[allow(dead_code, non_snake_case, unused_variables)]
-pub mod capture_meter {
+mod capture_meter {
     use crate::runtime::*;
 
     // Faust emits a source fragment that expects its host traits in scope.
@@ -9,14 +9,63 @@ pub mod capture_meter {
 }
 
 use capture_meter::CaptureMeter;
-use wasm_bindgen::prelude::*;
+use std::cell::RefCell;
 
-#[wasm_bindgen]
-pub fn process_capture_meter(input: &[f32], output: &mut [f32], sample_rate: i32) {
-    assert_eq!(input.len(), output.len());
+const RENDER_QUANTUM: usize = 128;
+
+thread_local! {
+    static PROCESSOR: RefCell<Option<Processor>> = const { RefCell::new(None) };
+}
+
+struct Processor {
+    dsp: CaptureMeter,
+    input: [f32; RENDER_QUANTUM],
+    output: [f32; RENDER_QUANTUM],
+}
+
+#[no_mangle]
+pub extern "C" fn initialize_capture_meter(sample_rate: i32) {
     let mut dsp = CaptureMeter::new();
     dsp.init(sample_rate);
-    dsp.compute(input.len(), &[input], &mut [output]);
+    PROCESSOR.set(Some(Processor {
+        dsp,
+        input: [0.0; RENDER_QUANTUM],
+        output: [0.0; RENDER_QUANTUM],
+    }));
+}
+
+#[no_mangle]
+pub extern "C" fn capture_meter_input() -> *mut f32 {
+    PROCESSOR.with_borrow_mut(|processor| {
+        processor
+            .as_mut()
+            .expect("capture meter is initialized")
+            .input
+            .as_mut_ptr()
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn capture_meter_output() -> *const f32 {
+    PROCESSOR.with_borrow(|processor| {
+        processor
+            .as_ref()
+            .expect("capture meter is initialized")
+            .output
+            .as_ptr()
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn process_capture_meter() {
+    PROCESSOR.with_borrow_mut(|processor| {
+        let processor = processor.as_mut().expect("capture meter is initialized");
+        processor.dsp.compute(
+            RENDER_QUANTUM,
+            &[&processor.input],
+            &mut [&mut processor.output],
+        );
+    });
 }
 
 #[cfg(test)]
@@ -25,10 +74,12 @@ mod tests {
 
     #[test]
     fn capture_meter_passes_samples_through() {
+        let mut dsp = CaptureMeter::new();
+        dsp.init(48_000);
         let input = [-1.0, -0.25, 0.0, 0.5, 1.0];
         let mut output = [0.0; 5];
 
-        process_capture_meter(&input, &mut output, 48_000);
+        dsp.compute(input.len(), &[&input], &mut [&mut output]);
 
         assert_eq!(output, input);
     }

--- a/crates/faust/src/lib.rs
+++ b/crates/faust/src/lib.rs
@@ -1,0 +1,6 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn faust_version() -> String {
+    "2.85.9".into()
+}

--- a/crates/faust/src/runtime.rs
+++ b/crates/faust/src/runtime.rs
@@ -1,0 +1,42 @@
+pub(crate) type F32 = f32;
+pub(crate) type FaustFloat = F32;
+
+#[derive(Copy, Clone)]
+pub struct ParamIndex(pub i32);
+
+#[allow(dead_code)]
+pub trait FaustDsp {
+    type T;
+
+    fn new() -> Self
+    where
+        Self: Sized;
+    fn metadata(&self, meta: &mut dyn Meta);
+    fn get_sample_rate(&self) -> i32;
+    fn get_num_inputs(&self) -> i32;
+    fn get_num_outputs(&self) -> i32;
+    fn class_init(sample_rate: i32)
+    where
+        Self: Sized;
+    fn instance_reset_params(&mut self);
+    fn instance_clear(&mut self);
+    fn instance_constants(&mut self, sample_rate: i32);
+    fn instance_init(&mut self, sample_rate: i32);
+    fn init(&mut self, sample_rate: i32);
+    fn build_user_interface(&self, ui: &mut dyn UI<Self::T>);
+    fn build_user_interface_static(ui: &mut dyn UI<Self::T>)
+    where
+        Self: Sized;
+    fn get_param(&self, param: ParamIndex) -> Option<Self::T>;
+    fn set_param(&mut self, param: ParamIndex, value: Self::T);
+    fn compute(&mut self, count: i32, inputs: &[&[Self::T]], outputs: &mut [&mut [Self::T]]);
+}
+
+pub trait Meta {
+    fn declare(&mut self, key: &str, value: &str);
+}
+
+pub trait UI<T> {
+    fn open_vertical_box(&mut self, label: &str);
+    fn close_box(&mut self);
+}

--- a/crates/faust/worklet.template.js
+++ b/crates/faust/worklet.template.js
@@ -1,0 +1,50 @@
+const PROCESSOR_NAME = "faust-capture-meter";
+const RENDER_QUANTUM = 128;
+
+class FaustCaptureMeterProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    const bytes = Uint8Array.from(atob("__FAUST_WASM_BASE64__"), (value) =>
+      value.charCodeAt(0),
+    );
+    const module = new WebAssembly.Module(bytes);
+    const instance = new WebAssembly.Instance(module, {});
+    this.exports = instance.exports;
+    this.exports.initialize_capture_meter(sampleRate);
+    this.input = new Float32Array(
+      this.exports.memory.buffer,
+      this.exports.capture_meter_input(),
+      RENDER_QUANTUM,
+    );
+    this.output = new Float32Array(
+      this.exports.memory.buffer,
+      this.exports.capture_meter_output(),
+      RENDER_QUANTUM,
+    );
+    this.peak = 0;
+    this.quantumCount = 0;
+  }
+
+  process(inputs, outputs) {
+    const source = inputs[0]?.[0];
+    if (source) {
+      this.input.set(source);
+    } else {
+      this.input.fill(0);
+    }
+    this.exports.process_capture_meter();
+    outputs[0]?.[0]?.set(this.output);
+    for (const sample of this.output) {
+      this.peak = Math.max(this.peak, Math.abs(sample));
+    }
+    this.quantumCount++;
+    if (this.quantumCount === 16) {
+      this.port.postMessage({ type: "analysis", peak: this.peak });
+      this.peak = 0;
+      this.quantumCount = 0;
+    }
+    return true;
+  }
+}
+
+registerProcessor(PROCESSOR_NAME, FaustCaptureMeterProcessor);

--- a/faust/README.md
+++ b/faust/README.md
@@ -1,0 +1,10 @@
+# Faust Development
+
+`capture-meter.dsp` is the reviewed source for the first real-time DSP node. Run
+`pnpm build-faust` with Faust 2.85.9 available as `faust`, or set `FAUST_BIN` to
+the compiler executable.
+
+The command generates `crates/faust/generated/capture-meter.rs` and builds the
+local wasm-pack output under `crates/faust/pkg/`. Both outputs are ignored while
+the generated DSP is not wired into the crate's browser ABI. Production WASM
+packages will be published through pkg.pr.new.

--- a/faust/README.md
+++ b/faust/README.md
@@ -1,10 +1,10 @@
 # Faust Development
 
-`capture-meter.dsp` is the reviewed source for the first real-time DSP node. Run
-`pnpm build-faust` with Faust 2.85.9 available as `faust`, or set `FAUST_BIN` to
-the compiler executable.
+`capture-meter.dsp` is the reviewed source for the first real-time DSP node.
+Install Faust with the system package manager, then run `pnpm build-faust`. Set
+`FAUST_BIN` when the compiler is not available as `faust`.
 
 The command generates `crates/faust/generated/capture-meter.rs` and builds the
-local wasm-pack output under `crates/faust/pkg/`. Both outputs are ignored while
-the generated DSP is not wired into the crate's browser ABI. Production WASM
-packages will be published through pkg.pr.new.
+local wasm-pack output under `crates/faust/pkg/`. The generated Rust is committed
+and compiled by the crate, while `pkg/` is ignored because production WASM
+packages are published through pkg.pr.new.

--- a/faust/capture-meter.dsp
+++ b/faust/capture-meter.dsp
@@ -1,0 +1,4 @@
+declare name "Capture Meter";
+declare description "Mono pass-through used to establish toy-midi's Faust build path.";
+
+process = _;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview --config vite.app.config.ts",
     "override-wasm": "yq -i '.overrides.\"@hiogawa/bass-pitch-wasm\" = \"workspace:*\"' pnpm-workspace.yaml",
     "build-wasm": "bash tools/build-wasm.sh",
+    "build-faust": "bash tools/build-faust.sh",
     "typecheck": "tsc -b",
     "lint": "cargo fmt && vp check --fix && pnpm lint-dead-code && pnpm typecheck",
     "lint-check": "cargo fmt -- --check && vp check && pnpm lint-dead-code && pnpm typecheck",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@hiogawa/bass-pitch-wasm": "https://pkg.pr.new/hi-ogawa/toy-midi/@hiogawa/bass-pitch-wasm@1361732",
+    "@hiogawa/toy-midi-faust": "workspace:*",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slider": "^1.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,12 @@ importers:
         specifier: 0.15.0
         version: 0.15.0
 
+  crates/faust:
+    devDependencies:
+      wasm-pack:
+        specifier: 0.15.0
+        version: 0.15.0
+
 packages:
 
   '@babel/runtime@7.29.7':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hiogawa/bass-pitch-wasm':
         specifier: https://pkg.pr.new/hi-ogawa/toy-midi/@hiogawa/bass-pitch-wasm@1361732
         version: https://pkg.pr.new/hi-ogawa/toy-midi/@hiogawa/bass-pitch-wasm@1361732
+      '@hiogawa/toy-midi-faust':
+        specifier: workspace:*
+        version: link:crates/faust
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.16
         version: 2.1.24(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -109,11 +112,7 @@ importers:
         specifier: 0.15.0
         version: 0.15.0
 
-  crates/faust:
-    devDependencies:
-      wasm-pack:
-        specifier: 0.15.0
-        version: 0.15.0
+  crates/faust: {}
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - crates/bass-pitch-wasm
+  - crates/faust
 allowBuilds:
   gl: false
   wasm-pack: true

--- a/src/components/input-meter.tsx
+++ b/src/components/input-meter.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import type { AudioAnalyser } from "../lib/audio-analyser";
+import type { AudioAnalyserSource } from "../lib/audio-analyser";
 import { gainToDb, MAX_DB, MIN_DB } from "../lib/music";
 
 export function InputMeter({
@@ -8,7 +8,7 @@ export function InputMeter({
   compact = false,
 }: {
   active: boolean;
-  analyser?: AudioAnalyser;
+  analyser?: AudioAnalyserSource;
   compact?: boolean;
 }) {
   const sampledPeak = useAnalyserPeak({ active, analyser });
@@ -73,7 +73,7 @@ function useAnalyserPeak({
   analyser,
 }: {
   active: boolean;
-  analyser?: AudioAnalyser;
+  analyser?: AudioAnalyserSource;
 }): number {
   const [peak, setPeak] = useState(0);
 

--- a/src/components/recorder/recorder-input.tsx
+++ b/src/components/recorder/recorder-input.tsx
@@ -1,6 +1,6 @@
 import { CircleHelpIcon, Mic2Icon } from "lucide-react";
 import { useDraftInput } from "../../hooks/use-draft-input";
-import type { AudioAnalyser } from "../../lib/audio-analyser";
+import type { AudioAnalyserSource } from "../../lib/audio-analyser";
 import { routes } from "../../lib/routes";
 import { InputMeter } from "../input-meter";
 import { Button } from "../ui/button";
@@ -30,7 +30,7 @@ export function InputSetup({
   error?: Error | null;
   hasAccess: boolean;
   inputActive: boolean;
-  inputAnalyser?: AudioAnalyser;
+  inputAnalyser?: AudioAnalyserSource;
   inputsInitialized: boolean;
   isProcessing: boolean;
   isRecording: boolean;

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -7,7 +7,7 @@ import {
   UploadIcon,
 } from "lucide-react";
 import { usePointerDrag } from "../../hooks/use-pointer-drag";
-import type { AudioAnalyser } from "../../lib/audio-analyser";
+import type { AudioAnalyserSource } from "../../lib/audio-analyser";
 import {
   dbToPercent,
   formatGainDb,
@@ -189,7 +189,7 @@ export function CaptureTrackRow({
   height: number;
   gain: number;
   inputActive: boolean;
-  inputAnalyser?: AudioAnalyser;
+  inputAnalyser?: AudioAnalyserSource;
   inputToggleDisabled: boolean;
   muted: boolean;
   soloed: boolean;

--- a/src/lib/audio-analyser.ts
+++ b/src/lib/audio-analyser.ts
@@ -4,7 +4,13 @@ export type AudioAnalysis = {
   peak: number;
 };
 
-export class AudioAnalyser {
+export interface AudioAnalyserSource {
+  readonly node: AudioNode;
+  subscribe(onAnalysis: (analysis: AudioAnalysis) => void): () => void;
+  dispose(): void;
+}
+
+export class AudioAnalyser implements AudioAnalyserSource {
   readonly node: AnalyserNode;
 
   private readonly samples: Float32Array<ArrayBuffer>;

--- a/src/lib/recorder/capture-input.ts
+++ b/src/lib/recorder/capture-input.ts
@@ -1,11 +1,14 @@
-import { AudioAnalyser } from "../audio-analyser.ts";
+import faustWorkletUrl from "@hiogawa/toy-midi-faust/worklet?url";
+import type { AudioAnalyserSource } from "../audio-analyser.ts";
 import {
   CaptureWorkletClient,
   type CaptureWorkletNotification,
   createCaptureWorkletSource,
 } from "./capture-worklet.ts";
+import { FaustCaptureAnalyser } from "./faust-capture-analyser.ts";
 
 const workletRegistrations = new WeakMap<AudioContext, Promise<void>>();
+const faustWorkletRegistrations = new WeakMap<AudioContext, Promise<void>>();
 
 export async function requestCaptureAccess(): Promise<void> {
   const stream =
@@ -23,7 +26,7 @@ export class CaptureInput {
   private readonly stream: MediaStream;
   private readonly source: MediaStreamAudioSourceNode;
   private readonly worklet: CaptureWorkletClient;
-  readonly analyser: AudioAnalyser;
+  readonly analyser: AudioAnalyserSource;
   private readonly silentGain: GainNode;
 
   static async open({
@@ -35,7 +38,10 @@ export class CaptureInput {
     deviceId: string;
     onNotification: (message: CaptureWorkletNotification) => void;
   }) {
-    await ensureCaptureWorklet(context);
+    await Promise.all([
+      ensureCaptureWorklet(context),
+      ensureFaustWorklet(context),
+    ]);
     const stream = await navigator.mediaDevices.getUserMedia(
       captureConstraints(deviceId),
     );
@@ -84,7 +90,7 @@ export class CaptureInput {
       context,
       onNotification,
     });
-    this.analyser = new AudioAnalyser(context);
+    this.analyser = new FaustCaptureAnalyser(context);
     this.silentGain = context.createGain();
     this.silentGain.gain.value = 0;
     // Keep the worklet connected so browsers continue rendering it. Zero gain
@@ -144,6 +150,20 @@ async function registerCaptureWorklet(context: AudioContext): Promise<void> {
     await context.audioWorklet.addModule(url);
   } finally {
     URL.revokeObjectURL(url);
+  }
+}
+
+async function ensureFaustWorklet(context: AudioContext): Promise<void> {
+  let registration = faustWorkletRegistrations.get(context);
+  if (!registration) {
+    registration = context.audioWorklet.addModule(faustWorkletUrl);
+    faustWorkletRegistrations.set(context, registration);
+  }
+  try {
+    await registration;
+  } catch (error) {
+    faustWorkletRegistrations.delete(context);
+    throw error;
   }
 }
 

--- a/src/lib/recorder/faust-capture-analyser.ts
+++ b/src/lib/recorder/faust-capture-analyser.ts
@@ -1,0 +1,33 @@
+import type { AudioAnalyserSource, AudioAnalysis } from "../audio-analyser.ts";
+
+const PROCESSOR_NAME = "faust-capture-meter";
+
+export class FaustCaptureAnalyser implements AudioAnalyserSource {
+  readonly node: AudioWorkletNode;
+  private readonly listeners = new Set<(analysis: AudioAnalysis) => void>();
+
+  constructor(context: AudioContext) {
+    this.node = new AudioWorkletNode(context, PROCESSOR_NAME, {
+      numberOfInputs: 1,
+      numberOfOutputs: 1,
+      outputChannelCount: [1],
+    });
+    this.node.port.onmessage = (
+      event: MessageEvent<{ type: "analysis"; peak: number }>,
+    ) => {
+      for (const listener of this.listeners) {
+        listener({ peak: event.data.peak });
+      }
+    };
+  }
+
+  subscribe(listener: (analysis: AudioAnalysis) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  dispose(): void {
+    this.listeners.clear();
+    this.node.disconnect();
+  }
+}

--- a/tools/build-faust.sh
+++ b/tools/build-faust.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+faust_bin="${FAUST_BIN:-faust}"
+expected_version="2.85.9"
+
+if ! command -v "$faust_bin" >/dev/null; then
+  echo "Faust $expected_version is required. Set FAUST_BIN to its executable." >&2
+  exit 1
+fi
+
+actual_version="$($faust_bin --version | sed -n '1s/.*version //p')"
+if [ "$actual_version" != "$expected_version" ]; then
+  echo "Expected Faust $expected_version, found ${actual_version:-unknown}." >&2
+  exit 1
+fi
+
+"$faust_bin" \
+  -lang rust \
+  -cn CaptureMeter \
+  -o crates/faust/generated/capture-meter.rs \
+  faust/capture-meter.dsp
+
+pnpm -C crates/faust build

--- a/tools/build-faust.sh
+++ b/tools/build-faust.sh
@@ -2,16 +2,9 @@
 set -euo pipefail
 
 faust_bin="${FAUST_BIN:-faust}"
-expected_version="2.85.9"
 
 if ! command -v "$faust_bin" >/dev/null; then
-  echo "Faust $expected_version is required. Set FAUST_BIN to its executable." >&2
-  exit 1
-fi
-
-actual_version="$($faust_bin --version | sed -n '1s/.*version //p')"
-if [ "$actual_version" != "$expected_version" ]; then
-  echo "Expected Faust $expected_version, found ${actual_version:-unknown}." >&2
+  echo "Faust is required. Set FAUST_BIN to its executable." >&2
   exit 1
 fi
 


### PR DESCRIPTION
- related to https://github.com/hi-ogawa/toy-midi/issues/432

This PR establishes the Faust source and package boundary, then uses it for the recorder input meter. `faust/capture-meter.dsp` generates committed Rust under `crates/faust`; the crate exposes a persistent raw WASM processor with stable 128-frame buffers and packages a self-contained AudioWorklet through pkg.pr.new.

The recorder inserts that pass-through worklet after the existing selected-channel capture output. Peak snapshots arrive every 16 render quanta through the existing meter subscription contract, while recording PCM and the latency checker remain on their existing paths. `pnpm build-faust` regenerates the Rust source and local package output, while publish CI compiles the committed generated source without requiring Faust.