### PR TITLE
fix: refine recorder capture controls

### DIFF
--- a/e2e/fake-audio/recorder-helpers.ts
+++ b/e2e/fake-audio/recorder-helpers.ts
@@ -48,14 +48,14 @@ export async function waitForRecordingSamples(recording: Locator) {
 
 export async function enableInput(page: Page) {
   // Fake audio still exercises permission, device discovery, and channel setup.
-  const route = page.getByRole("button", {
-    name: "Fake Default Audio Input · Input 1",
+  const inputSetupButton = page.getByRole("button", {
+    name: "Configure audio input",
   });
   await expect(page.getByTestId("recorder-input-toggle")).toHaveAttribute(
     "aria-pressed",
     "false",
   );
-  await route.click();
+  await inputSetupButton.click();
   await expect(
     page.getByRole("heading", { name: "Audio Input Setup" }),
   ).toBeVisible();
@@ -70,9 +70,7 @@ export async function enableInput(page: Page) {
   await expect(page.getByLabel("Channel")).toContainText("Channel 1");
   await page.getByRole("button", { name: "Close" }).click();
   await expect(
-    page.getByRole("button", {
-      name: "Fake Default Audio Input · Input 1",
-    }),
+    page.getByText("Fake Default Audio Input · Input 1"),
   ).toBeVisible();
   await expect(page.getByTestId("recorder-input-toggle")).toHaveAttribute(
     "aria-pressed",

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -3,6 +3,7 @@ import {
   ChevronRightIcon,
   DownloadIcon,
   MoreVerticalIcon,
+  Settings2Icon,
   Trash2Icon,
   UploadIcon,
 } from "lucide-react";
@@ -214,7 +215,7 @@ export function CaptureTrackRow({
   });
   return (
     <div className="relative grid grid-cols-[15rem_1fr]" style={{ height }}>
-      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[2rem_1rem_0.75rem_1fr] gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 p-3">
+      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[2rem_1.5rem_0.75rem_1.5rem] content-start gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 p-3">
         <div className="min-w-0">
           <div className="truncate text-xs font-semibold">Capture</div>
           <div className="mt-0.5 truncate text-[11px] text-neutral-400">
@@ -273,22 +274,34 @@ export function CaptureTrackRow({
             title={soloed ? "Disable Capture solo" : "Solo Capture"}
           />
         </div>
-        <button
-          type="button"
-          onClick={onInputSetup}
-          className={cn(
-            "col-span-2 min-w-0 truncate text-left text-[11px] hover:underline",
-            routeNeedsSetup
-              ? "font-medium text-orange-300 hover:text-orange-200"
-              : "text-neutral-400 hover:text-neutral-100",
-          )}
-        >
-          {route}
-        </button>
+        <div className="col-span-2 flex min-w-0 items-center gap-1">
+          <span
+            className={cn(
+              "min-w-0 flex-1 truncate text-[11px]",
+              routeNeedsSetup
+                ? "font-medium text-orange-300"
+                : "text-neutral-400",
+            )}
+          >
+            {route}
+          </span>
+          <button
+            type="button"
+            aria-label="Configure audio input"
+            title="Configure audio input"
+            onClick={onInputSetup}
+            className={cn(
+              "grid size-6 shrink-0 place-items-center rounded text-neutral-500 hover:bg-neutral-700 hover:text-neutral-200",
+              routeNeedsSetup && "text-orange-300 hover:text-orange-200",
+            )}
+          >
+            <Settings2Icon className="size-3.5" />
+          </button>
+        </div>
         <div className="col-span-2">
           <InputMeter active={inputActive} analyser={inputAnalyser} compact />
         </div>
-        <label className="col-span-2 grid grid-cols-[1fr_3.5rem] items-end gap-2 text-[10px] text-neutral-400">
+        <label className="col-span-2 grid grid-cols-[1fr_3.5rem] items-center gap-2 text-[10px] text-neutral-400">
           <div className="relative">
             <div
               className="pointer-events-none absolute top-1/2 h-3 w-px -translate-y-1/2 bg-neutral-500/70"
@@ -304,7 +317,7 @@ export function CaptureTrackRow({
               onChange={(event) =>
                 onGainChange(percentToGain(event.currentTarget.valueAsNumber))
               }
-              className="w-full accent-emerald-600"
+              className="block w-full accent-emerald-600"
             />
           </div>
           <span className="text-right font-mono">{formatGainDb(gain)}</span>


### PR DESCRIPTION
The Capture input route currently acts like an underlined link, while its compact rows have uneven sizing and the gain control shifts as the track is resized.

This PR makes the route status read-only with a dedicated input settings control, gives each control row fixed sizing and uniform gaps, and anchors the gain row so extra track height stays below the controls.