### PR TITLE
test: expose numeric recorder position

### DIFF
--- a/e2e/fake-audio/recorder-audio-track.test.ts
+++ b/e2e/fake-audio/recorder-audio-track.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "@playwright/test";
-import { createRecorderProject, dragBy } from "./recorder-helpers";
+import {
+  createRecorderProject,
+  dragBy,
+  getRecorderPosition,
+} from "./recorder-helpers";
 
 test("uploads and plays a backing track", async ({ page }) => {
   await createRecorderProject(page);
@@ -44,11 +48,10 @@ test("uploads and plays a backing track", async ({ page }) => {
 
   // Playback rolls the shared transport and can be paused from its new position.
   const playButton = page.getByTestId("recorder-play-button");
-  const position = page.getByTestId("recorder-position");
-  await expect(position).toHaveText("01|01 - 00:00.000");
+  await expect.poll(() => getRecorderPosition(page)).toBe(0);
   await playButton.click();
   await expect(playButton).toHaveAttribute("aria-pressed", "true");
-  await expect(position).not.toHaveText("01|01 - 00:00.000");
+  await expect.poll(() => getRecorderPosition(page)).toBeGreaterThan(0);
   await playButton.click();
   await expect(playButton).toHaveAttribute("aria-pressed", "false");
 

--- a/e2e/fake-audio/recorder-helpers.ts
+++ b/e2e/fake-audio/recorder-helpers.ts
@@ -15,6 +15,18 @@ export async function seekRecorderByPixels(page: Page, pixels: number) {
   await page.mouse.click(box!.x + pixels, box!.y + box!.height / 2);
 }
 
+export async function getRecorderPosition(page: Page): Promise<number> {
+  return page
+    .getByTestId("recorder-position")
+    .evaluate((element) => Number(element.dataset.position));
+}
+
+export async function getRecorderBeat(page: Page): Promise<number> {
+  return page
+    .getByTestId("recorder-position")
+    .evaluate((element) => Number(element.dataset.beat));
+}
+
 export async function dragBy(
   page: Page,
   locator: Locator,

--- a/e2e/fake-audio/recorder-loop-range.test.ts
+++ b/e2e/fake-audio/recorder-loop-range.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 import {
   createRecorderProject,
   dragBy,
+  getRecorderBeat,
   seekRecorderByPixels,
 } from "./recorder-helpers";
 
@@ -23,21 +24,20 @@ test("creates and edits a persisted loop range", async ({ page }) => {
 
   // Enabled playback returns to loop-in after reaching the end of the range.
   const playButton = page.getByTestId("recorder-play-button");
-  const position = page.getByTestId("recorder-position");
   await playButton.click();
   await expect(playButton).toHaveAttribute("aria-pressed", "true");
   await expect
-    .poll(async () => position.textContent(), {
+    .poll(() => getRecorderBeat(page), {
       intervals: [50],
       timeout: 1_500,
     })
-    .toMatch(/^01\|0[34] /);
+    .toBeGreaterThanOrEqual(2);
   await expect
-    .poll(async () => position.textContent(), {
+    .poll(() => getRecorderBeat(page), {
       intervals: [50],
       timeout: 1_500,
     })
-    .toMatch(/^01\|0[12] /);
+    .toBeLessThan(2);
   await playButton.click();
 
   // The range label moves it while the range body remains available to seek.
@@ -46,7 +46,7 @@ test("creates and edits a persisted loop range", async ({ page }) => {
   assert(movedBox);
   expect(movedBox.x).toBeCloseTo(initialBox.x + 80, -1);
   await seekRecorderByPixels(page, 320);
-  await expect(position).toHaveText(/^02\|01 /);
+  await expect.poll(() => getRecorderBeat(page)).toBe(4);
 
   // Disabling playback keeps the edited range available for later use.
   await toggle.click();

--- a/e2e/fake-audio/recorder-persistence.test.ts
+++ b/e2e/fake-audio/recorder-persistence.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { createRecorderProject } from "./recorder-helpers";
+import { createRecorderProject, getRecorderPosition } from "./recorder-helpers";
 
 test("saves and restores a recorder project", async ({ page }) => {
   // Create a project and give it a recognizable name.
@@ -21,9 +21,7 @@ test("saves and restores a recorder project", async ({ page }) => {
 
   // Transport updates are session state and do not stale persisted state.
   await page.getByTestId("recorder-play-button").click();
-  await expect(page.getByTestId("recorder-position")).not.toHaveText(
-    "1.1 - 0:00.000",
-  );
+  await expect.poll(() => getRecorderPosition(page)).toBeGreaterThan(0);
   await page.getByTestId("recorder-play-button").click();
   await expect(
     page.getByRole("button", { name: "All changes saved" }),

--- a/e2e/fake-audio/recorder-recording.test.ts
+++ b/e2e/fake-audio/recorder-recording.test.ts
@@ -4,6 +4,7 @@ import {
   createRecorderProject,
   dragBy,
   enableInput,
+  getRecorderPosition,
   seekRecorderByPixels,
   waitForRecordingSamples,
 } from "./recorder-helpers";
@@ -27,7 +28,6 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   // Recording starts capture and rolls the stopped transport.
   const recordButton = page.getByTestId("recorder-record-button");
   const playButton = page.getByTestId("recorder-play-button");
-  const position = page.getByTestId("recorder-position");
   const takesToggle = page.getByTestId("recorder-takes-toggle");
   await expect(takesToggle).toHaveAttribute("aria-expanded", "false");
   await expect(takesToggle).toContainText("0");
@@ -159,9 +159,11 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   await expect(takeRows).toHaveCount(2);
 
   // Selecting a source take does not seek, and Escape clears the selection.
-  const positionBeforeSelection = await position.textContent();
+  const positionBeforeSelection = await getRecorderPosition(page);
   await take.nth(0).click();
-  await expect(position).toHaveText(positionBeforeSelection!);
+  await expect
+    .poll(() => getRecorderPosition(page))
+    .toBe(positionBeforeSelection);
   await expect(take.nth(0)).toHaveAttribute("data-selected", "true");
   await page.keyboard.press("Escape");
   await expect(take.nth(0)).not.toHaveAttribute("data-selected", "true");

--- a/e2e/fake-audio/recorder-transport.test.ts
+++ b/e2e/fake-audio/recorder-transport.test.ts
@@ -2,6 +2,8 @@ import { expect, test } from "@playwright/test";
 import {
   createRecorderProject,
   enableInput,
+  getRecorderBeat,
+  getRecorderPosition,
   seekRecorderByPixels,
 } from "./recorder-helpers";
 
@@ -16,6 +18,8 @@ test("snaps recorder timeline seeking to the selected grid", async ({
   // The default 1/16 grid has four subdivisions per beat, so 0.9 beats snaps
   // to beat 1 rather than the adjacent 0.75-beat grid point.
   await seekRecorderByPixels(page, pixelsPerBeat * 0.9);
+  await expect.poll(() => getRecorderBeat(page)).toBe(1);
+  // Keep explicit coverage of the combined musical and elapsed-time display.
   await expect(position).toHaveText("01|02 - 00:00.500");
 
   // On the 1/4 grid, 0.4 beats rounds back to beat 0 rather than seeking to
@@ -23,27 +27,26 @@ test("snaps recorder timeline seeking to the selected grid", async ({
   await page.getByRole("button", { name: "1/16" }).click();
   await page.getByRole("menuitemradio", { name: "1/4" }).click();
   await seekRecorderByPixels(page, pixelsPerBeat * 0.4);
-  await expect(position).toHaveText("01|01 - 00:00.000");
+  await expect.poll(() => getRecorderBeat(page)).toBe(0);
 });
 
 test("seeks the recorder by five seconds with arrow keys", async ({ page }) => {
   await createRecorderProject(page);
 
   // Plain arrows move in five-second steps and clamp at the timeline start.
-  const position = page.getByTestId("recorder-position");
   await page.keyboard.press("ArrowRight");
-  await expect(position).toHaveText("03|03 - 00:05.000");
+  await expect.poll(() => getRecorderPosition(page)).toBe(5);
 
   await page.keyboard.press("ArrowLeft");
-  await expect(position).toHaveText("01|01 - 00:00.000");
+  await expect.poll(() => getRecorderPosition(page)).toBe(0);
   await page.keyboard.press("ArrowLeft");
-  await expect(position).toHaveText("01|01 - 00:00.000");
+  await expect.poll(() => getRecorderPosition(page)).toBe(0);
 
   // Focused text controls retain their native arrow-key behavior.
   const tempoInput = page.getByTestId("recorder-tempo-input");
   await tempoInput.focus();
   await page.keyboard.press("ArrowRight");
-  await expect(position).toHaveText("01|01 - 00:00.000");
+  await expect.poll(() => getRecorderPosition(page)).toBe(0);
 
   // Seeking during playback restarts participants and keeps the transport rolling.
   await tempoInput.blur();
@@ -53,14 +56,17 @@ test("seeks the recorder by five seconds with arrow keys", async ({ page }) => {
   await page.keyboard.press("ArrowRight");
   await expect(playButton).toHaveAttribute("aria-pressed", "true");
   await playButton.click();
-  await expect(position).toContainText(/00:0[5-9]\.|00:[1-5]\d\./);
+  await expect.poll(() => getRecorderPosition(page)).toBeGreaterThan(5);
 
   // Recording owns transport timing, so arrows cannot seek an active capture.
   await enableInput(page);
   const recordButton = page.getByTestId("recorder-record-button");
   await recordButton.click();
   await expect(recordButton).toHaveAttribute("aria-pressed", "true");
+  const positionBeforeSeek = await getRecorderPosition(page);
   await page.keyboard.press("ArrowRight");
-  await expect(position).not.toContainText("00:05.");
+  await expect
+    .poll(() => getRecorderPosition(page))
+    .toBeLessThan(positionBeforeSeek + 5);
   await recordButton.click();
 });

--- a/src/components/recorder/recorder-header.tsx
+++ b/src/components/recorder/recorder-header.tsx
@@ -256,6 +256,8 @@ export function RecorderHeader({
       </Button>
       <output
         data-testid="recorder-position"
+        data-position={position}
+        data-beat={secondsToBeats(position, tempo)}
         className="font-mono text-sm tabular-nums text-neutral-300"
       >
         {formatBarBeatAtTime({ seconds: position, tempo, timeSignature })} -{" "}


### PR DESCRIPTION
Recorder E2E tests were coupled to the combined bar/beat and elapsed-time display even when they only needed transport values. This made behavioral assertions parse presentation formatting.

This PR exposes recorder position in seconds and absolute beats as data attributes, adds shared helpers for reading them, and migrates numeric transport assertions while retaining one exact display-format assertion.