### PR TITLE
feat: add recorder input monitoring

### DIFF
--- a/e2e/fake-audio/recorder-recording.test.ts
+++ b/e2e/fake-audio/recorder-recording.test.ts
@@ -14,6 +14,13 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   // Connect the browser input before recording is available.
   await enableInput(page);
 
+  // Input monitoring can be enabled before recording starts.
+  const monitorButton = page.getByTestId("recorder-input-monitor");
+  await expect(monitorButton).toBeEnabled();
+  await expect(monitorButton).toHaveAttribute("aria-pressed", "false");
+  await monitorButton.click();
+  await expect(monitorButton).toHaveAttribute("aria-pressed", "true");
+
   // Place the playhead away from zero to exercise take placement.
   await seekRecorderByPixels(page, 160);
 
@@ -29,6 +36,7 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   await expect(page.getByTestId("recorder-download-take")).toBeDisabled();
   await page.keyboard.press("Escape");
   await recordButton.click();
+  await expect(monitorButton).toHaveAttribute("aria-pressed", "true");
   await expect(recordButton).toHaveAttribute("aria-pressed", "true");
   await expect(playButton).toHaveAttribute("aria-pressed", "true");
   const recording = page.getByTestId("recorder-clip-recording");

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -393,6 +393,7 @@ export function Recorder({ projectId }: { projectId: string }) {
               height={state.recordingTrack.height}
               inputActive={input.active}
               inputAnalyser={runtime.captureInput?.analyser}
+              inputMonitoring={state.inputMonitoring}
               inputToggleDisabled={
                 input.mutationPending ||
                 !input.initialized ||
@@ -407,6 +408,9 @@ export function Recorder({ projectId }: { projectId: string }) {
               }
               onGainChange={(gain) => runtime.setRecordingTrackMix({ gain })}
               onInputSetup={() => setIsInputSetupOpen(true)}
+              onInputMonitoringChange={(monitoring) =>
+                runtime.setInputMonitoring(monitoring)
+              }
               onInputToggle={input.toggle}
               onMutedChange={(muted) => runtime.setRecordingTrackMix({ muted })}
               onSoloedChange={(soloed) =>

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -2,6 +2,7 @@ import {
   ChevronDownIcon,
   ChevronRightIcon,
   DownloadIcon,
+  HeadphonesIcon,
   MoreVerticalIcon,
   Settings2Icon,
   Trash2Icon,
@@ -171,12 +172,14 @@ export function CaptureTrackRow({
   gain,
   inputActive,
   inputAnalyser,
+  inputMonitoring,
   inputToggleDisabled,
   muted,
   soloed,
   takeDownloadDisabled,
   onGainChange,
   onInputSetup,
+  onInputMonitoringChange,
   onInputToggle,
   onMutedChange,
   onSoloedChange,
@@ -191,12 +194,14 @@ export function CaptureTrackRow({
   gain: number;
   inputActive: boolean;
   inputAnalyser?: AudioAnalyser;
+  inputMonitoring: boolean;
   inputToggleDisabled: boolean;
   muted: boolean;
   soloed: boolean;
   takeDownloadDisabled: boolean;
   onGainChange: (gain: number) => void;
   onInputSetup: () => void;
+  onInputMonitoringChange: (monitoring: boolean) => void;
   onInputToggle: () => void;
   onMutedChange: (muted: boolean) => void;
   onSoloedChange: (soloed: boolean) => void;
@@ -296,6 +301,32 @@ export function CaptureTrackRow({
             )}
           >
             <Settings2Icon className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            data-testid="recorder-input-monitor"
+            disabled={!inputActive}
+            aria-label={
+              inputMonitoring
+                ? "Disable input monitoring"
+                : "Enable input monitoring"
+            }
+            aria-pressed={inputMonitoring}
+            title={
+              inputActive
+                ? inputMonitoring
+                  ? "Disable input monitoring"
+                  : "Enable input monitoring (use headphones to avoid feedback)"
+                : "Enable input first to monitor"
+            }
+            onClick={() => onInputMonitoringChange(!inputMonitoring)}
+            className={cn(
+              "grid size-6 shrink-0 place-items-center rounded text-neutral-500 hover:bg-neutral-700 hover:text-neutral-200 disabled:pointer-events-none disabled:opacity-30",
+              inputMonitoring &&
+                "bg-sky-500/25 text-sky-300 hover:bg-sky-500/35",
+            )}
+          >
+            <HeadphonesIcon className="size-3.5" />
           </button>
         </div>
         <div className="col-span-2">

--- a/src/lib/recorder/capture-input.ts
+++ b/src/lib/recorder/capture-input.ts
@@ -24,15 +24,17 @@ export class CaptureInput {
   private readonly source: MediaStreamAudioSourceNode;
   private readonly worklet: CaptureWorkletClient;
   readonly analyser: AudioAnalyser;
-  private readonly silentGain: GainNode;
+  private readonly monitorGain: GainNode;
 
   static async open({
     context,
     deviceId,
+    output,
     onNotification,
   }: {
     context: AudioContext;
     deviceId: string;
+    output: AudioNode;
     onNotification: (message: CaptureWorkletNotification) => void;
   }) {
     await ensureCaptureWorklet(context);
@@ -48,6 +50,7 @@ export class CaptureInput {
     const input = new CaptureInput({
       context,
       stream,
+      output,
       onNotification: (message) => {
         if (message.type === "channels" && message.value > 0) {
           channelCountPromise.resolve(message.value);
@@ -72,10 +75,12 @@ export class CaptureInput {
   private constructor({
     context,
     stream,
+    output,
     onNotification,
   }: {
     context: AudioContext;
     stream: MediaStream;
+    output: AudioNode;
     onNotification: (message: CaptureWorkletNotification) => void;
   }) {
     this.stream = stream;
@@ -85,19 +90,27 @@ export class CaptureInput {
       onNotification,
     });
     this.analyser = new AudioAnalyser(context);
-    this.silentGain = context.createGain();
-    this.silentGain.gain.value = 0;
+    this.monitorGain = context.createGain();
+    this.monitorGain.gain.value = 0;
     // Keep the worklet connected so browsers continue rendering it. Zero gain
-    // prevents microphone monitoring and feedback at the destination.
+    // prevents input monitoring and feedback until it is explicitly enabled.
     this.source
       .connect(this.worklet.node)
       .connect(this.analyser.node)
-      .connect(this.silentGain)
-      .connect(context.destination);
+      .connect(this.monitorGain)
+      .connect(output);
   }
 
   setChannel(channel: number): void {
     this.worklet.setChannel(channel);
+  }
+
+  setMonitoring(enabled: boolean): void {
+    this.monitorGain.gain.setTargetAtTime(
+      enabled ? 1 : 0,
+      this.monitorGain.context.currentTime,
+      0.01,
+    );
   }
 
   startCapture(): Promise<number> {
@@ -112,7 +125,7 @@ export class CaptureInput {
     this.source.disconnect();
     this.worklet.dispose();
     this.analyser.dispose();
-    this.silentGain.disconnect();
+    this.monitorGain.disconnect();
     for (const track of this.stream.getTracks()) {
       track.stop();
     }

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -115,6 +115,7 @@ export interface RecorderRuntimeState {
   inputChannelCount: number;
   selectedChannel: number;
   latencyCompensation: number;
+  inputMonitoring: boolean;
 }
 
 export type PersistableRecorderRuntimeState = Pick<
@@ -164,6 +165,7 @@ export function createDefaultRecorderRuntimeState(): RecorderRuntimeState {
     inputChannelCount: 0,
     selectedChannel: 0,
     latencyCompensation: 0,
+    inputMonitoring: false,
   };
 }
 
@@ -194,6 +196,7 @@ export class RecorderRuntime {
     const { input, channelCount } = await CaptureInput.open({
       context,
       deviceId,
+      output: this.masterOutput!,
       onNotification: (message) => {
         switch (message.type) {
           case "samples": {
@@ -229,6 +232,7 @@ export class RecorderRuntime {
       captureStatus: "ready",
       inputChannelCount: channelCount,
       selectedChannel: 0,
+      inputMonitoring: false,
     });
     return { channelCount };
   }
@@ -239,12 +243,21 @@ export class RecorderRuntime {
       captureStatus: "disabled",
       inputChannelCount: 0,
       selectedChannel: 0,
+      inputMonitoring: false,
     });
   }
 
   selectChannel(channel: number): void {
     this.captureInput?.setChannel(channel);
     this.store.update({ selectedChannel: channel });
+  }
+
+  setInputMonitoring(inputMonitoring: boolean): void {
+    if (inputMonitoring && !this.captureInput) {
+      return;
+    }
+    this.captureInput?.setMonitoring(inputMonitoring);
+    this.store.update({ inputMonitoring });
   }
 
   addAudioTrack(): string {


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/toy-midi/issues/358
- stacked on https://github.com/hi-ogawa/toy-midi/pull/440

The recorder assumes interface-level direct monitoring for performance, but it is still useful to briefly monitor the selected browser input to verify the device, channel, rough gain, and round-trip behavior.

This PR adds a headphones toggle beside the Capture input route. It independently plays the selected mono input at unity through Master, defaults off, is not persisted, and stops when the input route closes. Recording remains frame-accurate and unaffected by the monitor gain.