### PR TITLE
feat: add recorder input monitoring

### DIFF
--- a/e2e/fake-audio/recorder-helpers.ts
+++ b/e2e/fake-audio/recorder-helpers.ts
@@ -48,14 +48,14 @@ export async function waitForRecordingSamples(recording: Locator) {
 
 export async function enableInput(page: Page) {
   // Fake audio still exercises permission, device discovery, and channel setup.
-  const route = page.getByRole("button", {
-    name: "Fake Default Audio Input · Input 1",
+  const inputSetupButton = page.getByRole("button", {
+    name: "Configure audio input",
   });
   await expect(page.getByTestId("recorder-input-toggle")).toHaveAttribute(
     "aria-pressed",
     "false",
   );
-  await route.click();
+  await inputSetupButton.click();
   await expect(
     page.getByRole("heading", { name: "Audio Input Setup" }),
   ).toBeVisible();
@@ -70,9 +70,7 @@ export async function enableInput(page: Page) {
   await expect(page.getByLabel("Channel")).toContainText("Channel 1");
   await page.getByRole("button", { name: "Close" }).click();
   await expect(
-    page.getByRole("button", {
-      name: "Fake Default Audio Input · Input 1",
-    }),
+    page.getByText("Fake Default Audio Input · Input 1"),
   ).toBeVisible();
   await expect(page.getByTestId("recorder-input-toggle")).toHaveAttribute(
     "aria-pressed",

--- a/e2e/fake-audio/recorder-recording.test.ts
+++ b/e2e/fake-audio/recorder-recording.test.ts
@@ -35,7 +35,7 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   await expect(page.getByTestId("recorder-download-take")).toBeDisabled();
   await page.keyboard.press("Escape");
   await recordButton.click();
-  await expect(listenButton).toHaveAttribute("aria-pressed", "false");
+  await expect(listenButton).toHaveAttribute("aria-pressed", "true");
   await expect(recordButton).toHaveAttribute("aria-pressed", "true");
   await expect(playButton).toHaveAttribute("aria-pressed", "true");
   const recording = page.getByTestId("recorder-clip-recording");

--- a/e2e/fake-audio/recorder-recording.test.ts
+++ b/e2e/fake-audio/recorder-recording.test.ts
@@ -14,6 +14,7 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   // Connect the browser input before recording is available.
   await enableInput(page);
 
+  // Input monitoring can be enabled before recording starts.
   const monitorButton = page.getByTestId("recorder-input-monitor");
   await expect(monitorButton).toBeEnabled();
   await expect(monitorButton).toHaveAttribute("aria-pressed", "false");

--- a/e2e/fake-audio/recorder-recording.test.ts
+++ b/e2e/fake-audio/recorder-recording.test.ts
@@ -14,11 +14,11 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   // Connect the browser input before recording is available.
   await enableInput(page);
 
-  const listenButton = page.getByTestId("recorder-input-listen");
-  await expect(listenButton).toBeEnabled();
-  await expect(listenButton).toHaveAttribute("aria-pressed", "false");
-  await listenButton.click();
-  await expect(listenButton).toHaveAttribute("aria-pressed", "true");
+  const monitorButton = page.getByTestId("recorder-input-monitor");
+  await expect(monitorButton).toBeEnabled();
+  await expect(monitorButton).toHaveAttribute("aria-pressed", "false");
+  await monitorButton.click();
+  await expect(monitorButton).toHaveAttribute("aria-pressed", "true");
 
   // Place the playhead away from zero to exercise take placement.
   await seekRecorderByPixels(page, 160);
@@ -35,7 +35,7 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   await expect(page.getByTestId("recorder-download-take")).toBeDisabled();
   await page.keyboard.press("Escape");
   await recordButton.click();
-  await expect(listenButton).toHaveAttribute("aria-pressed", "true");
+  await expect(monitorButton).toHaveAttribute("aria-pressed", "true");
   await expect(recordButton).toHaveAttribute("aria-pressed", "true");
   await expect(playButton).toHaveAttribute("aria-pressed", "true");
   const recording = page.getByTestId("recorder-clip-recording");

--- a/e2e/fake-audio/recorder-recording.test.ts
+++ b/e2e/fake-audio/recorder-recording.test.ts
@@ -14,6 +14,12 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   // Connect the browser input before recording is available.
   await enableInput(page);
 
+  const listenButton = page.getByTestId("recorder-input-listen");
+  await expect(listenButton).toBeEnabled();
+  await expect(listenButton).toHaveAttribute("aria-pressed", "false");
+  await listenButton.click();
+  await expect(listenButton).toHaveAttribute("aria-pressed", "true");
+
   // Place the playhead away from zero to exercise take placement.
   await seekRecorderByPixels(page, 160);
 
@@ -29,6 +35,7 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   await expect(page.getByTestId("recorder-download-take")).toBeDisabled();
   await page.keyboard.press("Escape");
   await recordButton.click();
+  await expect(listenButton).toHaveAttribute("aria-pressed", "false");
   await expect(recordButton).toHaveAttribute("aria-pressed", "true");
   await expect(playButton).toHaveAttribute("aria-pressed", "true");
   const recording = page.getByTestId("recorder-clip-recording");

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -394,7 +394,6 @@ export function Recorder({ projectId }: { projectId: string }) {
               inputActive={input.active}
               inputAnalyser={runtime.captureInput?.analyser}
               inputListening={state.inputListening}
-              inputListeningDisabled={isRecording || isProcessing}
               inputToggleDisabled={
                 input.mutationPending ||
                 !input.initialized ||

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -393,6 +393,8 @@ export function Recorder({ projectId }: { projectId: string }) {
               height={state.recordingTrack.height}
               inputActive={input.active}
               inputAnalyser={runtime.captureInput?.analyser}
+              inputListening={state.inputListening}
+              inputListeningDisabled={isRecording || isProcessing}
               inputToggleDisabled={
                 input.mutationPending ||
                 !input.initialized ||
@@ -407,6 +409,9 @@ export function Recorder({ projectId }: { projectId: string }) {
               }
               onGainChange={(gain) => runtime.setRecordingTrackMix({ gain })}
               onInputSetup={() => setIsInputSetupOpen(true)}
+              onInputListeningChange={(listening) =>
+                runtime.setInputListening(listening)
+              }
               onInputToggle={input.toggle}
               onMutedChange={(muted) => runtime.setRecordingTrackMix({ muted })}
               onSoloedChange={(soloed) =>

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -393,7 +393,7 @@ export function Recorder({ projectId }: { projectId: string }) {
               height={state.recordingTrack.height}
               inputActive={input.active}
               inputAnalyser={runtime.captureInput?.analyser}
-              inputListening={state.inputListening}
+              inputMonitoring={state.inputMonitoring}
               inputToggleDisabled={
                 input.mutationPending ||
                 !input.initialized ||
@@ -408,8 +408,8 @@ export function Recorder({ projectId }: { projectId: string }) {
               }
               onGainChange={(gain) => runtime.setRecordingTrackMix({ gain })}
               onInputSetup={() => setIsInputSetupOpen(true)}
-              onInputListeningChange={(listening) =>
-                runtime.setInputListening(listening)
+              onInputMonitoringChange={(monitoring) =>
+                runtime.setInputMonitoring(monitoring)
               }
               onInputToggle={input.toggle}
               onMutedChange={(muted) => runtime.setRecordingTrackMix({ muted })}

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -321,7 +321,7 @@ export function CaptureTrackRow({
         <div className="col-span-2">
           <InputMeter active={inputActive} analyser={inputAnalyser} compact />
         </div>
-        <label className="col-span-2 grid grid-cols-[1fr_3.5rem] items-end gap-2 text-[10px] text-neutral-400">
+        <label className="col-span-2 grid grid-cols-[1fr_3.5rem] items-center gap-2 text-[10px] text-neutral-400">
           <div className="relative">
             <div
               className="pointer-events-none absolute top-1/2 h-3 w-px -translate-y-1/2 bg-neutral-500/70"
@@ -337,7 +337,7 @@ export function CaptureTrackRow({
               onChange={(event) =>
                 onGainChange(percentToGain(event.currentTarget.valueAsNumber))
               }
-              className="w-full accent-emerald-600"
+              className="block w-full accent-emerald-600"
             />
           </div>
           <span className="text-right font-mono">{formatGainDb(gain)}</span>

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -219,7 +219,7 @@ export function CaptureTrackRow({
   });
   return (
     <div className="relative grid grid-cols-[15rem_1fr]" style={{ height }}>
-      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[2rem_1rem_0.75rem_1fr] gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 p-3">
+      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[2rem_1.5rem_0.75rem_1fr] gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 p-3">
         <div className="min-w-0">
           <div className="truncate text-xs font-semibold">Capture</div>
           <div className="mt-0.5 truncate text-[11px] text-neutral-400">

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -4,6 +4,7 @@ import {
   DownloadIcon,
   HeadphonesIcon,
   MoreVerticalIcon,
+  Settings2Icon,
   Trash2Icon,
   UploadIcon,
 } from "lucide-react";
@@ -279,17 +280,27 @@ export function CaptureTrackRow({
           />
         </div>
         <div className="col-span-2 flex min-w-0 items-center gap-1">
-          <button
-            type="button"
-            onClick={onInputSetup}
+          <span
             className={cn(
-              "min-w-0 flex-1 truncate text-left text-[11px] hover:underline",
+              "min-w-0 flex-1 truncate text-[11px]",
               routeNeedsSetup
-                ? "font-medium text-orange-300 hover:text-orange-200"
-                : "text-neutral-400 hover:text-neutral-100",
+                ? "font-medium text-orange-300"
+                : "text-neutral-400",
             )}
           >
             {route}
+          </span>
+          <button
+            type="button"
+            aria-label="Configure audio input"
+            title="Configure audio input"
+            onClick={onInputSetup}
+            className={cn(
+              "grid size-6 shrink-0 place-items-center rounded text-neutral-500 hover:bg-neutral-700 hover:text-neutral-200",
+              routeNeedsSetup && "text-orange-300 hover:text-orange-200",
+            )}
+          >
+            <Settings2Icon className="size-3.5" />
           </button>
           <button
             type="button"

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -220,7 +220,7 @@ export function CaptureTrackRow({
   });
   return (
     <div className="relative grid grid-cols-[15rem_1fr]" style={{ height }}>
-      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[2rem_1.5rem_0.75rem_1.5rem_1fr] gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 p-3">
+      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[2rem_1.5rem_0.75rem_1.5rem] content-start gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 p-3">
         <div className="min-w-0">
           <div className="truncate text-xs font-semibold">Capture</div>
           <div className="mt-0.5 truncate text-[11px] text-neutral-400">

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -220,7 +220,7 @@ export function CaptureTrackRow({
   });
   return (
     <div className="relative grid grid-cols-[15rem_1fr]" style={{ height }}>
-      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[2rem_1.5rem_0.75rem_1fr] gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 p-3">
+      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[2rem_1.5rem_0.75rem_1.5rem_1fr] gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 p-3">
         <div className="min-w-0">
           <div className="truncate text-xs font-semibold">Capture</div>
           <div className="mt-0.5 truncate text-[11px] text-neutral-400">
@@ -332,7 +332,7 @@ export function CaptureTrackRow({
         <div className="col-span-2">
           <InputMeter active={inputActive} analyser={inputAnalyser} compact />
         </div>
-        <label className="col-span-2 grid grid-cols-[1fr_3.5rem] items-center self-start gap-2 text-[10px] text-neutral-400">
+        <label className="col-span-2 grid grid-cols-[1fr_3.5rem] items-center gap-2 text-[10px] text-neutral-400">
           <div className="relative">
             <div
               className="pointer-events-none absolute top-1/2 h-3 w-px -translate-y-1/2 bg-neutral-500/70"

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -332,7 +332,7 @@ export function CaptureTrackRow({
         <div className="col-span-2">
           <InputMeter active={inputActive} analyser={inputAnalyser} compact />
         </div>
-        <label className="col-span-2 grid grid-cols-[1fr_3.5rem] items-center gap-2 text-[10px] text-neutral-400">
+        <label className="col-span-2 grid grid-cols-[1fr_3.5rem] items-center self-start gap-2 text-[10px] text-neutral-400">
           <div className="relative">
             <div
               className="pointer-events-none absolute top-1/2 h-3 w-px -translate-y-1/2 bg-neutral-500/70"

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -171,14 +171,14 @@ export function CaptureTrackRow({
   gain,
   inputActive,
   inputAnalyser,
-  inputListening,
+  inputMonitoring,
   inputToggleDisabled,
   muted,
   soloed,
   takeDownloadDisabled,
   onGainChange,
   onInputSetup,
-  onInputListeningChange,
+  onInputMonitoringChange,
   onInputToggle,
   onMutedChange,
   onSoloedChange,
@@ -193,14 +193,14 @@ export function CaptureTrackRow({
   gain: number;
   inputActive: boolean;
   inputAnalyser?: AudioAnalyser;
-  inputListening: boolean;
+  inputMonitoring: boolean;
   inputToggleDisabled: boolean;
   muted: boolean;
   soloed: boolean;
   takeDownloadDisabled: boolean;
   onGainChange: (gain: number) => void;
   onInputSetup: () => void;
-  onInputListeningChange: (listening: boolean) => void;
+  onInputMonitoringChange: (monitoring: boolean) => void;
   onInputToggle: () => void;
   onMutedChange: (muted: boolean) => void;
   onSoloedChange: (soloed: boolean) => void;
@@ -293,21 +293,25 @@ export function CaptureTrackRow({
           </button>
           <button
             type="button"
-            data-testid="recorder-input-listen"
+            data-testid="recorder-input-monitor"
             disabled={!inputActive}
-            aria-label={inputListening ? "Stop listening" : "Listen to input"}
-            aria-pressed={inputListening}
+            aria-label={
+              inputMonitoring
+                ? "Disable input monitoring"
+                : "Enable input monitoring"
+            }
+            aria-pressed={inputMonitoring}
             title={
               inputActive
-                ? inputListening
-                  ? "Stop listening"
-                  : "Listen to input (use headphones to avoid feedback)"
-                : "Enable input first to listen"
+                ? inputMonitoring
+                  ? "Disable input monitoring"
+                  : "Enable input monitoring (use headphones to avoid feedback)"
+                : "Enable input first to monitor"
             }
-            onClick={() => onInputListeningChange(!inputListening)}
+            onClick={() => onInputMonitoringChange(!inputMonitoring)}
             className={cn(
               "grid size-6 shrink-0 place-items-center rounded text-neutral-500 hover:bg-neutral-700 hover:text-neutral-200 disabled:pointer-events-none disabled:opacity-30",
-              inputListening &&
+              inputMonitoring &&
                 "bg-sky-500/25 text-sky-300 hover:bg-sky-500/35",
             )}
           >

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -172,7 +172,6 @@ export function CaptureTrackRow({
   inputActive,
   inputAnalyser,
   inputListening,
-  inputListeningDisabled,
   inputToggleDisabled,
   muted,
   soloed,
@@ -195,7 +194,6 @@ export function CaptureTrackRow({
   inputActive: boolean;
   inputAnalyser?: AudioAnalyser;
   inputListening: boolean;
-  inputListeningDisabled: boolean;
   inputToggleDisabled: boolean;
   muted: boolean;
   soloed: boolean;
@@ -296,17 +294,15 @@ export function CaptureTrackRow({
           <button
             type="button"
             data-testid="recorder-input-listen"
-            disabled={!inputActive || inputListeningDisabled}
+            disabled={!inputActive}
             aria-label={inputListening ? "Stop listening" : "Listen to input"}
             aria-pressed={inputListening}
             title={
-              inputListeningDisabled
-                ? "Input listening is unavailable while recording"
-                : inputActive
-                  ? inputListening
-                    ? "Stop listening"
-                    : "Listen to input (use headphones to avoid feedback)"
-                  : "Enable input first to listen"
+              inputActive
+                ? inputListening
+                  ? "Stop listening"
+                  : "Listen to input (use headphones to avoid feedback)"
+                : "Enable input first to listen"
             }
             onClick={() => onInputListeningChange(!inputListening)}
             className={cn(

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -2,6 +2,7 @@ import {
   ChevronDownIcon,
   ChevronRightIcon,
   DownloadIcon,
+  HeadphonesIcon,
   MoreVerticalIcon,
   Trash2Icon,
   UploadIcon,
@@ -170,12 +171,15 @@ export function CaptureTrackRow({
   gain,
   inputActive,
   inputAnalyser,
+  inputListening,
+  inputListeningDisabled,
   inputToggleDisabled,
   muted,
   soloed,
   takeDownloadDisabled,
   onGainChange,
   onInputSetup,
+  onInputListeningChange,
   onInputToggle,
   onMutedChange,
   onSoloedChange,
@@ -190,12 +194,15 @@ export function CaptureTrackRow({
   gain: number;
   inputActive: boolean;
   inputAnalyser?: AudioAnalyser;
+  inputListening: boolean;
+  inputListeningDisabled: boolean;
   inputToggleDisabled: boolean;
   muted: boolean;
   soloed: boolean;
   takeDownloadDisabled: boolean;
   onGainChange: (gain: number) => void;
   onInputSetup: () => void;
+  onInputListeningChange: (listening: boolean) => void;
   onInputToggle: () => void;
   onMutedChange: (muted: boolean) => void;
   onSoloedChange: (soloed: boolean) => void;
@@ -273,18 +280,44 @@ export function CaptureTrackRow({
             title={soloed ? "Disable Capture solo" : "Solo Capture"}
           />
         </div>
-        <button
-          type="button"
-          onClick={onInputSetup}
-          className={cn(
-            "col-span-2 min-w-0 truncate text-left text-[11px] hover:underline",
-            routeNeedsSetup
-              ? "font-medium text-orange-300 hover:text-orange-200"
-              : "text-neutral-400 hover:text-neutral-100",
-          )}
-        >
-          {route}
-        </button>
+        <div className="col-span-2 flex min-w-0 items-center gap-1">
+          <button
+            type="button"
+            onClick={onInputSetup}
+            className={cn(
+              "min-w-0 flex-1 truncate text-left text-[11px] hover:underline",
+              routeNeedsSetup
+                ? "font-medium text-orange-300 hover:text-orange-200"
+                : "text-neutral-400 hover:text-neutral-100",
+            )}
+          >
+            {route}
+          </button>
+          <button
+            type="button"
+            data-testid="recorder-input-listen"
+            disabled={!inputActive || inputListeningDisabled}
+            aria-label={inputListening ? "Stop listening" : "Listen to input"}
+            aria-pressed={inputListening}
+            title={
+              inputListeningDisabled
+                ? "Input listening is unavailable while recording"
+                : inputActive
+                  ? inputListening
+                    ? "Stop listening"
+                    : "Listen to input (use headphones to avoid feedback)"
+                  : "Enable input first to listen"
+            }
+            onClick={() => onInputListeningChange(!inputListening)}
+            className={cn(
+              "grid size-6 shrink-0 place-items-center rounded text-neutral-500 hover:bg-neutral-700 hover:text-neutral-200 disabled:pointer-events-none disabled:opacity-30",
+              inputListening &&
+                "bg-sky-500/25 text-sky-300 hover:bg-sky-500/35",
+            )}
+          >
+            <HeadphonesIcon className="size-3.5" />
+          </button>
+        </div>
         <div className="col-span-2">
           <InputMeter active={inputActive} analyser={inputAnalyser} compact />
         </div>

--- a/src/lib/recorder/capture-input.ts
+++ b/src/lib/recorder/capture-input.ts
@@ -24,7 +24,7 @@ export class CaptureInput {
   private readonly source: MediaStreamAudioSourceNode;
   private readonly worklet: CaptureWorkletClient;
   readonly analyser: AudioAnalyser;
-  private readonly listeningGain: GainNode;
+  private readonly monitorGain: GainNode;
 
   static async open({
     context,
@@ -90,14 +90,14 @@ export class CaptureInput {
       onNotification,
     });
     this.analyser = new AudioAnalyser(context);
-    this.listeningGain = context.createGain();
-    this.listeningGain.gain.value = 0;
+    this.monitorGain = context.createGain();
+    this.monitorGain.gain.value = 0;
     // Keep the worklet connected so browsers continue rendering it. Zero gain
-    // prevents input playback and feedback until listening is explicitly enabled.
+    // prevents input monitoring and feedback until it is explicitly enabled.
     this.source
       .connect(this.worklet.node)
       .connect(this.analyser.node)
-      .connect(this.listeningGain)
+      .connect(this.monitorGain)
       .connect(output);
   }
 
@@ -105,10 +105,10 @@ export class CaptureInput {
     this.worklet.setChannel(channel);
   }
 
-  setListening(enabled: boolean): void {
-    this.listeningGain.gain.setTargetAtTime(
+  setMonitoring(enabled: boolean): void {
+    this.monitorGain.gain.setTargetAtTime(
       enabled ? 1 : 0,
-      this.listeningGain.context.currentTime,
+      this.monitorGain.context.currentTime,
       0.01,
     );
   }
@@ -125,7 +125,7 @@ export class CaptureInput {
     this.source.disconnect();
     this.worklet.dispose();
     this.analyser.dispose();
-    this.listeningGain.disconnect();
+    this.monitorGain.disconnect();
     for (const track of this.stream.getTracks()) {
       track.stop();
     }

--- a/src/lib/recorder/capture-input.ts
+++ b/src/lib/recorder/capture-input.ts
@@ -24,15 +24,17 @@ export class CaptureInput {
   private readonly source: MediaStreamAudioSourceNode;
   private readonly worklet: CaptureWorkletClient;
   readonly analyser: AudioAnalyser;
-  private readonly silentGain: GainNode;
+  private readonly listeningGain: GainNode;
 
   static async open({
     context,
     deviceId,
+    output,
     onNotification,
   }: {
     context: AudioContext;
     deviceId: string;
+    output: AudioNode;
     onNotification: (message: CaptureWorkletNotification) => void;
   }) {
     await ensureCaptureWorklet(context);
@@ -48,6 +50,7 @@ export class CaptureInput {
     const input = new CaptureInput({
       context,
       stream,
+      output,
       onNotification: (message) => {
         if (message.type === "channels" && message.value > 0) {
           channelCountPromise.resolve(message.value);
@@ -72,10 +75,12 @@ export class CaptureInput {
   private constructor({
     context,
     stream,
+    output,
     onNotification,
   }: {
     context: AudioContext;
     stream: MediaStream;
+    output: AudioNode;
     onNotification: (message: CaptureWorkletNotification) => void;
   }) {
     this.stream = stream;
@@ -85,19 +90,27 @@ export class CaptureInput {
       onNotification,
     });
     this.analyser = new AudioAnalyser(context);
-    this.silentGain = context.createGain();
-    this.silentGain.gain.value = 0;
+    this.listeningGain = context.createGain();
+    this.listeningGain.gain.value = 0;
     // Keep the worklet connected so browsers continue rendering it. Zero gain
-    // prevents microphone monitoring and feedback at the destination.
+    // prevents input playback and feedback until listening is explicitly enabled.
     this.source
       .connect(this.worklet.node)
       .connect(this.analyser.node)
-      .connect(this.silentGain)
-      .connect(context.destination);
+      .connect(this.listeningGain)
+      .connect(output);
   }
 
   setChannel(channel: number): void {
     this.worklet.setChannel(channel);
+  }
+
+  setListening(enabled: boolean): void {
+    this.listeningGain.gain.setTargetAtTime(
+      enabled ? 1 : 0,
+      this.listeningGain.context.currentTime,
+      0.01,
+    );
   }
 
   startCapture(): Promise<number> {
@@ -112,7 +125,7 @@ export class CaptureInput {
     this.source.disconnect();
     this.worklet.dispose();
     this.analyser.dispose();
-    this.silentGain.disconnect();
+    this.listeningGain.disconnect();
     for (const track of this.stream.getTracks()) {
       track.stop();
     }

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -115,7 +115,7 @@ export interface RecorderRuntimeState {
   inputChannelCount: number;
   selectedChannel: number;
   latencyCompensation: number;
-  inputListening: boolean;
+  inputMonitoring: boolean;
 }
 
 export type PersistableRecorderRuntimeState = Pick<
@@ -165,7 +165,7 @@ export function createDefaultRecorderRuntimeState(): RecorderRuntimeState {
     inputChannelCount: 0,
     selectedChannel: 0,
     latencyCompensation: 0,
-    inputListening: false,
+    inputMonitoring: false,
   };
 }
 
@@ -232,7 +232,7 @@ export class RecorderRuntime {
       captureStatus: "ready",
       inputChannelCount: channelCount,
       selectedChannel: 0,
-      inputListening: false,
+      inputMonitoring: false,
     });
     return { channelCount };
   }
@@ -243,7 +243,7 @@ export class RecorderRuntime {
       captureStatus: "disabled",
       inputChannelCount: 0,
       selectedChannel: 0,
-      inputListening: false,
+      inputMonitoring: false,
     });
   }
 
@@ -252,12 +252,12 @@ export class RecorderRuntime {
     this.store.update({ selectedChannel: channel });
   }
 
-  setInputListening(inputListening: boolean): void {
-    if (inputListening && !this.captureInput) {
+  setInputMonitoring(inputMonitoring: boolean): void {
+    if (inputMonitoring && !this.captureInput) {
       return;
     }
-    this.captureInput?.setListening(inputListening);
-    this.store.update({ inputListening });
+    this.captureInput?.setMonitoring(inputMonitoring);
+    this.store.update({ inputMonitoring });
   }
 
   addAudioTrack(): string {

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -115,6 +115,7 @@ export interface RecorderRuntimeState {
   inputChannelCount: number;
   selectedChannel: number;
   latencyCompensation: number;
+  inputListening: boolean;
 }
 
 export type PersistableRecorderRuntimeState = Pick<
@@ -164,6 +165,7 @@ export function createDefaultRecorderRuntimeState(): RecorderRuntimeState {
     inputChannelCount: 0,
     selectedChannel: 0,
     latencyCompensation: 0,
+    inputListening: false,
   };
 }
 
@@ -194,6 +196,7 @@ export class RecorderRuntime {
     const { input, channelCount } = await CaptureInput.open({
       context,
       deviceId,
+      output: this.masterOutput!,
       onNotification: (message) => {
         switch (message.type) {
           case "samples": {
@@ -229,6 +232,7 @@ export class RecorderRuntime {
       captureStatus: "ready",
       inputChannelCount: channelCount,
       selectedChannel: 0,
+      inputListening: false,
     });
     return { channelCount };
   }
@@ -239,12 +243,21 @@ export class RecorderRuntime {
       captureStatus: "disabled",
       inputChannelCount: 0,
       selectedChannel: 0,
+      inputListening: false,
     });
   }
 
   selectChannel(channel: number): void {
     this.captureInput?.setChannel(channel);
     this.store.update({ selectedChannel: channel });
+  }
+
+  setInputListening(inputListening: boolean): void {
+    if (inputListening && !this.captureInput) {
+      return;
+    }
+    this.captureInput?.setListening(inputListening);
+    this.store.update({ inputListening });
   }
 
   addAudioTrack(): string {
@@ -636,6 +649,7 @@ export class RecorderRuntime {
     }
     const context = this.ensureContext();
     await context.resume();
+    this.setInputListening(false);
     const captureStartFrame = await this.captureInput.startCapture();
     if (!this.store.get().isPlaying) {
       await this.play();

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -649,7 +649,6 @@ export class RecorderRuntime {
     }
     const context = this.ensureContext();
     await context.resume();
-    this.setInputListening(false);
     const captureStartFrame = await this.captureInput.startCapture();
     if (!this.store.get().isPlaying) {
       await this.play();


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/toy-midi/issues/358

The recorder assumes interface-level direct monitoring for performance, but it is still useful to briefly monitor the selected browser input to verify the device, channel, rough gain, and round-trip behavior.

This PR adds a headphones toggle beside the Capture input route. It independently plays the selected mono input at unity through Master, defaults off, is not persisted, and stops when the input route closes. Recording remains frame-accurate and unaffected by the monitor gain.