### PR TITLE
feat: add persisted recorder timeline locators

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,3 +48,5 @@ An active project session coordinates hydration, audio synchronization, autosave
 Project score routes read persisted documents directly and generate MusicXML in memory. They do not establish an active project session or mutate editor state; the editor flushes pending autosave before opening a score snapshot.
 
 Portable project files are zip archives containing project data, a manifest, and audio assets. MIDI import and export remain separate from the project-file format.
+
+The standalone recorder keeps project content in `RecorderRuntime` and saves explicitly to IndexedDB or portable project archives. Locators persist stable IDs, labels, and beat positions so tempo changes preserve their musical position. Locator selection remains transient UI state, and projects saved before locator support load with no locators.

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -84,45 +84,9 @@ test("edits, seeks, selects, and persists recorder locators", async ({
   await play.click();
   checkpoint("single seek during playback");
 
-  // Selecting a locator after a waveform makes Delete remove only the locator.
-  const fileChooser = page.waitForEvent("filechooser");
-  await page.getByTestId("recorder-add-audio-file").click();
-  await (await fileChooser).setFiles("e2e/fixtures/test-audio.wav");
-  const audio = page.getByTestId("recorder-clip-audio");
-  await expect(audio).toBeVisible();
-  await audio.click();
-  await expect(audio).toHaveAttribute("data-selected", "true");
-  await second.click();
-  await expect(audio).not.toHaveAttribute("data-selected", "true");
-  await page.keyboard.press("Delete");
-  await expect(second).toHaveCount(0);
-  await expect(audio).toBeVisible();
-  await expect(verse).toBeVisible();
-
-  // Creation also clears clip selection, and clip drag/trim clear locators.
-  await audio.click();
-  await seekRecorderByPixels(page, pixelsPerBeat * 8);
-  await add.click();
-  await expect(second).toHaveAttribute("aria-pressed", "true");
-  await expect(audio).not.toHaveAttribute("data-selected", "true");
-  await dragBy(page, audio, 20);
-  await expect(second).toHaveAttribute("aria-pressed", "false");
-  await expect(audio).toHaveAttribute("data-selected", "true");
-  await second.click();
-  await dragBy(page, audio.getByTestId("recorder-take-trim-end"), -10);
-  await expect(second).toHaveAttribute("aria-pressed", "false");
-
-  // Selecting a waveform after a locator makes Delete remove only the clip.
-  await second.click();
-  await audio.click();
-  await expect(second).toHaveAttribute("aria-pressed", "false");
-  await page.keyboard.press("Delete");
-  await expect(audio).toHaveCount(0);
-  await expect(second).toBeVisible();
   await second.click();
   await page.keyboard.press("Backspace");
   await expect(second).toHaveCount(0);
-  checkpoint("selection isolation and deletion");
 
   // Save restores the edited label and beat, but not the selection.
   await verse.click();

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -73,55 +73,50 @@ test("persists recorder locator edits and deletion", async ({ page }) => {
   const first = page.getByRole("button", { name: "Section 1", exact: true });
   const verse = page.getByRole("button", { name: "Verse", exact: true });
   const lane = page.getByTestId("recorder-locator-lane");
-  const unsavedProjectButton = page.getByRole("button", {
-    name: /Unsaved changes/,
-  });
-  const savedProjectButton = page.getByRole("button", {
-    name: "All changes saved",
-  });
+  const saveProjectButton = page.getByTestId("recorder-save-button");
 
   await seekRecorderByPixels(page, 80 * 2.5);
   await page.keyboard.press("l");
-  await expect(unsavedProjectButton).toBeEnabled();
+  await expect(saveProjectButton).toHaveAttribute("data-status", "unsaved");
   page.once("dialog", (dialog) => dialog.accept("Verse"));
   await first.dblclick();
 
   // Save restores the edited label and beat, but not the selection.
   await verse.click();
-  await unsavedProjectButton.click();
-  await expect(savedProjectButton).toHaveAttribute("aria-disabled", "true");
+  await saveProjectButton.click();
+  await expect(saveProjectButton).toHaveAttribute("data-status", "saved");
   await page.reload();
   await expect(verse).toHaveAttribute("aria-pressed", "false");
   await verse.click();
   await expect.poll(() => getRecorderBeat(page)).toBe(2.5);
-  await expect(savedProjectButton).toHaveAttribute("aria-disabled", "true");
+  await expect(saveProjectButton).toHaveAttribute("data-status", "saved");
 
   // Musical position survives tempo changes; each locator edit dirties the save.
   await page.getByTestId("recorder-tempo-input").fill("90");
   await page.getByTestId("recorder-tempo-input").press("Enter");
   await verse.click();
   await expect.poll(() => getRecorderBeat(page)).toBe(2.5);
-  await unsavedProjectButton.click();
-  await expect(savedProjectButton).toHaveAttribute("aria-disabled", "true");
+  await saveProjectButton.click();
+  await expect(saveProjectButton).toHaveAttribute("data-status", "saved");
   page.once("dialog", (dialog) => dialog.accept("Chorus"));
   await verse.dblclick();
   const chorus = page.getByRole("button", { name: "Chorus", exact: true });
-  await expect(unsavedProjectButton).toBeEnabled();
-  await unsavedProjectButton.click();
-  await expect(savedProjectButton).toHaveAttribute("aria-disabled", "true");
+  await expect(saveProjectButton).toHaveAttribute("data-status", "unsaved");
+  await saveProjectButton.click();
+  await expect(saveProjectButton).toHaveAttribute("data-status", "saved");
   await dragBy(page, chorus, 40);
-  await expect(unsavedProjectButton).toBeEnabled();
-  await unsavedProjectButton.click();
-  await expect(savedProjectButton).toHaveAttribute("aria-disabled", "true");
+  await expect(saveProjectButton).toHaveAttribute("data-status", "unsaved");
+  await saveProjectButton.click();
+  await expect(saveProjectButton).toHaveAttribute("data-status", "saved");
   await page.reload();
   await expect(chorus).toHaveAttribute("aria-pressed", "false");
   await chorus.click();
   await expect.poll(() => getRecorderBeat(page)).toBe(3);
   await page.keyboard.press("Delete");
   await expect(chorus).toHaveCount(0);
-  await expect(unsavedProjectButton).toBeEnabled();
-  await unsavedProjectButton.click();
-  await expect(savedProjectButton).toHaveAttribute("aria-disabled", "true");
+  await expect(saveProjectButton).toHaveAttribute("data-status", "unsaved");
+  await saveProjectButton.click();
+  await expect(saveProjectButton).toHaveAttribute("data-status", "saved");
   await page.reload();
   await expect(page.getByTestId("recorder-project-name")).toBeVisible();
   await expect(chorus).toHaveCount(0);

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -66,6 +66,14 @@ test("edits, seeks, and selects recorder locators", async ({ page }) => {
   await expect.poll(() => getRecorderBeat(page)).toBe(6);
   await verse.click();
   await expect.poll(() => getRecorderBeat(page)).toBe(2.5);
+
+  // Locator beats remain stable when tempo changes.
+  await page.getByTestId("recorder-tempo-input").fill("90");
+  await page.getByTestId("recorder-tempo-input").press("Enter");
+  await seekRecorderByPixels(page, pixelsPerBeat * 4);
+  await expect.poll(() => getRecorderBeat(page)).toBe(4);
+  await verse.click();
+  await expect.poll(() => getRecorderBeat(page)).toBe(2.5);
 });
 
 test("persists recorder locator edits and deletion", async ({ page }) => {
@@ -91,14 +99,6 @@ test("persists recorder locator edits and deletion", async ({ page }) => {
   await expect(verse).toHaveAttribute("aria-pressed", "false");
   await verse.click();
   await expect.poll(() => getRecorderBeat(page)).toBe(2.5);
-  await expect(saveProjectButton).toHaveAttribute("data-status", "saved");
-
-  // Locator beats remain stable when tempo changes.
-  await page.getByTestId("recorder-tempo-input").fill("90");
-  await page.getByTestId("recorder-tempo-input").press("Enter");
-  await verse.click();
-  await expect.poll(() => getRecorderBeat(page)).toBe(2.5);
-  await saveProjectButton.click();
   await expect(saveProjectButton).toHaveAttribute("data-status", "saved");
 
   // Renaming dirties the project.

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -89,6 +89,9 @@ test("persists recorder locator edits and deletion", async ({ page }) => {
   await page.keyboard.press("l");
   page.once("dialog", (dialog) => dialog.accept("Verse"));
   await first.dblclick();
+  await seekRecorderByPixels(page, pixelsPerBeat * 5);
+  await page.keyboard.press("l");
+  const second = page.getByRole("button", { name: "Section 2", exact: true });
   await expect(saveButton).toHaveAttribute("data-status", "unsaved");
 
   // Save restores the edited label and beat, but not the selection.
@@ -127,7 +130,7 @@ test("persists recorder locator edits and deletion", async ({ page }) => {
   await saveButton.click();
   await expect(saveButton).toHaveAttribute("data-status", "saved");
   await page.reload();
-  await expect(page.getByTestId("recorder-project-name")).toBeVisible();
   await expect(chorus).toHaveCount(0);
-  await expect(lane.getByRole("button")).toHaveCount(0);
+  await expect(second).toBeVisible();
+  await expect(lane.getByRole("button")).toHaveCount(1);
 });

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -44,6 +44,13 @@ test("edits, seeks, selects, and persists recorder locators", async ({
   await page.keyboard.press("Delete");
   await expect(verse).toBeVisible();
 
+  // Removing the selected locator leaves the other marker intact.
+  await second.click();
+  await page.keyboard.press("Backspace");
+  await expect(second).toHaveCount(0);
+
+  await expect(verse).toBeVisible();
+
   // Empty locator space deselects without seeking.
   await verse.click();
   const lane = page.getByTestId("recorder-locator-lane");
@@ -83,10 +90,6 @@ test("edits, seeks, selects, and persists recorder locators", async ({
   await expect.poll(() => getRecorderBeat(page)).toBeLessThan(4);
   await play.click();
   checkpoint("single seek during playback");
-
-  await second.click();
-  await page.keyboard.press("Backspace");
-  await expect(second).toHaveCount(0);
 
   // Save restores the edited label and beat, but not the selection.
   await verse.click();

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -75,11 +75,12 @@ test("persists recorder locator edits and deletion", async ({ page }) => {
   const lane = page.getByTestId("recorder-locator-lane");
   const saveProjectButton = page.getByTestId("recorder-save-button");
 
+  // Create and rename a locator at beat 2.5.
   await seekRecorderByPixels(page, 80 * 2.5);
   await page.keyboard.press("l");
-  await expect(saveProjectButton).toHaveAttribute("data-status", "unsaved");
   page.once("dialog", (dialog) => dialog.accept("Verse"));
   await first.dblclick();
+  await expect(saveProjectButton).toHaveAttribute("data-status", "unsaved");
 
   // Save restores the edited label and beat, but not the selection.
   await verse.click();

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -7,9 +7,7 @@ import {
   seekRecorderByPixels,
 } from "./recorder-helpers";
 
-test("edits, seeks, selects, and persists recorder locators", async ({
-  page,
-}) => {
+test("edits, seeks, and selects recorder locators", async ({ page }) => {
   const checkpoint = createCheckpoint();
   await createRecorderProject(page);
   const pixelsPerBeat = 80;
@@ -17,18 +15,11 @@ test("edits, seeks, selects, and persists recorder locators", async ({
   const first = page.getByRole("button", { name: "Section 1", exact: true });
   const second = page.getByRole("button", { name: "Section 2", exact: true });
   const verse = page.getByRole("button", { name: "Verse", exact: true });
-  const unsavedProjectButton = page.getByRole("button", {
-    name: /Unsaved changes/,
-  });
-  const savedProjectButton = page.getByRole("button", {
-    name: "All changes saved",
-  });
 
   // Both creation controls use the snapped playhead and select the new marker.
   await seekRecorderByPixels(page, pixelsPerBeat * 0.9);
   await page.keyboard.press("l");
   await expect(first).toHaveAttribute("aria-pressed", "true");
-  await expect(unsavedProjectButton).toBeEnabled();
   await seekRecorderByPixels(page, pixelsPerBeat * 4);
   await add.click();
   await expect(second).toHaveAttribute("aria-pressed", "true");
@@ -100,6 +91,25 @@ test("edits, seeks, selects, and persists recorder locators", async ({
   await expect.poll(() => getRecorderBeat(page)).toBeLessThan(4);
   await play.click();
   checkpoint("single seek during playback");
+});
+
+test("persists recorder locator edits and deletion", async ({ page }) => {
+  await createRecorderProject(page);
+  const first = page.getByRole("button", { name: "Section 1", exact: true });
+  const verse = page.getByRole("button", { name: "Verse", exact: true });
+  const lane = page.getByTestId("recorder-locator-lane");
+  const unsavedProjectButton = page.getByRole("button", {
+    name: /Unsaved changes/,
+  });
+  const savedProjectButton = page.getByRole("button", {
+    name: "All changes saved",
+  });
+
+  await seekRecorderByPixels(page, 80 * 2.5);
+  await page.keyboard.press("l");
+  await expect(unsavedProjectButton).toBeEnabled();
+  page.once("dialog", (dialog) => dialog.accept("Verse"));
+  await first.dblclick();
 
   // Save restores the edited label and beat, but not the selection.
   await verse.click();
@@ -141,5 +151,4 @@ test("edits, seeks, selects, and persists recorder locators", async ({
   await expect(page.getByTestId("recorder-project-name")).toBeVisible();
   await expect(chorus).toHaveCount(0);
   await expect(lane.getByRole("button")).toHaveCount(0);
-  checkpoint("save and reload");
 });

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -61,7 +61,12 @@ test("edits, seeks, selects, and persists recorder locators", async ({
 
   // Dragging snaps the marker to beat 2.5 without moving the playhead.
   await seekRecorderByPixels(page, pixelsPerBeat * 6);
+  const beforeDrag = await verse.boundingBox();
+  expect(beforeDrag).not.toBeNull();
   await dragBy(page, verse, 110);
+  await expect
+    .poll(async () => (await verse.boundingBox())?.x)
+    .toBeCloseTo(beforeDrag!.x + pixelsPerBeat * 1.5, 1);
   await expect(verse).toHaveAttribute("aria-pressed", "true");
   await expect.poll(() => getRecorderBeat(page)).toBe(6);
   await verse.click();

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -80,34 +80,31 @@ test("edits, seeks, and selects recorder locators", async ({ page }) => {
 test("persists recorder locator edits and deletion", async ({ page }) => {
   await createRecorderProject(page);
   const first = page.getByRole("button", { name: "Section 1", exact: true });
-  const verse = page.getByRole("button", { name: "Verse", exact: true });
   const lane = page.getByTestId("recorder-locator-lane");
   const saveButton = page.getByTestId("recorder-save-button");
 
-  // Create and rename a locator at beat 2.5.
+  // Create locators at beats 2.5 and 5.
   await seekRecorderByPixels(page, pixelsPerBeat * 2.5);
   await page.keyboard.press("l");
-  page.once("dialog", (dialog) => dialog.accept("Verse"));
-  await first.dblclick();
   await seekRecorderByPixels(page, pixelsPerBeat * 5);
   await page.keyboard.press("l");
   const second = page.getByRole("button", { name: "Section 2", exact: true });
   await expect(saveButton).toHaveAttribute("data-status", "unsaved");
 
-  // Save restores the edited label and beat, but not the selection.
-  await verse.click();
-  await expect(verse).toHaveAttribute("aria-pressed", "true");
+  // Save restores the locator beat, but not the selection.
+  await first.click();
+  await expect(first).toHaveAttribute("aria-pressed", "true");
   await saveButton.click();
   await expect(saveButton).toHaveAttribute("data-status", "saved");
   await page.reload();
-  await expect(verse).toHaveAttribute("aria-pressed", "false");
-  await verse.click();
+  await expect(first).toHaveAttribute("aria-pressed", "false");
+  await first.click();
   await expect.poll(() => getRecorderBeat(page)).toBe(2.5);
   await expect(saveButton).toHaveAttribute("data-status", "saved");
 
   // Renaming dirties the project.
   page.once("dialog", (dialog) => dialog.accept("Chorus"));
-  await verse.dblclick();
+  await first.dblclick();
   const chorus = page.getByRole("button", { name: "Chorus", exact: true });
   await expect(saveButton).toHaveAttribute("data-status", "unsaved");
   await saveButton.click();

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -80,6 +80,11 @@ test("edits, seeks, and selects recorder locators", async ({ page }) => {
 test("persists recorder locator edits and deletion", async ({ page }) => {
   await createRecorderProject(page);
   const first = page.getByRole("button", { name: "Section 1", exact: true });
+  const firstRenamed = page.getByRole("button", {
+    name: "Renamed 1",
+    exact: true,
+  });
+  const second = page.getByRole("button", { name: "Section 2", exact: true });
   const lane = page.getByTestId("recorder-locator-lane");
   const saveButton = page.getByTestId("recorder-save-button");
 
@@ -88,7 +93,6 @@ test("persists recorder locator edits and deletion", async ({ page }) => {
   await page.keyboard.press("l");
   await seekRecorderByPixels(page, pixelsPerBeat * 5);
   await page.keyboard.press("l");
-  const second = page.getByRole("button", { name: "Section 2", exact: true });
   await expect(saveButton).toHaveAttribute("data-status", "unsaved");
 
   // Save restores the locator beat, but not the selection.
@@ -105,10 +109,6 @@ test("persists recorder locator edits and deletion", async ({ page }) => {
   // Renaming dirties the project.
   page.once("dialog", (dialog) => dialog.accept("Renamed 1"));
   await first.dblclick();
-  const firstRenamed = page.getByRole("button", {
-    name: "Renamed 1",
-    exact: true,
-  });
   await expect(saveButton).toHaveAttribute("data-status", "unsaved");
   await saveButton.click();
   await expect(saveButton).toHaveAttribute("data-status", "saved");

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from "@playwright/test";
-import { createCheckpoint } from "../helpers";
 import {
   createRecorderProject,
   dragBy,
@@ -8,7 +7,6 @@ import {
 } from "./recorder-helpers";
 
 test("edits, seeks, and selects recorder locators", async ({ page }) => {
-  const checkpoint = createCheckpoint();
   await createRecorderProject(page);
   const pixelsPerBeat = 80;
   const add = page.getByRole("button", { name: "Add locator at playhead" });
@@ -68,7 +66,6 @@ test("edits, seeks, and selects recorder locators", async ({ page }) => {
   await expect.poll(() => getRecorderBeat(page)).toBe(6);
   await verse.click();
   await expect.poll(() => getRecorderBeat(page)).toBe(2.5);
-  checkpoint("create, rename, deselect, and drag");
 });
 
 test("persists recorder locator edits and deletion", async ({ page }) => {

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -69,28 +69,6 @@ test("edits, seeks, and selects recorder locators", async ({ page }) => {
   await verse.click();
   await expect.poll(() => getRecorderBeat(page)).toBe(2.5);
   checkpoint("create, rename, deselect, and drag");
-
-  // During playback, pointer-down must not seek before the completed click.
-  await seekRecorderByPixels(page, pixelsPerBeat * 6);
-  const play = page.getByTestId("recorder-play-button");
-  await play.click();
-  await expect.poll(() => getRecorderBeat(page)).toBeGreaterThan(6.5);
-  const verseBox = await verse.boundingBox();
-  expect(verseBox).not.toBeNull();
-  await page.mouse.move(
-    verseBox!.x + verseBox!.width / 2,
-    verseBox!.y + verseBox!.height / 2,
-  );
-  const beforePress = await getRecorderBeat(page);
-  await page.mouse.down();
-  expect(await getRecorderBeat(page)).toBeGreaterThanOrEqual(beforePress);
-  await expect
-    .poll(() => getRecorderBeat(page))
-    .toBeGreaterThan(beforePress + 0.5);
-  await page.mouse.up();
-  await expect.poll(() => getRecorderBeat(page)).toBeLessThan(4);
-  await play.click();
-  checkpoint("single seek during playback");
 });
 
 test("persists recorder locator edits and deletion", async ({ page }) => {

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -17,14 +17,18 @@ test("edits, seeks, selects, and persists recorder locators", async ({
   const first = page.getByRole("button", { name: "Section 1", exact: true });
   const second = page.getByRole("button", { name: "Section 2", exact: true });
   const verse = page.getByRole("button", { name: "Verse", exact: true });
-  const unsaved = page.getByRole("button", { name: /Unsaved changes/ });
-  const saved = page.getByRole("button", { name: "All changes saved" });
+  const unsavedProjectButton = page.getByRole("button", {
+    name: /Unsaved changes/,
+  });
+  const savedProjectButton = page.getByRole("button", {
+    name: "All changes saved",
+  });
 
   // Both creation controls use the snapped playhead and select the new marker.
   await seekRecorderByPixels(page, pixelsPerBeat * 0.9);
   await page.keyboard.press("l");
   await expect(first).toHaveAttribute("aria-pressed", "true");
-  await expect(unsaved).toBeEnabled();
+  await expect(unsavedProjectButton).toBeEnabled();
   await seekRecorderByPixels(page, pixelsPerBeat * 4);
   await add.click();
   await expect(second).toHaveAttribute("aria-pressed", "true");
@@ -99,40 +103,40 @@ test("edits, seeks, selects, and persists recorder locators", async ({
 
   // Save restores the edited label and beat, but not the selection.
   await verse.click();
-  await unsaved.click();
-  await expect(saved).toHaveAttribute("aria-disabled", "true");
+  await unsavedProjectButton.click();
+  await expect(savedProjectButton).toHaveAttribute("aria-disabled", "true");
   await page.reload();
   await expect(verse).toHaveAttribute("aria-pressed", "false");
   await verse.click();
   await expect.poll(() => getRecorderBeat(page)).toBe(2.5);
-  await expect(saved).toHaveAttribute("aria-disabled", "true");
+  await expect(savedProjectButton).toHaveAttribute("aria-disabled", "true");
 
   // Musical position survives tempo changes; each locator edit dirties the save.
   await page.getByTestId("recorder-tempo-input").fill("90");
   await page.getByTestId("recorder-tempo-input").press("Enter");
   await verse.click();
   await expect.poll(() => getRecorderBeat(page)).toBe(2.5);
-  await unsaved.click();
-  await expect(saved).toHaveAttribute("aria-disabled", "true");
+  await unsavedProjectButton.click();
+  await expect(savedProjectButton).toHaveAttribute("aria-disabled", "true");
   page.once("dialog", (dialog) => dialog.accept("Chorus"));
   await verse.dblclick();
   const chorus = page.getByRole("button", { name: "Chorus", exact: true });
-  await expect(unsaved).toBeEnabled();
-  await unsaved.click();
-  await expect(saved).toHaveAttribute("aria-disabled", "true");
+  await expect(unsavedProjectButton).toBeEnabled();
+  await unsavedProjectButton.click();
+  await expect(savedProjectButton).toHaveAttribute("aria-disabled", "true");
   await dragBy(page, chorus, 40);
-  await expect(unsaved).toBeEnabled();
-  await unsaved.click();
-  await expect(saved).toHaveAttribute("aria-disabled", "true");
+  await expect(unsavedProjectButton).toBeEnabled();
+  await unsavedProjectButton.click();
+  await expect(savedProjectButton).toHaveAttribute("aria-disabled", "true");
   await page.reload();
   await expect(chorus).toHaveAttribute("aria-pressed", "false");
   await chorus.click();
   await expect.poll(() => getRecorderBeat(page)).toBe(3);
   await page.keyboard.press("Delete");
   await expect(chorus).toHaveCount(0);
-  await expect(unsaved).toBeEnabled();
-  await unsaved.click();
-  await expect(saved).toHaveAttribute("aria-disabled", "true");
+  await expect(unsavedProjectButton).toBeEnabled();
+  await unsavedProjectButton.click();
+  await expect(savedProjectButton).toHaveAttribute("aria-disabled", "true");
   await page.reload();
   await expect(page.getByTestId("recorder-project-name")).toBeVisible();
   await expect(chorus).toHaveCount(0);

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -93,19 +93,23 @@ test("persists recorder locator edits and deletion", async ({ page }) => {
   await expect.poll(() => getRecorderBeat(page)).toBe(2.5);
   await expect(saveProjectButton).toHaveAttribute("data-status", "saved");
 
-  // Musical position survives tempo changes; each locator edit dirties the save.
+  // Locator beats remain stable when tempo changes.
   await page.getByTestId("recorder-tempo-input").fill("90");
   await page.getByTestId("recorder-tempo-input").press("Enter");
   await verse.click();
   await expect.poll(() => getRecorderBeat(page)).toBe(2.5);
   await saveProjectButton.click();
   await expect(saveProjectButton).toHaveAttribute("data-status", "saved");
+
+  // Renaming dirties the project.
   page.once("dialog", (dialog) => dialog.accept("Chorus"));
   await verse.dblclick();
   const chorus = page.getByRole("button", { name: "Chorus", exact: true });
   await expect(saveProjectButton).toHaveAttribute("data-status", "unsaved");
   await saveProjectButton.click();
   await expect(saveProjectButton).toHaveAttribute("data-status", "saved");
+
+  // Moving a locator dirties the project and persists its new beat.
   await dragBy(page, chorus, 40);
   await expect(saveProjectButton).toHaveAttribute("data-status", "unsaved");
   await saveProjectButton.click();
@@ -114,6 +118,8 @@ test("persists recorder locator edits and deletion", async ({ page }) => {
   await expect(chorus).toHaveAttribute("aria-pressed", "false");
   await chorus.click();
   await expect.poll(() => getRecorderBeat(page)).toBe(3);
+
+  // Deleting a locator dirties the project and persists its removal.
   await page.keyboard.press("Delete");
   await expect(chorus).toHaveCount(0);
   await expect(saveProjectButton).toHaveAttribute("data-status", "unsaved");

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -84,6 +84,7 @@ test("persists recorder locator edits and deletion", async ({ page }) => {
 
   // Save restores the edited label and beat, but not the selection.
   await verse.click();
+  await expect(verse).toHaveAttribute("aria-pressed", "true");
   await saveProjectButton.click();
   await expect(saveProjectButton).toHaveAttribute("data-status", "saved");
   await page.reload();

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -1,0 +1,168 @@
+import { expect, test } from "@playwright/test";
+import { createCheckpoint } from "../helpers";
+import {
+  createRecorderProject,
+  dragBy,
+  getRecorderBeat,
+  seekRecorderByPixels,
+} from "./recorder-helpers";
+
+test("edits, seeks, selects, and persists recorder locators", async ({
+  page,
+}) => {
+  const checkpoint = createCheckpoint();
+  await createRecorderProject(page);
+  const pixelsPerBeat = 80;
+  const add = page.getByRole("button", { name: "Add locator at playhead" });
+  const first = page.getByRole("button", { name: "Section 1", exact: true });
+  const second = page.getByRole("button", { name: "Section 2", exact: true });
+  const verse = page.getByRole("button", { name: "Verse", exact: true });
+  const unsaved = page.getByRole("button", { name: /Unsaved changes/ });
+  const saved = page.getByRole("button", { name: "All changes saved" });
+
+  // Both creation controls use the snapped playhead and select the new marker.
+  await seekRecorderByPixels(page, pixelsPerBeat * 0.9);
+  await page.keyboard.press("l");
+  await expect(first).toHaveAttribute("aria-pressed", "true");
+  await expect(unsaved).toBeEnabled();
+  await seekRecorderByPixels(page, pixelsPerBeat * 4);
+  await add.click();
+  await expect(second).toHaveAttribute("aria-pressed", "true");
+  await expect(first).toHaveAttribute("aria-pressed", "false");
+  await first.click();
+  await expect.poll(() => getRecorderBeat(page)).toBe(1);
+
+  // Rename commits through the prompt; cancelling keeps the existing label.
+  page.once("dialog", (dialog) => dialog.accept("Verse"));
+  await first.dblclick();
+  await expect(verse).toBeVisible();
+  page.once("dialog", (dialog) => dialog.dismiss());
+  await verse.dblclick();
+  await expect(verse).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(verse).toHaveAttribute("aria-pressed", "false");
+  await page.keyboard.press("Delete");
+  await expect(verse).toBeVisible();
+
+  // Empty locator space deselects without seeking.
+  await verse.click();
+  const lane = page.getByTestId("recorder-locator-lane");
+  const laneBox = await lane.boundingBox();
+  expect(laneBox).not.toBeNull();
+  await lane.click({ position: { x: laneBox!.width - 10, y: 12 } });
+  await expect(verse).toHaveAttribute("aria-pressed", "false");
+  await expect.poll(() => getRecorderBeat(page)).toBe(1);
+
+  // Dragging snaps the marker to beat 2.5 without moving the playhead.
+  await seekRecorderByPixels(page, pixelsPerBeat * 6);
+  await dragBy(page, verse, 110);
+  await expect(verse).toHaveAttribute("aria-pressed", "true");
+  await expect.poll(() => getRecorderBeat(page)).toBe(6);
+  await verse.click();
+  await expect.poll(() => getRecorderBeat(page)).toBe(2.5);
+  checkpoint("create, rename, deselect, and drag");
+
+  // During playback, pointer-down must not seek before the completed click.
+  await seekRecorderByPixels(page, pixelsPerBeat * 6);
+  const play = page.getByTestId("recorder-play-button");
+  await play.click();
+  await expect.poll(() => getRecorderBeat(page)).toBeGreaterThan(6.5);
+  const verseBox = await verse.boundingBox();
+  expect(verseBox).not.toBeNull();
+  await page.mouse.move(
+    verseBox!.x + verseBox!.width / 2,
+    verseBox!.y + verseBox!.height / 2,
+  );
+  const beforePress = await getRecorderBeat(page);
+  await page.mouse.down();
+  expect(await getRecorderBeat(page)).toBeGreaterThanOrEqual(beforePress);
+  await expect
+    .poll(() => getRecorderBeat(page))
+    .toBeGreaterThan(beforePress + 0.5);
+  await page.mouse.up();
+  await expect.poll(() => getRecorderBeat(page)).toBeLessThan(4);
+  await play.click();
+  checkpoint("single seek during playback");
+
+  // Selecting a locator after a waveform makes Delete remove only the locator.
+  const fileChooser = page.waitForEvent("filechooser");
+  await page.getByTestId("recorder-add-audio-file").click();
+  await (await fileChooser).setFiles("e2e/fixtures/test-audio.wav");
+  const audio = page.getByTestId("recorder-clip-audio");
+  await expect(audio).toBeVisible();
+  await audio.click();
+  await expect(audio).toHaveAttribute("data-selected", "true");
+  await second.click();
+  await expect(audio).not.toHaveAttribute("data-selected", "true");
+  await page.keyboard.press("Delete");
+  await expect(second).toHaveCount(0);
+  await expect(audio).toBeVisible();
+  await expect(verse).toBeVisible();
+
+  // Creation also clears clip selection, and clip drag/trim clear locators.
+  await audio.click();
+  await seekRecorderByPixels(page, pixelsPerBeat * 8);
+  await add.click();
+  await expect(second).toHaveAttribute("aria-pressed", "true");
+  await expect(audio).not.toHaveAttribute("data-selected", "true");
+  await dragBy(page, audio, 20);
+  await expect(second).toHaveAttribute("aria-pressed", "false");
+  await expect(audio).toHaveAttribute("data-selected", "true");
+  await second.click();
+  await dragBy(page, audio.getByTestId("recorder-take-trim-end"), -10);
+  await expect(second).toHaveAttribute("aria-pressed", "false");
+
+  // Selecting a waveform after a locator makes Delete remove only the clip.
+  await second.click();
+  await audio.click();
+  await expect(second).toHaveAttribute("aria-pressed", "false");
+  await page.keyboard.press("Delete");
+  await expect(audio).toHaveCount(0);
+  await expect(second).toBeVisible();
+  await second.click();
+  await page.keyboard.press("Backspace");
+  await expect(second).toHaveCount(0);
+  checkpoint("selection isolation and deletion");
+
+  // Save restores the edited label and beat, but not the selection.
+  await verse.click();
+  await unsaved.click();
+  await expect(saved).toHaveAttribute("aria-disabled", "true");
+  await page.reload();
+  await expect(verse).toHaveAttribute("aria-pressed", "false");
+  await verse.click();
+  await expect.poll(() => getRecorderBeat(page)).toBe(2.5);
+  await expect(saved).toHaveAttribute("aria-disabled", "true");
+
+  // Musical position survives tempo changes; each locator edit dirties the save.
+  await page.getByTestId("recorder-tempo-input").fill("90");
+  await page.getByTestId("recorder-tempo-input").press("Enter");
+  await verse.click();
+  await expect.poll(() => getRecorderBeat(page)).toBe(2.5);
+  await unsaved.click();
+  await expect(saved).toHaveAttribute("aria-disabled", "true");
+  page.once("dialog", (dialog) => dialog.accept("Chorus"));
+  await verse.dblclick();
+  const chorus = page.getByRole("button", { name: "Chorus", exact: true });
+  await expect(unsaved).toBeEnabled();
+  await unsaved.click();
+  await expect(saved).toHaveAttribute("aria-disabled", "true");
+  await dragBy(page, chorus, 40);
+  await expect(unsaved).toBeEnabled();
+  await unsaved.click();
+  await expect(saved).toHaveAttribute("aria-disabled", "true");
+  await page.reload();
+  await expect(chorus).toHaveAttribute("aria-pressed", "false");
+  await chorus.click();
+  await expect.poll(() => getRecorderBeat(page)).toBe(3);
+  await page.keyboard.press("Delete");
+  await expect(chorus).toHaveCount(0);
+  await expect(unsaved).toBeEnabled();
+  await unsaved.click();
+  await expect(saved).toHaveAttribute("aria-disabled", "true");
+  await page.reload();
+  await expect(page.getByTestId("recorder-project-name")).toBeVisible();
+  await expect(chorus).toHaveCount(0);
+  await expect(lane.getByRole("button")).toHaveCount(0);
+  checkpoint("save and reload");
+});

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -103,31 +103,34 @@ test("persists recorder locator edits and deletion", async ({ page }) => {
   await expect(saveButton).toHaveAttribute("data-status", "saved");
 
   // Renaming dirties the project.
-  page.once("dialog", (dialog) => dialog.accept("Chorus"));
+  page.once("dialog", (dialog) => dialog.accept("Renamed 1"));
   await first.dblclick();
-  const chorus = page.getByRole("button", { name: "Chorus", exact: true });
+  const firstRenamed = page.getByRole("button", {
+    name: "Renamed 1",
+    exact: true,
+  });
   await expect(saveButton).toHaveAttribute("data-status", "unsaved");
   await saveButton.click();
   await expect(saveButton).toHaveAttribute("data-status", "saved");
 
   // Moving a locator dirties the project and persists its new beat.
-  await dragBy(page, chorus, pixelsPerBeat * 0.5);
+  await dragBy(page, firstRenamed, pixelsPerBeat * 0.5);
   await expect(saveButton).toHaveAttribute("data-status", "unsaved");
   await saveButton.click();
   await expect(saveButton).toHaveAttribute("data-status", "saved");
   await page.reload();
-  await expect(chorus).toHaveAttribute("aria-pressed", "false");
-  await chorus.click();
+  await expect(firstRenamed).toHaveAttribute("aria-pressed", "false");
+  await firstRenamed.click();
   await expect.poll(() => getRecorderBeat(page)).toBe(3);
 
   // Deleting a locator dirties the project and persists its removal.
   await page.keyboard.press("Delete");
-  await expect(chorus).toHaveCount(0);
+  await expect(firstRenamed).toHaveCount(0);
   await expect(saveButton).toHaveAttribute("data-status", "unsaved");
   await saveButton.click();
   await expect(saveButton).toHaveAttribute("data-status", "saved");
   await page.reload();
-  await expect(chorus).toHaveCount(0);
+  await expect(firstRenamed).toHaveCount(0);
   await expect(second).toBeVisible();
   await expect(lane.getByRole("button")).toHaveCount(1);
 });

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -6,9 +6,10 @@ import {
   seekRecorderByPixels,
 } from "./recorder-helpers";
 
+const pixelsPerBeat = 80;
+
 test("edits, seeks, and selects recorder locators", async ({ page }) => {
   await createRecorderProject(page);
-  const pixelsPerBeat = 80;
   const add = page.getByRole("button", { name: "Add locator at playhead" });
   const first = page.getByRole("button", { name: "Section 1", exact: true });
   const second = page.getByRole("button", { name: "Section 2", exact: true });
@@ -81,39 +82,39 @@ test("persists recorder locator edits and deletion", async ({ page }) => {
   const first = page.getByRole("button", { name: "Section 1", exact: true });
   const verse = page.getByRole("button", { name: "Verse", exact: true });
   const lane = page.getByTestId("recorder-locator-lane");
-  const saveProjectButton = page.getByTestId("recorder-save-button");
+  const saveButton = page.getByTestId("recorder-save-button");
 
   // Create and rename a locator at beat 2.5.
-  await seekRecorderByPixels(page, 80 * 2.5);
+  await seekRecorderByPixels(page, pixelsPerBeat * 2.5);
   await page.keyboard.press("l");
   page.once("dialog", (dialog) => dialog.accept("Verse"));
   await first.dblclick();
-  await expect(saveProjectButton).toHaveAttribute("data-status", "unsaved");
+  await expect(saveButton).toHaveAttribute("data-status", "unsaved");
 
   // Save restores the edited label and beat, but not the selection.
   await verse.click();
   await expect(verse).toHaveAttribute("aria-pressed", "true");
-  await saveProjectButton.click();
-  await expect(saveProjectButton).toHaveAttribute("data-status", "saved");
+  await saveButton.click();
+  await expect(saveButton).toHaveAttribute("data-status", "saved");
   await page.reload();
   await expect(verse).toHaveAttribute("aria-pressed", "false");
   await verse.click();
   await expect.poll(() => getRecorderBeat(page)).toBe(2.5);
-  await expect(saveProjectButton).toHaveAttribute("data-status", "saved");
+  await expect(saveButton).toHaveAttribute("data-status", "saved");
 
   // Renaming dirties the project.
   page.once("dialog", (dialog) => dialog.accept("Chorus"));
   await verse.dblclick();
   const chorus = page.getByRole("button", { name: "Chorus", exact: true });
-  await expect(saveProjectButton).toHaveAttribute("data-status", "unsaved");
-  await saveProjectButton.click();
-  await expect(saveProjectButton).toHaveAttribute("data-status", "saved");
+  await expect(saveButton).toHaveAttribute("data-status", "unsaved");
+  await saveButton.click();
+  await expect(saveButton).toHaveAttribute("data-status", "saved");
 
   // Moving a locator dirties the project and persists its new beat.
-  await dragBy(page, chorus, 40);
-  await expect(saveProjectButton).toHaveAttribute("data-status", "unsaved");
-  await saveProjectButton.click();
-  await expect(saveProjectButton).toHaveAttribute("data-status", "saved");
+  await dragBy(page, chorus, pixelsPerBeat * 0.5);
+  await expect(saveButton).toHaveAttribute("data-status", "unsaved");
+  await saveButton.click();
+  await expect(saveButton).toHaveAttribute("data-status", "saved");
   await page.reload();
   await expect(chorus).toHaveAttribute("aria-pressed", "false");
   await chorus.click();
@@ -122,9 +123,9 @@ test("persists recorder locator edits and deletion", async ({ page }) => {
   // Deleting a locator dirties the project and persists its removal.
   await page.keyboard.press("Delete");
   await expect(chorus).toHaveCount(0);
-  await expect(saveProjectButton).toHaveAttribute("data-status", "unsaved");
-  await saveProjectButton.click();
-  await expect(saveProjectButton).toHaveAttribute("data-status", "saved");
+  await expect(saveButton).toHaveAttribute("data-status", "unsaved");
+  await saveButton.click();
+  await expect(saveButton).toHaveAttribute("data-status", "saved");
   await page.reload();
   await expect(page.getByTestId("recorder-project-name")).toBeVisible();
   await expect(chorus).toHaveCount(0);

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -55,7 +55,9 @@ test("edits, seeks, selects, and persists recorder locators", async ({
   const lane = page.getByTestId("recorder-locator-lane");
   const laneBox = await lane.boundingBox();
   expect(laneBox).not.toBeNull();
-  await lane.click({ position: { x: laneBox!.width - 10, y: 12 } });
+  await lane.click({
+    position: { x: laneBox!.width - 10, y: laneBox!.height / 2 },
+  });
   await expect(verse).toHaveAttribute("aria-pressed", "false");
   await expect.poll(() => getRecorderBeat(page)).toBe(1);
 

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -48,7 +48,6 @@ test("edits, seeks, selects, and persists recorder locators", async ({
   await second.click();
   await page.keyboard.press("Backspace");
   await expect(second).toHaveCount(0);
-
   await expect(verse).toBeVisible();
 
   // Empty locator space deselects without seeking.

--- a/e2e/fake-audio/recorder-selection-domains.test.ts
+++ b/e2e/fake-audio/recorder-selection-domains.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+import {
+  createRecorderProject,
+  dragBy,
+  seekRecorderByPixels,
+} from "./recorder-helpers";
+
+test("keeps recorder clip and locator selection domains exclusive", async ({
+  page,
+}) => {
+  await createRecorderProject(page);
+  const pixelsPerBeat = 80;
+  const add = page.getByRole("button", { name: "Add locator at playhead" });
+  const marker = page.getByRole("button", { name: "Section 1", exact: true });
+  await seekRecorderByPixels(page, pixelsPerBeat * 4);
+  await add.click();
+
+  // Selecting a locator after a waveform makes Delete remove only the locator.
+  const fileChooser = page.waitForEvent("filechooser");
+  await page.getByTestId("recorder-add-audio-file").click();
+  await (await fileChooser).setFiles("e2e/fixtures/test-audio.wav");
+  const audio = page.getByTestId("recorder-clip-audio");
+  await expect(audio).toBeVisible();
+  await audio.click();
+  await expect(audio).toHaveAttribute("data-selected", "true");
+  await marker.click();
+  await expect(audio).not.toHaveAttribute("data-selected", "true");
+  await page.keyboard.press("Delete");
+  await expect(marker).toHaveCount(0);
+  await expect(audio).toBeVisible();
+
+  // Creation also clears clip selection, and clip drag/trim clear locators.
+  await audio.click();
+  await seekRecorderByPixels(page, pixelsPerBeat * 8);
+  await add.click();
+  await expect(marker).toHaveAttribute("aria-pressed", "true");
+  await expect(audio).not.toHaveAttribute("data-selected", "true");
+  await dragBy(page, audio, 20);
+  await expect(marker).toHaveAttribute("aria-pressed", "false");
+  await expect(audio).toHaveAttribute("data-selected", "true");
+  await marker.click();
+  await dragBy(page, audio.getByTestId("recorder-take-trim-end"), -10);
+  await expect(marker).toHaveAttribute("aria-pressed", "false");
+
+  // Selecting a waveform after a locator makes Delete remove only the clip.
+  await marker.click();
+  await audio.click();
+  await expect(marker).toHaveAttribute("aria-pressed", "false");
+  await page.keyboard.press("Delete");
+  await expect(audio).toHaveCount(0);
+  await expect(marker).toBeVisible();
+});

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -330,6 +330,16 @@ export function Recorder({ projectId }: { projectId: string }) {
                   runtime.setPunch({ range: undefined, enabled: false })
                 }
               />
+              {/* Continue the track playhead through the sticky header. Locator
+                  markers have a positive z-index so they stay above this line. */}
+              {timeline.showPlayhead && (
+                <div className="pointer-events-none absolute inset-y-0 left-[15rem] right-0 overflow-hidden">
+                  <div
+                    className="absolute inset-y-0 w-px bg-sky-400"
+                    style={{ left: timeline.playheadX }}
+                  />
+                </div>
+              )}
             </div>
             {state.referenceVideo && (
               <ReferenceTimelineRow

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -287,7 +287,7 @@ export function Recorder({ projectId }: { projectId: string }) {
             locators.select(id);
           }}
         />
-        <div className="relative min-h-0 flex-1">
+        <div className="min-h-0 flex-1">
           <section
             data-testid="recorder-track-scroll"
             className="relative h-full min-w-0 overflow-x-hidden overflow-y-auto"
@@ -297,6 +297,15 @@ export function Recorder({ projectId }: { projectId: string }) {
               className="pointer-events-none absolute inset-y-0 left-[15rem] right-0"
             />
             <div className="relative">
+              {timeline.showPlayhead && (
+                <div className="pointer-events-none absolute inset-y-0 left-[15rem] right-0 z-50 overflow-hidden">
+                  <div
+                    data-testid="recorder-playhead"
+                    className="absolute inset-y-0 w-px bg-sky-400"
+                    style={{ left: timeline.playheadX }}
+                  />
+                </div>
+              )}
               <div className="sticky top-0 z-40">
                 <TimelineHeader
                   pixelsPerBeat={timeline.pixelsPerBeat}
@@ -601,15 +610,6 @@ export function Recorder({ projectId }: { projectId: string }) {
                 ))}
             </div>
           </section>
-          {timeline.showPlayhead && (
-            <div className="pointer-events-none absolute inset-y-0 left-[15rem] right-0 z-50 overflow-hidden">
-              <div
-                data-testid="recorder-playhead"
-                className="absolute inset-y-0 w-px bg-sky-400"
-                style={{ left: timeline.playheadX }}
-              />
-            </div>
-          )}
         </div>
 
         <Dialog

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -62,11 +62,10 @@ export function Recorder({ projectId }: { projectId: string }) {
   const clipInteraction = useRecorderClipInteraction({
     runtime,
     state,
-    onSelect: (): void => {
+    onSelect: () => {
       locators.select(undefined);
     },
   });
-
   const locators = useRecorderLocators({
     state,
     subdivisionsPerBeat: timeline.subdivisionsPerBeat,

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -274,335 +274,154 @@ export function Recorder({ projectId }: { projectId: string }) {
         onMixerToggle={() => setIsMixerOpen((open) => !open)}
       />
 
-      <div className="min-h-0 flex-1">
-        <section
-          data-testid="recorder-track-scroll"
-          className="relative h-full min-w-0 overflow-x-hidden overflow-y-auto"
-        >
-          <div
-            ref={timeline.viewportRef}
-            className="pointer-events-none absolute inset-y-0 left-[15rem] right-0"
-          />
-          <div className="relative">
-            {timeline.showPlayhead && (
-              <div className="pointer-events-none absolute inset-y-0 left-[15rem] right-0 z-30 overflow-hidden">
-                <div
-                  data-testid="recorder-playhead"
-                  className="absolute inset-y-0 w-px bg-sky-400"
-                  style={{ left: timeline.playheadX }}
+      <div className="flex min-h-0 flex-1 flex-col">
+        <RecorderLocatorRow
+          locators={locators}
+          pixelsPerBeat={timeline.pixelsPerBeat}
+          viewportStartBeat={timeline.viewportStartBeat}
+          subdivisionsPerBeat={timeline.subdivisionsPerBeat}
+          onAdd={addLocator}
+          onSeek={(beat) => runtime.seek(beatsToSeconds(beat, timeline.tempo))}
+          onSelect={(id) => {
+            clipInteraction.clear();
+            locators.select(id);
+          }}
+        />
+        <div className="relative min-h-0 flex-1">
+          <section
+            data-testid="recorder-track-scroll"
+            className="relative h-full min-w-0 overflow-x-hidden overflow-y-auto"
+          >
+            <div
+              ref={timeline.viewportRef}
+              className="pointer-events-none absolute inset-y-0 left-[15rem] right-0"
+            />
+            <div className="relative">
+              <div className="sticky top-0 z-40">
+                <TimelineHeader
+                  pixelsPerBeat={timeline.pixelsPerBeat}
+                  beatsPerBar={timeline.beatsPerBar}
+                  subdivisionsPerBeat={timeline.subdivisionsPerBeat}
+                  viewportStartBeat={timeline.viewportStartBeat}
+                  tempo={timeline.tempo}
+                  timelineWidth={timeline.viewportWidth}
+                  isAddingAudio={addAudioMutation.isPending}
+                  onAddAudioTrack={() => runtime.addAudioTrack()}
+                  onAddAudioFile={(file) => addAudioMutation.mutate(file)}
+                  onSeek={(position) => runtime.seek(position)}
+                  loop={state.loop}
+                  punch={state.punch}
+                  onLoopRangeChange={(range) => runtime.setLoop({ range })}
+                  onLoopRangeClear={() =>
+                    runtime.setLoop({ range: undefined, enabled: false })
+                  }
+                  onPunchRangeChange={(range) => runtime.setPunch({ range })}
+                  onPunchRangeClear={() =>
+                    runtime.setPunch({ range: undefined, enabled: false })
+                  }
                 />
               </div>
-            )}
-            <div className="sticky top-0 z-40">
-              <RecorderLocatorRow
-                locators={locators}
-                pixelsPerBeat={timeline.pixelsPerBeat}
-                viewportStartBeat={timeline.viewportStartBeat}
-                subdivisionsPerBeat={timeline.subdivisionsPerBeat}
-                onAdd={addLocator}
-                onSeek={(beat) =>
-                  runtime.seek(beatsToSeconds(beat, timeline.tempo))
-                }
-                onSelect={(id) => {
-                  clipInteraction.clear();
-                  locators.select(id);
-                }}
-              />
-              <TimelineHeader
-                pixelsPerBeat={timeline.pixelsPerBeat}
-                beatsPerBar={timeline.beatsPerBar}
-                subdivisionsPerBeat={timeline.subdivisionsPerBeat}
-                viewportStartBeat={timeline.viewportStartBeat}
-                tempo={timeline.tempo}
-                timelineWidth={timeline.viewportWidth}
-                isAddingAudio={addAudioMutation.isPending}
-                onAddAudioTrack={() => runtime.addAudioTrack()}
-                onAddAudioFile={(file) => addAudioMutation.mutate(file)}
-                onSeek={(position) => runtime.seek(position)}
-                loop={state.loop}
-                punch={state.punch}
-                onLoopRangeChange={(range) => runtime.setLoop({ range })}
-                onLoopRangeClear={() =>
-                  runtime.setLoop({ range: undefined, enabled: false })
-                }
-                onPunchRangeChange={(range) => runtime.setPunch({ range })}
-                onPunchRangeClear={() =>
-                  runtime.setPunch({ range: undefined, enabled: false })
-                }
-              />
-              {/* Continue the track playhead through the ruler, below the h-7 locator row. */}
-              {timeline.showPlayhead && (
-                <div className="pointer-events-none absolute top-7 bottom-0 left-[15rem] right-0 overflow-hidden">
-                  <div
-                    className="absolute inset-y-0 w-px bg-sky-400"
-                    style={{ left: timeline.playheadX }}
-                  />
-                </div>
-              )}
-            </div>
-            {state.referenceVideo && (
-              <ReferenceTimelineRow
-                referenceVideo={state.referenceVideo}
-                position={state.position}
-                pixelsPerBeat={timeline.pixelsPerBeat}
-                beatsPerBar={timeline.beatsPerBar}
-                subdivisionsPerBeat={timeline.subdivisionsPerBeat}
-                viewportStartBeat={timeline.viewportStartBeat}
-                tempo={timeline.tempo}
-                viewportWidth={timeline.viewportWidth}
-                onSeek={(position) => runtime.seek(position)}
-                selected={clipInteraction.isSelected({ type: "reference" })}
-                onClipClick={(additive) =>
-                  clipInteraction.select({ type: "reference" }, additive)
-                }
-                onClipDragStart={(additive) =>
-                  clipInteraction.startMove({
-                    clip: { type: "reference" },
-                    additive,
-                  })
-                }
-                onClipDragMove={clipInteraction.move}
-                muted={state.referenceVideo.muted}
-                onMutedChange={(muted) => runtime.setReferenceVideoMuted(muted)}
-                onRemove={() => runtime.removeReferenceVideo()}
-              />
-            )}
-            {state.audioTracks.map((track, index) => (
-              <TrackRow
-                key={track.id}
-                title={`Audio ${index + 1}`}
-                subtitle={track.clip?.name ?? "No file loaded"}
-                height={track.height}
-                gain={track.gain}
-                muted={track.muted}
-                soloed={track.soloed}
-                onGainChange={(gain) =>
-                  runtime.setAudioTrackMix(track.id, { gain })
-                }
-                onMutedChange={(muted) =>
-                  runtime.setAudioTrackMix(track.id, { muted })
-                }
-                onSoloedChange={(soloed) =>
-                  runtime.setAudioTrackMix(track.id, { soloed })
-                }
-                onHeightChange={(height) =>
-                  runtime.setAudioTrackHeight(track.id, height)
-                }
-                action={
-                  <AudioTrackActions
-                    label={`Audio ${index + 1}`}
-                    onFileChange={(file) =>
-                      audioTrackMutation.mutate({ file, id: track.id })
-                    }
-                    onRemove={() => runtime.removeAudioTrack(track.id)}
-                  />
-                }
-              >
-                <TimelineLane
-                  clip={
-                    track.clip
-                      ? {
-                          duration: track.trimEnd - track.trimStart,
-                          label: track.clip.name,
-                          offset: track.timelineOffset + track.trimStart,
-                          testId: "audio",
-                          audioView: track.clip.audioView,
-                          audioDuration: track.clip.buffer.duration,
-                          audioOffset: track.trimStart,
-                        }
-                      : undefined
-                  }
+              {state.referenceVideo && (
+                <ReferenceTimelineRow
+                  referenceVideo={state.referenceVideo}
+                  position={state.position}
                   pixelsPerBeat={timeline.pixelsPerBeat}
                   beatsPerBar={timeline.beatsPerBar}
                   subdivisionsPerBeat={timeline.subdivisionsPerBeat}
                   viewportStartBeat={timeline.viewportStartBeat}
                   tempo={timeline.tempo}
                   viewportWidth={timeline.viewportWidth}
-                  emptyLabel="Load an audio file"
-                  selected={clipInteraction.isSelected({
-                    type: "audio",
-                    id: track.id,
-                  })}
+                  onSeek={(position) => runtime.seek(position)}
+                  selected={clipInteraction.isSelected({ type: "reference" })}
                   onClipClick={(additive) =>
-                    clipInteraction.select(
-                      { type: "audio", id: track.id },
-                      additive,
-                    )
+                    clipInteraction.select({ type: "reference" }, additive)
                   }
-                  onTrimStart={(edge) =>
-                    clipInteraction.startTrim({
-                      clip: { type: "audio", id: track.id },
-                      edge,
-                    })
-                  }
-                  onTrimMove={clipInteraction.trim}
                   onClipDragStart={(additive) =>
                     clipInteraction.startMove({
-                      clip: { type: "audio", id: track.id },
+                      clip: { type: "reference" },
                       additive,
                     })
                   }
                   onClipDragMove={clipInteraction.move}
-                  onSeek={(position) => {
-                    clipInteraction.clear();
-                    runtime.seek(position);
-                  }}
-                />
-              </TrackRow>
-            ))}
-
-            <CaptureTrackRow
-              route={input.route.label}
-              routeNeedsSetup={input.route.needsSetup}
-              subtitle={
-                isProcessing
-                  ? "Finalizing take…"
-                  : isRecording
-                    ? `Recording · ${formatTimeWithMilliseconds(state.pendingRecording?.duration ?? 0)}`
-                    : takes.length > 0
-                      ? `${takes.length} ${takes.length === 1 ? "take" : "takes"}`
-                      : "No takes"
-              }
-              gain={state.recordingTrack.gain}
-              height={state.recordingTrack.height}
-              inputActive={input.active}
-              inputAnalyser={runtime.captureInput?.analyser}
-              inputMonitoring={state.inputMonitoring}
-              inputToggleDisabled={
-                input.mutationPending ||
-                !input.initialized ||
-                isRecording ||
-                isProcessing ||
-                (!input.active && input.route.needsSetup)
-              }
-              muted={state.recordingTrack.muted}
-              soloed={state.recordingTrack.soloed}
-              takeDownloadDisabled={
-                takes.length === 0 || isRecording || isProcessing
-              }
-              onGainChange={(gain) => runtime.setRecordingTrackMix({ gain })}
-              onInputSetup={() => setIsInputSetupOpen(true)}
-              onInputMonitoringChange={(monitoring) =>
-                runtime.setInputMonitoring(monitoring)
-              }
-              onInputToggle={input.toggle}
-              onMutedChange={(muted) => runtime.setRecordingTrackMix({ muted })}
-              onSoloedChange={(soloed) =>
-                runtime.setRecordingTrackMix({ soloed })
-              }
-              onHeightChange={(height) =>
-                runtime.setRecordingTrackHeight(height)
-              }
-              onTakeDownload={() => {
-                const comp = runtime.renderComp();
-                if (!comp) {
-                  return;
-                }
-                downloadBlob(
-                  encodeWav(comp),
-                  buildExportFileName({
-                    baseName: "toy-midi-recording",
-                    extension: "wav",
-                  }),
-                );
-              }}
-            >
-              <TakeTimelineLane
-                takes={takes}
-                regions={state.previewTakeRegions ?? state.takeRegions}
-                pendingRecording={state.pendingRecording}
-                captureStatus={state.captureStatus}
-                isTakeSelected={(id) =>
-                  clipInteraction.isSelected({ type: "take", id })
-                }
-                beatsPerBar={timeline.beatsPerBar}
-                subdivisionsPerBeat={timeline.subdivisionsPerBeat}
-                pixelsPerBeat={timeline.pixelsPerBeat}
-                tempo={timeline.tempo}
-                viewportStartBeat={timeline.viewportStartBeat}
-                viewportWidth={timeline.viewportWidth}
-                onSeek={(position) => {
-                  clipInteraction.clear();
-                  runtime.seek(position);
-                }}
-                onTakeDragStart={(id, additive) =>
-                  clipInteraction.startMove({
-                    clip: { type: "take", id },
-                    additive,
-                  })
-                }
-                onTakeClick={(id, additive) =>
-                  clipInteraction.select({ type: "take", id }, additive)
-                }
-                onTakeDragMove={clipInteraction.move}
-                onTakeTrimStart={(id, edge) =>
-                  clipInteraction.startTrim({
-                    clip: { type: "take", id },
-                    edge,
-                  })
-                }
-                onTakeTrimMove={clipInteraction.trim}
-              />
-            </CaptureTrackRow>
-            <TakesDisclosureRow
-              expanded={takesExpanded}
-              takeCount={takes.length}
-              onExpandedChange={setTakesExpanded}
-            />
-            {takesExpanded &&
-              takes.map((take) => (
-                <TakeTrackRow
-                  key={take.id}
-                  number={take.number}
-                  muted={take.muted}
-                  soloed={take.soloed}
+                  muted={state.referenceVideo.muted}
                   onMutedChange={(muted) =>
-                    runtime.setTakeMuted(take.id, muted)
+                    runtime.setReferenceVideoMuted(muted)
+                  }
+                  onRemove={() => runtime.removeReferenceVideo()}
+                />
+              )}
+              {state.audioTracks.map((track, index) => (
+                <TrackRow
+                  key={track.id}
+                  title={`Audio ${index + 1}`}
+                  subtitle={track.clip?.name ?? "No file loaded"}
+                  height={track.height}
+                  gain={track.gain}
+                  muted={track.muted}
+                  soloed={track.soloed}
+                  onGainChange={(gain) =>
+                    runtime.setAudioTrackMix(track.id, { gain })
+                  }
+                  onMutedChange={(muted) =>
+                    runtime.setAudioTrackMix(track.id, { muted })
                   }
                   onSoloedChange={(soloed) =>
-                    runtime.setTakeSoloed(take.id, soloed)
+                    runtime.setAudioTrackMix(track.id, { soloed })
                   }
-                  onDelete={() =>
-                    runtime.removeClips([{ type: "take", id: take.id }])
+                  onHeightChange={(height) =>
+                    runtime.setAudioTrackHeight(track.id, height)
+                  }
+                  action={
+                    <AudioTrackActions
+                      label={`Audio ${index + 1}`}
+                      onFileChange={(file) =>
+                        audioTrackMutation.mutate({ file, id: track.id })
+                      }
+                      onRemove={() => runtime.removeAudioTrack(track.id)}
+                    />
                   }
                 >
                   <TimelineLane
-                    clip={{
-                      label: `Take ${take.number}`,
-                      duration: take.trimEnd - take.trimStart,
-                      offset: take.timelineOffset + take.trimStart,
-                      testId: "take-lane",
-                      audioView: take.audioView,
-                      audioDuration: take.duration,
-                      audioOffset: take.trimStart,
-                    }}
+                    clip={
+                      track.clip
+                        ? {
+                            duration: track.trimEnd - track.trimStart,
+                            label: track.clip.name,
+                            offset: track.timelineOffset + track.trimStart,
+                            testId: "audio",
+                            audioView: track.clip.audioView,
+                            audioDuration: track.clip.buffer.duration,
+                            audioOffset: track.trimStart,
+                          }
+                        : undefined
+                    }
                     pixelsPerBeat={timeline.pixelsPerBeat}
                     beatsPerBar={timeline.beatsPerBar}
                     subdivisionsPerBeat={timeline.subdivisionsPerBeat}
                     viewportStartBeat={timeline.viewportStartBeat}
                     tempo={timeline.tempo}
                     viewportWidth={timeline.viewportWidth}
-                    emptyLabel=""
+                    emptyLabel="Load an audio file"
                     selected={clipInteraction.isSelected({
-                      type: "take",
-                      id: take.id,
+                      type: "audio",
+                      id: track.id,
                     })}
                     onClipClick={(additive) =>
                       clipInteraction.select(
-                        { type: "take", id: take.id },
+                        { type: "audio", id: track.id },
                         additive,
                       )
                     }
                     onTrimStart={(edge) =>
                       clipInteraction.startTrim({
-                        clip: { type: "take", id: take.id },
+                        clip: { type: "audio", id: track.id },
                         edge,
                       })
                     }
                     onTrimMove={clipInteraction.trim}
                     onClipDragStart={(additive) =>
                       clipInteraction.startMove({
-                        clip: { type: "take", id: take.id },
+                        clip: { type: "audio", id: track.id },
                         additive,
                       })
                     }
@@ -612,10 +431,186 @@ export function Recorder({ projectId }: { projectId: string }) {
                       runtime.seek(position);
                     }}
                   />
-                </TakeTrackRow>
+                </TrackRow>
               ))}
-          </div>
-        </section>
+
+              <CaptureTrackRow
+                route={input.route.label}
+                routeNeedsSetup={input.route.needsSetup}
+                subtitle={
+                  isProcessing
+                    ? "Finalizing take…"
+                    : isRecording
+                      ? `Recording · ${formatTimeWithMilliseconds(state.pendingRecording?.duration ?? 0)}`
+                      : takes.length > 0
+                        ? `${takes.length} ${takes.length === 1 ? "take" : "takes"}`
+                        : "No takes"
+                }
+                gain={state.recordingTrack.gain}
+                height={state.recordingTrack.height}
+                inputActive={input.active}
+                inputAnalyser={runtime.captureInput?.analyser}
+                inputMonitoring={state.inputMonitoring}
+                inputToggleDisabled={
+                  input.mutationPending ||
+                  !input.initialized ||
+                  isRecording ||
+                  isProcessing ||
+                  (!input.active && input.route.needsSetup)
+                }
+                muted={state.recordingTrack.muted}
+                soloed={state.recordingTrack.soloed}
+                takeDownloadDisabled={
+                  takes.length === 0 || isRecording || isProcessing
+                }
+                onGainChange={(gain) => runtime.setRecordingTrackMix({ gain })}
+                onInputSetup={() => setIsInputSetupOpen(true)}
+                onInputMonitoringChange={(monitoring) =>
+                  runtime.setInputMonitoring(monitoring)
+                }
+                onInputToggle={input.toggle}
+                onMutedChange={(muted) =>
+                  runtime.setRecordingTrackMix({ muted })
+                }
+                onSoloedChange={(soloed) =>
+                  runtime.setRecordingTrackMix({ soloed })
+                }
+                onHeightChange={(height) =>
+                  runtime.setRecordingTrackHeight(height)
+                }
+                onTakeDownload={() => {
+                  const comp = runtime.renderComp();
+                  if (!comp) {
+                    return;
+                  }
+                  downloadBlob(
+                    encodeWav(comp),
+                    buildExportFileName({
+                      baseName: "toy-midi-recording",
+                      extension: "wav",
+                    }),
+                  );
+                }}
+              >
+                <TakeTimelineLane
+                  takes={takes}
+                  regions={state.previewTakeRegions ?? state.takeRegions}
+                  pendingRecording={state.pendingRecording}
+                  captureStatus={state.captureStatus}
+                  isTakeSelected={(id) =>
+                    clipInteraction.isSelected({ type: "take", id })
+                  }
+                  beatsPerBar={timeline.beatsPerBar}
+                  subdivisionsPerBeat={timeline.subdivisionsPerBeat}
+                  pixelsPerBeat={timeline.pixelsPerBeat}
+                  tempo={timeline.tempo}
+                  viewportStartBeat={timeline.viewportStartBeat}
+                  viewportWidth={timeline.viewportWidth}
+                  onSeek={(position) => {
+                    clipInteraction.clear();
+                    runtime.seek(position);
+                  }}
+                  onTakeDragStart={(id, additive) =>
+                    clipInteraction.startMove({
+                      clip: { type: "take", id },
+                      additive,
+                    })
+                  }
+                  onTakeClick={(id, additive) =>
+                    clipInteraction.select({ type: "take", id }, additive)
+                  }
+                  onTakeDragMove={clipInteraction.move}
+                  onTakeTrimStart={(id, edge) =>
+                    clipInteraction.startTrim({
+                      clip: { type: "take", id },
+                      edge,
+                    })
+                  }
+                  onTakeTrimMove={clipInteraction.trim}
+                />
+              </CaptureTrackRow>
+              <TakesDisclosureRow
+                expanded={takesExpanded}
+                takeCount={takes.length}
+                onExpandedChange={setTakesExpanded}
+              />
+              {takesExpanded &&
+                takes.map((take) => (
+                  <TakeTrackRow
+                    key={take.id}
+                    number={take.number}
+                    muted={take.muted}
+                    soloed={take.soloed}
+                    onMutedChange={(muted) =>
+                      runtime.setTakeMuted(take.id, muted)
+                    }
+                    onSoloedChange={(soloed) =>
+                      runtime.setTakeSoloed(take.id, soloed)
+                    }
+                    onDelete={() =>
+                      runtime.removeClips([{ type: "take", id: take.id }])
+                    }
+                  >
+                    <TimelineLane
+                      clip={{
+                        label: `Take ${take.number}`,
+                        duration: take.trimEnd - take.trimStart,
+                        offset: take.timelineOffset + take.trimStart,
+                        testId: "take-lane",
+                        audioView: take.audioView,
+                        audioDuration: take.duration,
+                        audioOffset: take.trimStart,
+                      }}
+                      pixelsPerBeat={timeline.pixelsPerBeat}
+                      beatsPerBar={timeline.beatsPerBar}
+                      subdivisionsPerBeat={timeline.subdivisionsPerBeat}
+                      viewportStartBeat={timeline.viewportStartBeat}
+                      tempo={timeline.tempo}
+                      viewportWidth={timeline.viewportWidth}
+                      emptyLabel=""
+                      selected={clipInteraction.isSelected({
+                        type: "take",
+                        id: take.id,
+                      })}
+                      onClipClick={(additive) =>
+                        clipInteraction.select(
+                          { type: "take", id: take.id },
+                          additive,
+                        )
+                      }
+                      onTrimStart={(edge) =>
+                        clipInteraction.startTrim({
+                          clip: { type: "take", id: take.id },
+                          edge,
+                        })
+                      }
+                      onTrimMove={clipInteraction.trim}
+                      onClipDragStart={(additive) =>
+                        clipInteraction.startMove({
+                          clip: { type: "take", id: take.id },
+                          additive,
+                        })
+                      }
+                      onClipDragMove={clipInteraction.move}
+                      onSeek={(position) => {
+                        clipInteraction.clear();
+                        runtime.seek(position);
+                      }}
+                    />
+                  </TakeTrackRow>
+                ))}
+            </div>
+          </section>
+          {timeline.showPlayhead && (
+            <div className="pointer-events-none absolute inset-y-0 left-[15rem] right-0 z-50 overflow-hidden">
+              <div
+                data-testid="recorder-playhead"
+                className="absolute inset-y-0 w-px bg-sky-400"
+                style={{ left: timeline.playheadX }}
+              />
+            </div>
+          )}
+        </div>
 
         <Dialog
           isOpen={isInputSetupOpen}

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -65,8 +65,7 @@ export function Recorder({ projectId }: { projectId: string }) {
   });
 
   const locators = useRecorderLocators({
-    position: state.position,
-    tempo: timeline.tempo,
+    state,
     subdivisionsPerBeat: timeline.subdivisionsPerBeat,
   });
 

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -69,11 +69,6 @@ export function Recorder({ projectId }: { projectId: string }) {
     subdivisionsPerBeat: timeline.subdivisionsPerBeat,
   });
 
-  function addLocator() {
-    clipInteraction.clear();
-    locators.add();
-  }
-
   const playMutation = useMutation({
     mutationFn: () => {
       return runtime.play();
@@ -163,7 +158,7 @@ export function Recorder({ projectId }: { projectId: string }) {
     }
     if (matchKeyboardEvent(event, "L")) {
       event.preventDefault();
-      addLocator();
+      locators.add();
       return;
     }
     if (
@@ -264,12 +259,9 @@ export function Recorder({ projectId }: { projectId: string }) {
           pixelsPerBeat={timeline.pixelsPerBeat}
           viewportStartBeat={timeline.viewportStartBeat}
           subdivisionsPerBeat={timeline.subdivisionsPerBeat}
-          onAdd={addLocator}
+          onAdd={locators.add}
           onSeek={(beat) => runtime.seek(beatsToSeconds(beat, timeline.tempo))}
-          onSelect={(id) => {
-            clipInteraction.clear();
-            locators.select(id);
-          }}
+          onSelect={locators.select}
         />
         <section
           data-testid="recorder-track-scroll"

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -263,9 +263,7 @@ export function Recorder({ projectId }: { projectId: string }) {
           pixelsPerBeat={timeline.pixelsPerBeat}
           viewportStartBeat={timeline.viewportStartBeat}
           subdivisionsPerBeat={timeline.subdivisionsPerBeat}
-          onAdd={locators.add}
           onSeek={(beat) => runtime.seek(beatsToSeconds(beat, timeline.tempo))}
-          onSelect={locators.select}
         />
         <section
           data-testid="recorder-track-scroll"

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -330,10 +330,9 @@ export function Recorder({ projectId }: { projectId: string }) {
                   runtime.setPunch({ range: undefined, enabled: false })
                 }
               />
-              {/* Continue the track playhead through the sticky header. Locator
-                  markers have a positive z-index so they stay above this line. */}
+              {/* Continue the track playhead through the ruler, below the h-7 locator row. */}
               {timeline.showPlayhead && (
-                <div className="pointer-events-none absolute inset-y-0 left-[15rem] right-0 overflow-hidden">
+                <div className="pointer-events-none absolute top-7 bottom-0 left-[15rem] right-0 overflow-hidden">
                   <div
                     className="absolute inset-y-0 w-px bg-sky-400"
                     style={{ left: timeline.playheadX }}

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -7,11 +7,10 @@ import {
   isShortcutTextInputTarget,
   matchKeyboardEvent,
 } from "../../lib/keyboard";
-import { snapToGrid } from "../../lib/music";
 import { exportRecorderProjectArchive } from "../../lib/recorder/project-archive";
 import { RecorderRuntime } from "../../lib/recorder/runtime";
 import { formatTimeWithMilliseconds } from "../../lib/time-format";
-import { beatsToSeconds, secondsToBeats } from "../../lib/timeline";
+import { beatsToSeconds } from "../../lib/timeline";
 import { encodeWav } from "../../lib/wav";
 import { parseTimeSignature } from "../../types";
 import { Dialog } from "../ui/dialog";
@@ -65,19 +64,15 @@ export function Recorder({ projectId }: { projectId: string }) {
     state,
   });
 
-  const locators = useRecorderLocators();
+  const locators = useRecorderLocators({
+    position: state.position,
+    tempo: timeline.tempo,
+    subdivisionsPerBeat: timeline.subdivisionsPerBeat,
+  });
 
   function addLocator() {
     clipInteraction.clear();
-    locators.add(
-      Math.max(
-        0,
-        snapToGrid(
-          secondsToBeats(state.position, timeline.tempo),
-          1 / timeline.subdivisionsPerBeat,
-        ),
-      ),
-    );
+    locators.add();
   }
 
   const playMutation = useMutation({

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -263,7 +263,9 @@ export function Recorder({ projectId }: { projectId: string }) {
           pixelsPerBeat={timeline.pixelsPerBeat}
           viewportStartBeat={timeline.viewportStartBeat}
           subdivisionsPerBeat={timeline.subdivisionsPerBeat}
-          onSeek={(beat) => runtime.seek(beatsToSeconds(beat, timeline.tempo))}
+          onSeekBeat={(beat) =>
+            runtime.seek(beatsToSeconds(beat, timeline.tempo))
+          }
         />
         <section
           data-testid="recorder-track-scroll"

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -277,150 +277,309 @@ export function Recorder({ projectId }: { projectId: string }) {
             locators.select(id);
           }}
         />
-        <div className="min-h-0 flex-1">
-          <section
-            data-testid="recorder-track-scroll"
-            className="relative h-full min-w-0 overflow-x-hidden overflow-y-auto"
-          >
-            <div
-              ref={timeline.viewportRef}
-              className="pointer-events-none absolute inset-y-0 left-[15rem] right-0"
-            />
-            <div className="relative">
-              {timeline.showPlayhead && (
-                <div className="pointer-events-none absolute inset-y-0 left-[15rem] right-0 z-50 overflow-hidden">
-                  <div
-                    data-testid="recorder-playhead"
-                    className="absolute inset-y-0 w-px bg-sky-400"
-                    style={{ left: timeline.playheadX }}
-                  />
-                </div>
-              )}
-              <div className="sticky top-0 z-40">
-                <TimelineHeader
-                  pixelsPerBeat={timeline.pixelsPerBeat}
-                  beatsPerBar={timeline.beatsPerBar}
-                  subdivisionsPerBeat={timeline.subdivisionsPerBeat}
-                  viewportStartBeat={timeline.viewportStartBeat}
-                  tempo={timeline.tempo}
-                  timelineWidth={timeline.viewportWidth}
-                  isAddingAudio={addAudioMutation.isPending}
-                  onAddAudioTrack={() => runtime.addAudioTrack()}
-                  onAddAudioFile={(file) => addAudioMutation.mutate(file)}
-                  onSeek={(position) => runtime.seek(position)}
-                  loop={state.loop}
-                  punch={state.punch}
-                  onLoopRangeChange={(range) => runtime.setLoop({ range })}
-                  onLoopRangeClear={() =>
-                    runtime.setLoop({ range: undefined, enabled: false })
-                  }
-                  onPunchRangeChange={(range) => runtime.setPunch({ range })}
-                  onPunchRangeClear={() =>
-                    runtime.setPunch({ range: undefined, enabled: false })
-                  }
+        <section
+          data-testid="recorder-track-scroll"
+          className="relative min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto"
+        >
+          <div
+            ref={timeline.viewportRef}
+            className="pointer-events-none absolute inset-y-0 left-[15rem] right-0"
+          />
+          <div className="relative">
+            {timeline.showPlayhead && (
+              <div className="pointer-events-none absolute inset-y-0 left-[15rem] right-0 z-30 overflow-hidden">
+                <div
+                  data-testid="recorder-playhead"
+                  className="absolute inset-y-0 w-px bg-sky-400"
+                  style={{ left: timeline.playheadX }}
                 />
               </div>
-              {state.referenceVideo && (
-                <ReferenceTimelineRow
-                  referenceVideo={state.referenceVideo}
-                  position={state.position}
+            )}
+            <TimelineHeader
+              pixelsPerBeat={timeline.pixelsPerBeat}
+              beatsPerBar={timeline.beatsPerBar}
+              subdivisionsPerBeat={timeline.subdivisionsPerBeat}
+              viewportStartBeat={timeline.viewportStartBeat}
+              tempo={timeline.tempo}
+              timelineWidth={timeline.viewportWidth}
+              isAddingAudio={addAudioMutation.isPending}
+              onAddAudioTrack={() => runtime.addAudioTrack()}
+              onAddAudioFile={(file) => addAudioMutation.mutate(file)}
+              onSeek={(position) => runtime.seek(position)}
+              loop={state.loop}
+              punch={state.punch}
+              onLoopRangeChange={(range) => runtime.setLoop({ range })}
+              onLoopRangeClear={() =>
+                runtime.setLoop({ range: undefined, enabled: false })
+              }
+              onPunchRangeChange={(range) => runtime.setPunch({ range })}
+              onPunchRangeClear={() =>
+                runtime.setPunch({ range: undefined, enabled: false })
+              }
+            />
+            {state.referenceVideo && (
+              <ReferenceTimelineRow
+                referenceVideo={state.referenceVideo}
+                position={state.position}
+                pixelsPerBeat={timeline.pixelsPerBeat}
+                beatsPerBar={timeline.beatsPerBar}
+                subdivisionsPerBeat={timeline.subdivisionsPerBeat}
+                viewportStartBeat={timeline.viewportStartBeat}
+                tempo={timeline.tempo}
+                viewportWidth={timeline.viewportWidth}
+                onSeek={(position) => runtime.seek(position)}
+                selected={clipInteraction.isSelected({ type: "reference" })}
+                onClipClick={(additive) =>
+                  clipInteraction.select({ type: "reference" }, additive)
+                }
+                onClipDragStart={(additive) =>
+                  clipInteraction.startMove({
+                    clip: { type: "reference" },
+                    additive,
+                  })
+                }
+                onClipDragMove={clipInteraction.move}
+                muted={state.referenceVideo.muted}
+                onMutedChange={(muted) => runtime.setReferenceVideoMuted(muted)}
+                onRemove={() => runtime.removeReferenceVideo()}
+              />
+            )}
+            {state.audioTracks.map((track, index) => (
+              <TrackRow
+                key={track.id}
+                title={`Audio ${index + 1}`}
+                subtitle={track.clip?.name ?? "No file loaded"}
+                height={track.height}
+                gain={track.gain}
+                muted={track.muted}
+                soloed={track.soloed}
+                onGainChange={(gain) =>
+                  runtime.setAudioTrackMix(track.id, { gain })
+                }
+                onMutedChange={(muted) =>
+                  runtime.setAudioTrackMix(track.id, { muted })
+                }
+                onSoloedChange={(soloed) =>
+                  runtime.setAudioTrackMix(track.id, { soloed })
+                }
+                onHeightChange={(height) =>
+                  runtime.setAudioTrackHeight(track.id, height)
+                }
+                action={
+                  <AudioTrackActions
+                    label={`Audio ${index + 1}`}
+                    onFileChange={(file) =>
+                      audioTrackMutation.mutate({ file, id: track.id })
+                    }
+                    onRemove={() => runtime.removeAudioTrack(track.id)}
+                  />
+                }
+              >
+                <TimelineLane
+                  clip={
+                    track.clip
+                      ? {
+                          duration: track.trimEnd - track.trimStart,
+                          label: track.clip.name,
+                          offset: track.timelineOffset + track.trimStart,
+                          testId: "audio",
+                          audioView: track.clip.audioView,
+                          audioDuration: track.clip.buffer.duration,
+                          audioOffset: track.trimStart,
+                        }
+                      : undefined
+                  }
                   pixelsPerBeat={timeline.pixelsPerBeat}
                   beatsPerBar={timeline.beatsPerBar}
                   subdivisionsPerBeat={timeline.subdivisionsPerBeat}
                   viewportStartBeat={timeline.viewportStartBeat}
                   tempo={timeline.tempo}
                   viewportWidth={timeline.viewportWidth}
-                  onSeek={(position) => runtime.seek(position)}
-                  selected={clipInteraction.isSelected({ type: "reference" })}
+                  emptyLabel="Load an audio file"
+                  selected={clipInteraction.isSelected({
+                    type: "audio",
+                    id: track.id,
+                  })}
                   onClipClick={(additive) =>
-                    clipInteraction.select({ type: "reference" }, additive)
+                    clipInteraction.select(
+                      { type: "audio", id: track.id },
+                      additive,
+                    )
                   }
+                  onTrimStart={(edge) =>
+                    clipInteraction.startTrim({
+                      clip: { type: "audio", id: track.id },
+                      edge,
+                    })
+                  }
+                  onTrimMove={clipInteraction.trim}
                   onClipDragStart={(additive) =>
                     clipInteraction.startMove({
-                      clip: { type: "reference" },
+                      clip: { type: "audio", id: track.id },
                       additive,
                     })
                   }
                   onClipDragMove={clipInteraction.move}
-                  muted={state.referenceVideo.muted}
-                  onMutedChange={(muted) =>
-                    runtime.setReferenceVideoMuted(muted)
-                  }
-                  onRemove={() => runtime.removeReferenceVideo()}
+                  onSeek={(position) => {
+                    clipInteraction.clear();
+                    runtime.seek(position);
+                  }}
                 />
-              )}
-              {state.audioTracks.map((track, index) => (
-                <TrackRow
-                  key={track.id}
-                  title={`Audio ${index + 1}`}
-                  subtitle={track.clip?.name ?? "No file loaded"}
-                  height={track.height}
-                  gain={track.gain}
-                  muted={track.muted}
-                  soloed={track.soloed}
-                  onGainChange={(gain) =>
-                    runtime.setAudioTrackMix(track.id, { gain })
-                  }
+              </TrackRow>
+            ))}
+
+            <CaptureTrackRow
+              route={input.route.label}
+              routeNeedsSetup={input.route.needsSetup}
+              subtitle={
+                isProcessing
+                  ? "Finalizing take…"
+                  : isRecording
+                    ? `Recording · ${formatTimeWithMilliseconds(state.pendingRecording?.duration ?? 0)}`
+                    : takes.length > 0
+                      ? `${takes.length} ${takes.length === 1 ? "take" : "takes"}`
+                      : "No takes"
+              }
+              gain={state.recordingTrack.gain}
+              height={state.recordingTrack.height}
+              inputActive={input.active}
+              inputAnalyser={runtime.captureInput?.analyser}
+              inputMonitoring={state.inputMonitoring}
+              inputToggleDisabled={
+                input.mutationPending ||
+                !input.initialized ||
+                isRecording ||
+                isProcessing ||
+                (!input.active && input.route.needsSetup)
+              }
+              muted={state.recordingTrack.muted}
+              soloed={state.recordingTrack.soloed}
+              takeDownloadDisabled={
+                takes.length === 0 || isRecording || isProcessing
+              }
+              onGainChange={(gain) => runtime.setRecordingTrackMix({ gain })}
+              onInputSetup={() => setIsInputSetupOpen(true)}
+              onInputMonitoringChange={(monitoring) =>
+                runtime.setInputMonitoring(monitoring)
+              }
+              onInputToggle={input.toggle}
+              onMutedChange={(muted) => runtime.setRecordingTrackMix({ muted })}
+              onSoloedChange={(soloed) =>
+                runtime.setRecordingTrackMix({ soloed })
+              }
+              onHeightChange={(height) =>
+                runtime.setRecordingTrackHeight(height)
+              }
+              onTakeDownload={() => {
+                const comp = runtime.renderComp();
+                if (!comp) {
+                  return;
+                }
+                downloadBlob(
+                  encodeWav(comp),
+                  buildExportFileName({
+                    baseName: "toy-midi-recording",
+                    extension: "wav",
+                  }),
+                );
+              }}
+            >
+              <TakeTimelineLane
+                takes={takes}
+                regions={state.previewTakeRegions ?? state.takeRegions}
+                pendingRecording={state.pendingRecording}
+                captureStatus={state.captureStatus}
+                isTakeSelected={(id) =>
+                  clipInteraction.isSelected({ type: "take", id })
+                }
+                beatsPerBar={timeline.beatsPerBar}
+                subdivisionsPerBeat={timeline.subdivisionsPerBeat}
+                pixelsPerBeat={timeline.pixelsPerBeat}
+                tempo={timeline.tempo}
+                viewportStartBeat={timeline.viewportStartBeat}
+                viewportWidth={timeline.viewportWidth}
+                onSeek={(position) => {
+                  clipInteraction.clear();
+                  runtime.seek(position);
+                }}
+                onTakeDragStart={(id, additive) =>
+                  clipInteraction.startMove({
+                    clip: { type: "take", id },
+                    additive,
+                  })
+                }
+                onTakeClick={(id, additive) =>
+                  clipInteraction.select({ type: "take", id }, additive)
+                }
+                onTakeDragMove={clipInteraction.move}
+                onTakeTrimStart={(id, edge) =>
+                  clipInteraction.startTrim({
+                    clip: { type: "take", id },
+                    edge,
+                  })
+                }
+                onTakeTrimMove={clipInteraction.trim}
+              />
+            </CaptureTrackRow>
+            <TakesDisclosureRow
+              expanded={takesExpanded}
+              takeCount={takes.length}
+              onExpandedChange={setTakesExpanded}
+            />
+            {takesExpanded &&
+              takes.map((take) => (
+                <TakeTrackRow
+                  key={take.id}
+                  number={take.number}
+                  muted={take.muted}
+                  soloed={take.soloed}
                   onMutedChange={(muted) =>
-                    runtime.setAudioTrackMix(track.id, { muted })
+                    runtime.setTakeMuted(take.id, muted)
                   }
                   onSoloedChange={(soloed) =>
-                    runtime.setAudioTrackMix(track.id, { soloed })
+                    runtime.setTakeSoloed(take.id, soloed)
                   }
-                  onHeightChange={(height) =>
-                    runtime.setAudioTrackHeight(track.id, height)
-                  }
-                  action={
-                    <AudioTrackActions
-                      label={`Audio ${index + 1}`}
-                      onFileChange={(file) =>
-                        audioTrackMutation.mutate({ file, id: track.id })
-                      }
-                      onRemove={() => runtime.removeAudioTrack(track.id)}
-                    />
+                  onDelete={() =>
+                    runtime.removeClips([{ type: "take", id: take.id }])
                   }
                 >
                   <TimelineLane
-                    clip={
-                      track.clip
-                        ? {
-                            duration: track.trimEnd - track.trimStart,
-                            label: track.clip.name,
-                            offset: track.timelineOffset + track.trimStart,
-                            testId: "audio",
-                            audioView: track.clip.audioView,
-                            audioDuration: track.clip.buffer.duration,
-                            audioOffset: track.trimStart,
-                          }
-                        : undefined
-                    }
+                    clip={{
+                      label: `Take ${take.number}`,
+                      duration: take.trimEnd - take.trimStart,
+                      offset: take.timelineOffset + take.trimStart,
+                      testId: "take-lane",
+                      audioView: take.audioView,
+                      audioDuration: take.duration,
+                      audioOffset: take.trimStart,
+                    }}
                     pixelsPerBeat={timeline.pixelsPerBeat}
                     beatsPerBar={timeline.beatsPerBar}
                     subdivisionsPerBeat={timeline.subdivisionsPerBeat}
                     viewportStartBeat={timeline.viewportStartBeat}
                     tempo={timeline.tempo}
                     viewportWidth={timeline.viewportWidth}
-                    emptyLabel="Load an audio file"
+                    emptyLabel=""
                     selected={clipInteraction.isSelected({
-                      type: "audio",
-                      id: track.id,
+                      type: "take",
+                      id: take.id,
                     })}
                     onClipClick={(additive) =>
                       clipInteraction.select(
-                        { type: "audio", id: track.id },
+                        { type: "take", id: take.id },
                         additive,
                       )
                     }
                     onTrimStart={(edge) =>
                       clipInteraction.startTrim({
-                        clip: { type: "audio", id: track.id },
+                        clip: { type: "take", id: take.id },
                         edge,
                       })
                     }
                     onTrimMove={clipInteraction.trim}
                     onClipDragStart={(additive) =>
                       clipInteraction.startMove({
-                        clip: { type: "audio", id: track.id },
+                        clip: { type: "take", id: take.id },
                         additive,
                       })
                     }
@@ -430,177 +589,10 @@ export function Recorder({ projectId }: { projectId: string }) {
                       runtime.seek(position);
                     }}
                   />
-                </TrackRow>
+                </TakeTrackRow>
               ))}
-
-              <CaptureTrackRow
-                route={input.route.label}
-                routeNeedsSetup={input.route.needsSetup}
-                subtitle={
-                  isProcessing
-                    ? "Finalizing take…"
-                    : isRecording
-                      ? `Recording · ${formatTimeWithMilliseconds(state.pendingRecording?.duration ?? 0)}`
-                      : takes.length > 0
-                        ? `${takes.length} ${takes.length === 1 ? "take" : "takes"}`
-                        : "No takes"
-                }
-                gain={state.recordingTrack.gain}
-                height={state.recordingTrack.height}
-                inputActive={input.active}
-                inputAnalyser={runtime.captureInput?.analyser}
-                inputMonitoring={state.inputMonitoring}
-                inputToggleDisabled={
-                  input.mutationPending ||
-                  !input.initialized ||
-                  isRecording ||
-                  isProcessing ||
-                  (!input.active && input.route.needsSetup)
-                }
-                muted={state.recordingTrack.muted}
-                soloed={state.recordingTrack.soloed}
-                takeDownloadDisabled={
-                  takes.length === 0 || isRecording || isProcessing
-                }
-                onGainChange={(gain) => runtime.setRecordingTrackMix({ gain })}
-                onInputSetup={() => setIsInputSetupOpen(true)}
-                onInputMonitoringChange={(monitoring) =>
-                  runtime.setInputMonitoring(monitoring)
-                }
-                onInputToggle={input.toggle}
-                onMutedChange={(muted) =>
-                  runtime.setRecordingTrackMix({ muted })
-                }
-                onSoloedChange={(soloed) =>
-                  runtime.setRecordingTrackMix({ soloed })
-                }
-                onHeightChange={(height) =>
-                  runtime.setRecordingTrackHeight(height)
-                }
-                onTakeDownload={() => {
-                  const comp = runtime.renderComp();
-                  if (!comp) {
-                    return;
-                  }
-                  downloadBlob(
-                    encodeWav(comp),
-                    buildExportFileName({
-                      baseName: "toy-midi-recording",
-                      extension: "wav",
-                    }),
-                  );
-                }}
-              >
-                <TakeTimelineLane
-                  takes={takes}
-                  regions={state.previewTakeRegions ?? state.takeRegions}
-                  pendingRecording={state.pendingRecording}
-                  captureStatus={state.captureStatus}
-                  isTakeSelected={(id) =>
-                    clipInteraction.isSelected({ type: "take", id })
-                  }
-                  beatsPerBar={timeline.beatsPerBar}
-                  subdivisionsPerBeat={timeline.subdivisionsPerBeat}
-                  pixelsPerBeat={timeline.pixelsPerBeat}
-                  tempo={timeline.tempo}
-                  viewportStartBeat={timeline.viewportStartBeat}
-                  viewportWidth={timeline.viewportWidth}
-                  onSeek={(position) => {
-                    clipInteraction.clear();
-                    runtime.seek(position);
-                  }}
-                  onTakeDragStart={(id, additive) =>
-                    clipInteraction.startMove({
-                      clip: { type: "take", id },
-                      additive,
-                    })
-                  }
-                  onTakeClick={(id, additive) =>
-                    clipInteraction.select({ type: "take", id }, additive)
-                  }
-                  onTakeDragMove={clipInteraction.move}
-                  onTakeTrimStart={(id, edge) =>
-                    clipInteraction.startTrim({
-                      clip: { type: "take", id },
-                      edge,
-                    })
-                  }
-                  onTakeTrimMove={clipInteraction.trim}
-                />
-              </CaptureTrackRow>
-              <TakesDisclosureRow
-                expanded={takesExpanded}
-                takeCount={takes.length}
-                onExpandedChange={setTakesExpanded}
-              />
-              {takesExpanded &&
-                takes.map((take) => (
-                  <TakeTrackRow
-                    key={take.id}
-                    number={take.number}
-                    muted={take.muted}
-                    soloed={take.soloed}
-                    onMutedChange={(muted) =>
-                      runtime.setTakeMuted(take.id, muted)
-                    }
-                    onSoloedChange={(soloed) =>
-                      runtime.setTakeSoloed(take.id, soloed)
-                    }
-                    onDelete={() =>
-                      runtime.removeClips([{ type: "take", id: take.id }])
-                    }
-                  >
-                    <TimelineLane
-                      clip={{
-                        label: `Take ${take.number}`,
-                        duration: take.trimEnd - take.trimStart,
-                        offset: take.timelineOffset + take.trimStart,
-                        testId: "take-lane",
-                        audioView: take.audioView,
-                        audioDuration: take.duration,
-                        audioOffset: take.trimStart,
-                      }}
-                      pixelsPerBeat={timeline.pixelsPerBeat}
-                      beatsPerBar={timeline.beatsPerBar}
-                      subdivisionsPerBeat={timeline.subdivisionsPerBeat}
-                      viewportStartBeat={timeline.viewportStartBeat}
-                      tempo={timeline.tempo}
-                      viewportWidth={timeline.viewportWidth}
-                      emptyLabel=""
-                      selected={clipInteraction.isSelected({
-                        type: "take",
-                        id: take.id,
-                      })}
-                      onClipClick={(additive) =>
-                        clipInteraction.select(
-                          { type: "take", id: take.id },
-                          additive,
-                        )
-                      }
-                      onTrimStart={(edge) =>
-                        clipInteraction.startTrim({
-                          clip: { type: "take", id: take.id },
-                          edge,
-                        })
-                      }
-                      onTrimMove={clipInteraction.trim}
-                      onClipDragStart={(additive) =>
-                        clipInteraction.startMove({
-                          clip: { type: "take", id: take.id },
-                          additive,
-                        })
-                      }
-                      onClipDragMove={clipInteraction.move}
-                      onSeek={(position) => {
-                        clipInteraction.clear();
-                        runtime.seek(position);
-                      }}
-                    />
-                  </TakeTrackRow>
-                ))}
-            </div>
-          </section>
-        </div>
+          </div>
+        </section>
 
         <Dialog
           isOpen={isInputSetupOpen}

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -67,6 +67,7 @@ export function Recorder({ projectId }: { projectId: string }) {
     },
   });
   const locators = useRecorderLocators({
+    runtime,
     state,
     subdivisionsPerBeat: timeline.subdivisionsPerBeat,
     onSelect: clipInteraction.clear,

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -7,14 +7,17 @@ import {
   isShortcutTextInputTarget,
   matchKeyboardEvent,
 } from "../../lib/keyboard";
+import { snapToGrid } from "../../lib/music";
 import { exportRecorderProjectArchive } from "../../lib/recorder/project-archive";
 import { RecorderRuntime } from "../../lib/recorder/runtime";
 import { formatTimeWithMilliseconds } from "../../lib/time-format";
+import { secondsToBeats } from "../../lib/timeline";
 import { encodeWav } from "../../lib/wav";
 import { parseTimeSignature } from "../../types";
 import { Dialog } from "../ui/dialog";
 import { RecorderHeader } from "./recorder-header";
 import { InputSetup } from "./recorder-input";
+import { RecorderLocatorRow, useRecorderLocators } from "./recorder-locators";
 import { RecorderMixer } from "./recorder-mixer";
 import { RecorderPanel } from "./recorder-panel";
 import {
@@ -61,6 +64,21 @@ export function Recorder({ projectId }: { projectId: string }) {
     runtime,
     state,
   });
+
+  const locators = useRecorderLocators();
+
+  function addLocator() {
+    clipInteraction.clear();
+    locators.add(
+      Math.max(
+        0,
+        snapToGrid(
+          secondsToBeats(state.position, timeline.tempo),
+          1 / timeline.subdivisionsPerBeat,
+        ),
+      ),
+    );
+  }
 
   const playMutation = useMutation({
     mutationFn: () => {
@@ -149,6 +167,23 @@ export function Recorder({ projectId }: { projectId: string }) {
     if (isShortcutTextInputTarget(event.target) || event.repeat) {
       return;
     }
+    if (matchKeyboardEvent(event, "L")) {
+      event.preventDefault();
+      addLocator();
+      return;
+    }
+    if (
+      locators.selectedId &&
+      (matchKeyboardEvent(event, "Delete") ||
+        matchKeyboardEvent(event, "Backspace"))
+    ) {
+      event.preventDefault();
+      locators.removeSelected();
+      return;
+    }
+    if (matchKeyboardEvent(event, "Escape")) {
+      locators.select(undefined);
+    }
     const seekDirection = matchKeyboardEvent(event, "ArrowLeft")
       ? -1
       : matchKeyboardEvent(event, "ArrowRight")
@@ -186,7 +221,17 @@ export function Recorder({ projectId }: { projectId: string }) {
   });
 
   return (
-    <main className="flex h-screen flex-col overflow-hidden bg-neutral-900 text-neutral-100">
+    <main
+      className="flex h-screen flex-col overflow-hidden bg-neutral-900 text-neutral-100"
+      onPointerDownCapture={(event) => {
+        if (
+          event.target instanceof Element &&
+          !event.target.closest("[data-recorder-locators]")
+        ) {
+          locators.select(undefined);
+        }
+      }}
+    >
       <RecorderHeader
         title={state.title}
         saveStatus={project.saveStatus}
@@ -248,28 +293,41 @@ export function Recorder({ projectId }: { projectId: string }) {
                 />
               </div>
             )}
-            <TimelineHeader
-              pixelsPerBeat={timeline.pixelsPerBeat}
-              beatsPerBar={timeline.beatsPerBar}
-              subdivisionsPerBeat={timeline.subdivisionsPerBeat}
-              viewportStartBeat={timeline.viewportStartBeat}
-              tempo={timeline.tempo}
-              timelineWidth={timeline.viewportWidth}
-              isAddingAudio={addAudioMutation.isPending}
-              onAddAudioTrack={() => runtime.addAudioTrack()}
-              onAddAudioFile={(file) => addAudioMutation.mutate(file)}
-              onSeek={(position) => runtime.seek(position)}
-              loop={state.loop}
-              punch={state.punch}
-              onLoopRangeChange={(range) => runtime.setLoop({ range })}
-              onLoopRangeClear={() =>
-                runtime.setLoop({ range: undefined, enabled: false })
-              }
-              onPunchRangeChange={(range) => runtime.setPunch({ range })}
-              onPunchRangeClear={() =>
-                runtime.setPunch({ range: undefined, enabled: false })
-              }
-            />
+            <div className="sticky top-0 z-40">
+              <RecorderLocatorRow
+                locators={locators}
+                pixelsPerBeat={timeline.pixelsPerBeat}
+                viewportStartBeat={timeline.viewportStartBeat}
+                subdivisionsPerBeat={timeline.subdivisionsPerBeat}
+                onAdd={addLocator}
+                onSelect={(id) => {
+                  clipInteraction.clear();
+                  locators.select(id);
+                }}
+              />
+              <TimelineHeader
+                pixelsPerBeat={timeline.pixelsPerBeat}
+                beatsPerBar={timeline.beatsPerBar}
+                subdivisionsPerBeat={timeline.subdivisionsPerBeat}
+                viewportStartBeat={timeline.viewportStartBeat}
+                tempo={timeline.tempo}
+                timelineWidth={timeline.viewportWidth}
+                isAddingAudio={addAudioMutation.isPending}
+                onAddAudioTrack={() => runtime.addAudioTrack()}
+                onAddAudioFile={(file) => addAudioMutation.mutate(file)}
+                onSeek={(position) => runtime.seek(position)}
+                loop={state.loop}
+                punch={state.punch}
+                onLoopRangeChange={(range) => runtime.setLoop({ range })}
+                onLoopRangeClear={() =>
+                  runtime.setLoop({ range: undefined, enabled: false })
+                }
+                onPunchRangeChange={(range) => runtime.setPunch({ range })}
+                onPunchRangeClear={() =>
+                  runtime.setPunch({ range: undefined, enabled: false })
+                }
+              />
+            </div>
             {state.referenceVideo && (
               <ReferenceTimelineRow
                 referenceVideo={state.referenceVideo}

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -11,7 +11,7 @@ import { snapToGrid } from "../../lib/music";
 import { exportRecorderProjectArchive } from "../../lib/recorder/project-archive";
 import { RecorderRuntime } from "../../lib/recorder/runtime";
 import { formatTimeWithMilliseconds } from "../../lib/time-format";
-import { secondsToBeats } from "../../lib/timeline";
+import { beatsToSeconds, secondsToBeats } from "../../lib/timeline";
 import { encodeWav } from "../../lib/wav";
 import { parseTimeSignature } from "../../types";
 import { Dialog } from "../ui/dialog";
@@ -300,6 +300,9 @@ export function Recorder({ projectId }: { projectId: string }) {
                 viewportStartBeat={timeline.viewportStartBeat}
                 subdivisionsPerBeat={timeline.subdivisionsPerBeat}
                 onAdd={addLocator}
+                onSeek={(beat) =>
+                  runtime.seek(beatsToSeconds(beat, timeline.tempo))
+                }
                 onSelect={(id) => {
                   clipInteraction.clear();
                   locators.select(id);

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -62,11 +62,15 @@ export function Recorder({ projectId }: { projectId: string }) {
   const clipInteraction = useRecorderClipInteraction({
     runtime,
     state,
+    onSelect: (): void => {
+      locators.select(undefined);
+    },
   });
 
   const locators = useRecorderLocators({
     state,
     subdivisionsPerBeat: timeline.subdivisionsPerBeat,
+    onSelect: clipInteraction.clear,
   });
 
   const playMutation = useMutation({

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -221,17 +221,7 @@ export function Recorder({ projectId }: { projectId: string }) {
   });
 
   return (
-    <main
-      className="flex h-screen flex-col overflow-hidden bg-neutral-900 text-neutral-100"
-      onPointerDownCapture={(event) => {
-        if (
-          event.target instanceof Element &&
-          !event.target.closest("[data-recorder-locators]")
-        ) {
-          locators.select(undefined);
-        }
-      }}
-    >
+    <main className="flex h-screen flex-col overflow-hidden bg-neutral-900 text-neutral-100">
       <RecorderHeader
         title={state.title}
         saveStatus={project.saveStatus}

--- a/src/components/recorder/recorder-locators.tsx
+++ b/src/components/recorder/recorder-locators.tsx
@@ -2,18 +2,31 @@ import { PlusIcon } from "lucide-react";
 import { useRef, useState } from "react";
 import { usePointerGesture } from "../../hooks/use-pointer-gesture";
 import { snapToGrid } from "../../lib/music";
+import { secondsToBeats } from "../../lib/timeline";
 import { Button } from "../ui/button";
 import { cn } from "../ui/utils";
 
 type Locator = { id: string; beat: number; label: string };
 
 // UI prototype only. Locators are discarded when the editor is unmounted.
-export function useRecorderLocators() {
+export function useRecorderLocators({
+  position,
+  tempo,
+  subdivisionsPerBeat,
+}: {
+  position: number;
+  tempo: number;
+  subdivisionsPerBeat: number;
+}) {
   const [items, setItems] = useState<Locator[]>([]);
   const [selectedId, select] = useState<string>();
   const nextNumber = useRef(1);
 
-  function add(beat: number) {
+  function add() {
+    const beat = Math.max(
+      0,
+      snapToGrid(secondsToBeats(position, tempo), 1 / subdivisionsPerBeat),
+    );
     const locator = {
       id: crypto.randomUUID(),
       beat,

--- a/src/components/recorder/recorder-locators.tsx
+++ b/src/components/recorder/recorder-locators.tsx
@@ -13,12 +13,14 @@ type Locator = { id: string; beat: number; label: string };
 export function useRecorderLocators({
   state,
   subdivisionsPerBeat,
+  onSelect,
 }: {
   state: RecorderRuntimeState;
   subdivisionsPerBeat: number;
+  onSelect: () => void;
 }) {
   const [items, setItems] = useState<Locator[]>([]);
-  const [selectedId, select] = useState<string>();
+  const [selectedId, setSelectedId] = useState<string>();
   const nextNumber = useRef(1);
 
   function add() {
@@ -36,6 +38,13 @@ export function useRecorderLocators({
     };
     setItems((current) => [...current, locator]);
     select(locator.id);
+  }
+
+  function select(id: string | undefined) {
+    if (id !== undefined) {
+      onSelect();
+    }
+    setSelectedId(id);
   }
 
   function update(

--- a/src/components/recorder/recorder-locators.tsx
+++ b/src/components/recorder/recorder-locators.tsx
@@ -70,13 +70,13 @@ export function RecorderLocatorRow({
   pixelsPerBeat,
   viewportStartBeat,
   subdivisionsPerBeat,
-  onSeek,
+  onSeekBeat,
 }: {
   locators: ReturnType<typeof useRecorderLocators>;
   pixelsPerBeat: number;
   viewportStartBeat: number;
   subdivisionsPerBeat: number;
-  onSeek: (beat: number) => void;
+  onSeekBeat: (beat: number) => void;
 }) {
   return (
     <div className="grid h-7 grid-cols-[15rem_1fr] border-b border-neutral-700 bg-neutral-800">
@@ -109,7 +109,7 @@ export function RecorderLocatorRow({
             pixelsPerBeat={pixelsPerBeat}
             subdivisionsPerBeat={subdivisionsPerBeat}
             onSelect={() => locators.select(locator.id)}
-            onSeek={() => onSeek(locator.beat)}
+            onSeek={() => onSeekBeat(locator.beat)}
             onUpdate={(changes) =>
               locators.update({ id: locator.id, ...changes })
             }

--- a/src/components/recorder/recorder-locators.tsx
+++ b/src/components/recorder/recorder-locators.tsx
@@ -57,7 +57,6 @@ export function RecorderLocatorRow({
   onSelect: (id: string) => void;
   onSeek: (beat: number) => void;
 }) {
-  const sorted = [...locators.items].sort((a, b) => a.beat - b.beat);
   return (
     <div className="grid h-7 grid-cols-[15rem_1fr] border-b border-neutral-700 bg-neutral-800">
       <div className="flex items-center justify-between border-r border-neutral-700 px-3 text-xs font-semibold text-neutral-400">
@@ -80,21 +79,12 @@ export function RecorderLocatorRow({
           locators.select(undefined);
         }}
       >
-        {sorted.map((locator, index) => (
+        {locators.items.map((locator) => (
           <LocatorMarker
             key={locator.id}
             locator={locator}
             selected={locators.selectedId === locator.id}
             left={(locator.beat - viewportStartBeat) * pixelsPerBeat}
-            labelWidth={Math.min(
-              160,
-              Math.max(
-                0,
-                ((sorted[index + 1]?.beat ?? Infinity) - locator.beat) *
-                  pixelsPerBeat -
-                  14,
-              ),
-            )}
             pixelsPerBeat={pixelsPerBeat}
             subdivisionsPerBeat={subdivisionsPerBeat}
             onSelect={() => onSelect(locator.id)}
@@ -111,7 +101,6 @@ function LocatorMarker({
   locator,
   selected,
   left,
-  labelWidth,
   pixelsPerBeat,
   subdivisionsPerBeat,
   onSelect,
@@ -121,7 +110,6 @@ function LocatorMarker({
   locator: Locator;
   selected: boolean;
   left: number;
-  labelWidth: number;
   pixelsPerBeat: number;
   subdivisionsPerBeat: number;
   onSelect: () => void;
@@ -181,10 +169,9 @@ function LocatorMarker({
         <span className="mt-auto mb-1 size-0 shrink-0 border-x-[6px] border-t-[8px] border-x-transparent border-t-current" />
         <span
           className={cn(
-            "truncate rounded px-1 text-[11px] select-none group-hover:bg-neutral-700",
+            "max-w-40 truncate rounded px-1 text-[11px] select-none group-hover:bg-neutral-700",
             selected && "bg-sky-300/20 text-sky-100",
           )}
-          style={{ maxWidth: labelWidth }}
         >
           {locator.label}
         </span>

--- a/src/components/recorder/recorder-locators.tsx
+++ b/src/components/recorder/recorder-locators.tsx
@@ -96,6 +96,7 @@ export function RecorderLocatorRow({
         </Button>
       </div>
       <div
+        data-testid="recorder-locator-lane"
         className="relative overflow-hidden"
         onPointerDown={(event) => {
           if (event.button === 0) {

--- a/src/components/recorder/recorder-locators.tsx
+++ b/src/components/recorder/recorder-locators.tsx
@@ -2,6 +2,7 @@ import { PlusIcon } from "lucide-react";
 import { useRef, useState } from "react";
 import { usePointerGesture } from "../../hooks/use-pointer-gesture";
 import { snapToGrid } from "../../lib/music";
+import type { RecorderRuntimeState } from "../../lib/recorder/runtime";
 import { secondsToBeats } from "../../lib/timeline";
 import { Button } from "../ui/button";
 import { cn } from "../ui/utils";
@@ -10,12 +11,10 @@ type Locator = { id: string; beat: number; label: string };
 
 // UI prototype only. Locators are discarded when the editor is unmounted.
 export function useRecorderLocators({
-  position,
-  tempo,
+  state,
   subdivisionsPerBeat,
 }: {
-  position: number;
-  tempo: number;
+  state: RecorderRuntimeState;
   subdivisionsPerBeat: number;
 }) {
   const [items, setItems] = useState<Locator[]>([]);
@@ -25,7 +24,10 @@ export function useRecorderLocators({
   function add() {
     const beat = Math.max(
       0,
-      snapToGrid(secondsToBeats(position, tempo), 1 / subdivisionsPerBeat),
+      snapToGrid(
+        secondsToBeats(state.position, state.tempo),
+        1 / subdivisionsPerBeat,
+      ),
     );
     const locator = {
       id: crypto.randomUUID(),

--- a/src/components/recorder/recorder-locators.tsx
+++ b/src/components/recorder/recorder-locators.tsx
@@ -97,10 +97,9 @@ export function RecorderLocatorRow({
       <div
         className="relative overflow-hidden"
         onPointerDown={(event) => {
-          if (event.button !== 0) {
-            return;
+          if (event.button === 0) {
+            locators.select(undefined);
           }
-          locators.select(undefined);
         }}
       >
         {locators.items.map((locator) => (

--- a/src/components/recorder/recorder-locators.tsx
+++ b/src/components/recorder/recorder-locators.tsx
@@ -1,28 +1,29 @@
 import { PlusIcon } from "lucide-react";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { usePointerGesture } from "../../hooks/use-pointer-gesture";
 import { snapToGrid } from "../../lib/music";
-import type { RecorderRuntimeState } from "../../lib/recorder/runtime";
+import type {
+  RecorderRuntime,
+  RecorderRuntimeState,
+  RecorderLocator,
+} from "../../lib/recorder/runtime";
 import { secondsToBeats } from "../../lib/timeline";
 import { Button } from "../ui/button";
 import { cn } from "../ui/utils";
 
-type Locator = { id: string; beat: number; label: string };
-
-// UI prototype only. Locators are discarded when the editor is unmounted.
 export function useRecorderLocators({
+  runtime,
   state,
   subdivisionsPerBeat,
   onSelect,
 }: {
+  runtime: RecorderRuntime;
   state: RecorderRuntimeState;
   subdivisionsPerBeat: number;
   /** Only coordinates selection domains by clearing selection in the other domain. */
   onSelect: () => void;
 }) {
-  const [items, setItems] = useState<Locator[]>([]);
   const [selectedId, setSelectedId] = useState<string>();
-  const nextNumber = useRef(1);
 
   function add() {
     const beat = Math.max(
@@ -32,13 +33,7 @@ export function useRecorderLocators({
         1 / subdivisionsPerBeat,
       ),
     );
-    const locator = {
-      id: crypto.randomUUID(),
-      beat,
-      label: `Section ${nextNumber.current++}`,
-    };
-    setItems((current) => [...current, locator]);
-    select(locator.id);
+    select(runtime.addLocator(beat));
   }
 
   function select(id: string | undefined) {
@@ -50,19 +45,26 @@ export function useRecorderLocators({
 
   function update(
     id: string,
-    changes: Partial<Pick<Locator, "beat" | "label">>,
+    changes: Partial<Pick<RecorderLocator, "beat" | "label">>,
   ) {
-    setItems((current) =>
-      current.map((item) => (item.id === id ? { ...item, ...changes } : item)),
-    );
+    runtime.updateLocator({ id, ...changes });
   }
 
   function removeSelected() {
-    setItems((current) => current.filter((item) => item.id !== selectedId));
+    if (selectedId !== undefined) {
+      runtime.deleteLocator(selectedId);
+    }
     select(undefined);
   }
 
-  return { items, selectedId, select, add, update, removeSelected };
+  return {
+    items: state.locators,
+    selectedId,
+    select,
+    add,
+    update,
+    removeSelected,
+  };
 }
 
 export function RecorderLocatorRow({
@@ -131,14 +133,14 @@ function LocatorMarker({
   onSeek,
   onUpdate,
 }: {
-  locator: Locator;
+  locator: RecorderLocator;
   selected: boolean;
   left: number;
   pixelsPerBeat: number;
   subdivisionsPerBeat: number;
   onSelect: () => void;
   onSeek: () => void;
-  onUpdate: (changes: Partial<Pick<Locator, "beat" | "label">>) => void;
+  onUpdate: (changes: Partial<Pick<RecorderLocator, "beat" | "label">>) => void;
 }) {
   const [dragging, setDragging] = useState(false);
   const dragRef = usePointerGesture({

--- a/src/components/recorder/recorder-locators.tsx
+++ b/src/components/recorder/recorder-locators.tsx
@@ -17,6 +17,7 @@ export function useRecorderLocators({
 }: {
   state: RecorderRuntimeState;
   subdivisionsPerBeat: number;
+  /** Only coordinates selection domains by clearing selection in the other domain. */
   onSelect: () => void;
 }) {
   const [items, setItems] = useState<Locator[]>([]);

--- a/src/components/recorder/recorder-locators.tsx
+++ b/src/components/recorder/recorder-locators.tsx
@@ -70,16 +70,12 @@ export function RecorderLocatorRow({
   pixelsPerBeat,
   viewportStartBeat,
   subdivisionsPerBeat,
-  onAdd,
-  onSelect,
   onSeek,
 }: {
   locators: ReturnType<typeof useRecorderLocators>;
   pixelsPerBeat: number;
   viewportStartBeat: number;
   subdivisionsPerBeat: number;
-  onAdd: () => void;
-  onSelect: (id: string) => void;
   onSeek: (beat: number) => void;
 }) {
   return (
@@ -90,7 +86,7 @@ export function RecorderLocatorRow({
           title="Add locator at playhead (L)"
           aria-label="Add locator at playhead"
           className="size-6 hover:bg-neutral-700"
-          onClick={onAdd}
+          onClick={locators.add}
         >
           <PlusIcon className="size-3.5" />
         </Button>
@@ -112,7 +108,7 @@ export function RecorderLocatorRow({
             left={(locator.beat - viewportStartBeat) * pixelsPerBeat}
             pixelsPerBeat={pixelsPerBeat}
             subdivisionsPerBeat={subdivisionsPerBeat}
-            onSelect={() => onSelect(locator.id)}
+            onSelect={() => locators.select(locator.id)}
             onSeek={() => onSeek(locator.beat)}
             onUpdate={(changes) =>
               locators.update({ id: locator.id, ...changes })

--- a/src/components/recorder/recorder-locators.tsx
+++ b/src/components/recorder/recorder-locators.tsx
@@ -97,10 +97,8 @@ export function RecorderLocatorRow({
             )}
             pixelsPerBeat={pixelsPerBeat}
             subdivisionsPerBeat={subdivisionsPerBeat}
-            onSelect={() => {
-              onSelect(locator.id);
-              onSeek(locator.beat);
-            }}
+            onSelect={() => onSelect(locator.id)}
+            onSeek={() => onSeek(locator.beat)}
             onUpdate={(changes) => locators.update(locator.id, changes)}
           />
         ))}
@@ -117,6 +115,7 @@ function LocatorMarker({
   pixelsPerBeat,
   subdivisionsPerBeat,
   onSelect,
+  onSeek,
   onUpdate,
 }: {
   locator: Locator;
@@ -126,6 +125,7 @@ function LocatorMarker({
   pixelsPerBeat: number;
   subdivisionsPerBeat: number;
   onSelect: () => void;
+  onSeek: () => void;
   onUpdate: (changes: Partial<Pick<Locator, "beat" | "label">>) => void;
 }) {
   const [draft, setDraft] = useState<string>();
@@ -138,6 +138,7 @@ function LocatorMarker({
       onSelect();
       return locator.beat;
     },
+    onClick: onSeek,
     onDragStart: () => setDragging(true),
     onDragMove: (_event, { data, deltaX }) => {
       onUpdate({
@@ -178,7 +179,13 @@ function LocatorMarker({
         aria-label={locator.label}
         aria-pressed={selected}
         title={`${locator.label}\nDrag to move · Double-click to rename · Delete to remove`}
-        onClick={onSelect}
+        onClick={(event) => {
+          // Pointer clicks are handled by the gesture; retain keyboard activation.
+          if (event.detail === 0) {
+            onSelect();
+            onSeek();
+          }
+        }}
         onDoubleClick={startRename}
         className={cn(
           "group absolute inset-y-0 -left-1.5 flex w-max items-center gap-1 text-neutral-400 outline-none hover:text-sky-200 focus-visible:ring-1 focus-visible:ring-sky-300",

--- a/src/components/recorder/recorder-locators.tsx
+++ b/src/components/recorder/recorder-locators.tsx
@@ -59,10 +59,7 @@ export function RecorderLocatorRow({
 }) {
   const sorted = [...locators.items].sort((a, b) => a.beat - b.beat);
   return (
-    <div
-      data-recorder-locators
-      className="grid h-7 grid-cols-[15rem_1fr] border-b border-neutral-700 bg-neutral-800"
-    >
+    <div className="grid h-7 grid-cols-[15rem_1fr] border-b border-neutral-700 bg-neutral-800">
       <div className="flex items-center justify-between border-r border-neutral-700 px-3 text-xs font-semibold text-neutral-400">
         <span>Locators</span>
         <Button

--- a/src/components/recorder/recorder-locators.tsx
+++ b/src/components/recorder/recorder-locators.tsx
@@ -171,13 +171,6 @@ function LocatorMarker({
         aria-label={locator.label}
         aria-pressed={selected}
         title={`${locator.label}\nDrag to move · Double-click to rename · Delete to remove`}
-        onClick={(event) => {
-          // Pointer clicks are handled by the gesture; retain keyboard activation.
-          if (event.detail === 0) {
-            onSelect();
-            onSeek();
-          }
-        }}
         onDoubleClick={rename}
         className={cn(
           "group absolute inset-y-0 -left-1.5 flex w-max items-center gap-1 text-neutral-400 outline-none hover:text-sky-200 focus-visible:ring-1 focus-visible:ring-sky-300",

--- a/src/components/recorder/recorder-locators.tsx
+++ b/src/components/recorder/recorder-locators.tsx
@@ -47,6 +47,7 @@ export function RecorderLocatorRow({
   subdivisionsPerBeat,
   onAdd,
   onSelect,
+  onSeek,
 }: {
   locators: ReturnType<typeof useRecorderLocators>;
   pixelsPerBeat: number;
@@ -54,6 +55,7 @@ export function RecorderLocatorRow({
   subdivisionsPerBeat: number;
   onAdd: () => void;
   onSelect: (id: string) => void;
+  onSeek: (beat: number) => void;
 }) {
   const sorted = [...locators.items].sort((a, b) => a.beat - b.beat);
   return (
@@ -74,7 +76,22 @@ export function RecorderLocatorRow({
       </div>
       <div
         className="relative overflow-hidden"
-        onPointerDown={() => locators.select(undefined)}
+        onPointerDown={(event) => {
+          if (event.button !== 0) {
+            return;
+          }
+          locators.select(undefined);
+          const rect = event.currentTarget.getBoundingClientRect();
+          onSeek(
+            Math.max(
+              0,
+              snapToGrid(
+                viewportStartBeat + (event.clientX - rect.left) / pixelsPerBeat,
+                1 / subdivisionsPerBeat,
+              ),
+            ),
+          );
+        }}
       >
         {sorted.map((locator, index) => (
           <LocatorMarker
@@ -93,7 +110,10 @@ export function RecorderLocatorRow({
             )}
             pixelsPerBeat={pixelsPerBeat}
             subdivisionsPerBeat={subdivisionsPerBeat}
-            onSelect={() => onSelect(locator.id)}
+            onSelect={() => {
+              onSelect(locator.id);
+              onSeek(locator.beat);
+            }}
             onUpdate={(changes) => locators.update(locator.id, changes)}
           />
         ))}

--- a/src/components/recorder/recorder-locators.tsx
+++ b/src/components/recorder/recorder-locators.tsx
@@ -128,9 +128,7 @@ function LocatorMarker({
   onSeek: () => void;
   onUpdate: (changes: Partial<Pick<Locator, "beat" | "label">>) => void;
 }) {
-  const [draft, setDraft] = useState<string>();
   const [dragging, setDragging] = useState(false);
-  const cancelled = useRef(false);
   const dragRef = usePointerGesture({
     onStart: (event) => {
       event.preventDefault();
@@ -155,23 +153,17 @@ function LocatorMarker({
     },
   });
 
-  function startRename() {
-    cancelled.current = false;
-    setDraft(locator.label);
-    onSelect();
-  }
-
-  function finishRename() {
-    if (!cancelled.current && draft?.trim()) {
-      onUpdate({ label: draft.trim() });
+  function rename() {
+    const label = window.prompt("Rename locator:", locator.label)?.trim();
+    if (label) {
+      onUpdate({ label });
     }
-    setDraft(undefined);
   }
 
   return (
     <div
       className="absolute inset-y-0"
-      style={{ left, zIndex: draft !== undefined ? 20 : selected ? 10 : 1 }}
+      style={{ left, zIndex: selected ? 10 : 1 }}
     >
       <button
         ref={dragRef}
@@ -186,7 +178,7 @@ function LocatorMarker({
             onSeek();
           }
         }}
-        onDoubleClick={startRename}
+        onDoubleClick={rename}
         className={cn(
           "group absolute inset-y-0 -left-1.5 flex w-max items-center gap-1 text-neutral-400 outline-none hover:text-sky-200 focus-visible:ring-1 focus-visible:ring-sky-300",
           selected && "text-sky-300",
@@ -204,33 +196,6 @@ function LocatorMarker({
           {locator.label}
         </span>
       </button>
-      {draft !== undefined && (
-        <input
-          ref={focusRenameInput}
-          aria-label="Locator name"
-          className="absolute top-0.5 left-2 h-6 w-40 rounded border border-sky-300 bg-neutral-900 px-1 text-[11px] text-neutral-100 outline-none"
-          value={draft}
-          onPointerDown={(event) => event.stopPropagation()}
-          onChange={(event) => setDraft(event.target.value)}
-          onBlur={finishRename}
-          onKeyDown={(event) => {
-            event.stopPropagation();
-            if (event.key === "Enter") {
-              event.preventDefault();
-              finishRename();
-            } else if (event.key === "Escape") {
-              event.preventDefault();
-              cancelled.current = true;
-              setDraft(undefined);
-            }
-          }}
-        />
-      )}
     </div>
   );
-}
-
-function focusRenameInput(element: HTMLInputElement | null) {
-  element?.focus();
-  element?.select();
 }

--- a/src/components/recorder/recorder-locators.tsx
+++ b/src/components/recorder/recorder-locators.tsx
@@ -1,0 +1,222 @@
+import { PlusIcon } from "lucide-react";
+import { useRef, useState } from "react";
+import { usePointerGesture } from "../../hooks/use-pointer-gesture";
+import { snapToGrid } from "../../lib/music";
+import { Button } from "../ui/button";
+import { cn } from "../ui/utils";
+
+type Locator = { id: string; beat: number; label: string };
+
+// UI prototype only. Locators are discarded when the editor is unmounted.
+export function useRecorderLocators() {
+  const [items, setItems] = useState<Locator[]>([]);
+  const [selectedId, select] = useState<string>();
+  const nextNumber = useRef(1);
+
+  function add(beat: number) {
+    const locator = {
+      id: crypto.randomUUID(),
+      beat,
+      label: `Section ${nextNumber.current++}`,
+    };
+    setItems((current) => [...current, locator]);
+    select(locator.id);
+  }
+
+  function update(
+    id: string,
+    changes: Partial<Pick<Locator, "beat" | "label">>,
+  ) {
+    setItems((current) =>
+      current.map((item) => (item.id === id ? { ...item, ...changes } : item)),
+    );
+  }
+
+  function removeSelected() {
+    setItems((current) => current.filter((item) => item.id !== selectedId));
+    select(undefined);
+  }
+
+  return { items, selectedId, select, add, update, removeSelected };
+}
+
+export function RecorderLocatorRow({
+  locators,
+  pixelsPerBeat,
+  viewportStartBeat,
+  subdivisionsPerBeat,
+  onAdd,
+  onSelect,
+}: {
+  locators: ReturnType<typeof useRecorderLocators>;
+  pixelsPerBeat: number;
+  viewportStartBeat: number;
+  subdivisionsPerBeat: number;
+  onAdd: () => void;
+  onSelect: (id: string) => void;
+}) {
+  const sorted = [...locators.items].sort((a, b) => a.beat - b.beat);
+  return (
+    <div
+      data-recorder-locators
+      className="grid h-7 grid-cols-[15rem_1fr] border-b border-neutral-700 bg-neutral-800"
+    >
+      <div className="flex items-center justify-between border-r border-neutral-700 px-3 text-xs font-semibold text-neutral-400">
+        <span>Locators</span>
+        <Button
+          title="Add locator at playhead (L)"
+          aria-label="Add locator at playhead"
+          className="size-6 hover:bg-neutral-700"
+          onClick={onAdd}
+        >
+          <PlusIcon className="size-3.5" />
+        </Button>
+      </div>
+      <div
+        className="relative overflow-hidden"
+        onPointerDown={() => locators.select(undefined)}
+      >
+        {sorted.map((locator, index) => (
+          <LocatorMarker
+            key={locator.id}
+            locator={locator}
+            selected={locators.selectedId === locator.id}
+            left={(locator.beat - viewportStartBeat) * pixelsPerBeat}
+            labelWidth={Math.min(
+              160,
+              Math.max(
+                0,
+                ((sorted[index + 1]?.beat ?? Infinity) - locator.beat) *
+                  pixelsPerBeat -
+                  14,
+              ),
+            )}
+            pixelsPerBeat={pixelsPerBeat}
+            subdivisionsPerBeat={subdivisionsPerBeat}
+            onSelect={() => onSelect(locator.id)}
+            onUpdate={(changes) => locators.update(locator.id, changes)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function LocatorMarker({
+  locator,
+  selected,
+  left,
+  labelWidth,
+  pixelsPerBeat,
+  subdivisionsPerBeat,
+  onSelect,
+  onUpdate,
+}: {
+  locator: Locator;
+  selected: boolean;
+  left: number;
+  labelWidth: number;
+  pixelsPerBeat: number;
+  subdivisionsPerBeat: number;
+  onSelect: () => void;
+  onUpdate: (changes: Partial<Pick<Locator, "beat" | "label">>) => void;
+}) {
+  const [draft, setDraft] = useState<string>();
+  const [dragging, setDragging] = useState(false);
+  const cancelled = useRef(false);
+  const dragRef = usePointerGesture({
+    onStart: (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      onSelect();
+      return locator.beat;
+    },
+    onDragStart: () => setDragging(true),
+    onDragMove: (_event, { data, deltaX }) => {
+      onUpdate({
+        beat: Math.max(
+          0,
+          snapToGrid(data + deltaX / pixelsPerBeat, 1 / subdivisionsPerBeat),
+        ),
+      });
+    },
+    onDragEnd: () => setDragging(false),
+    onCancel: (_event, { data }) => {
+      onUpdate({ beat: data });
+      setDragging(false);
+    },
+  });
+
+  function startRename() {
+    cancelled.current = false;
+    setDraft(locator.label);
+    onSelect();
+  }
+
+  function finishRename() {
+    if (!cancelled.current && draft?.trim()) {
+      onUpdate({ label: draft.trim() });
+    }
+    setDraft(undefined);
+  }
+
+  return (
+    <div
+      className="absolute inset-y-0"
+      style={{ left, zIndex: draft !== undefined ? 20 : selected ? 10 : 1 }}
+    >
+      <button
+        ref={dragRef}
+        type="button"
+        aria-label={locator.label}
+        aria-pressed={selected}
+        title={`${locator.label}\nDrag to move · Double-click to rename · Delete to remove`}
+        onClick={onSelect}
+        onDoubleClick={startRename}
+        className={cn(
+          "group absolute inset-y-0 -left-1.5 flex w-max items-center gap-1 text-neutral-400 outline-none hover:text-sky-200 focus-visible:ring-1 focus-visible:ring-sky-300",
+          selected && "text-sky-300",
+          dragging ? "cursor-ew-resize" : "cursor-pointer",
+        )}
+      >
+        <span className="mt-auto mb-1 size-0 shrink-0 border-x-[6px] border-t-[8px] border-x-transparent border-t-current" />
+        <span
+          className={cn(
+            "truncate rounded px-1 text-[11px] select-none group-hover:bg-neutral-700",
+            selected && "bg-sky-300/20 text-sky-100",
+          )}
+          style={{ maxWidth: labelWidth }}
+        >
+          {locator.label}
+        </span>
+      </button>
+      {draft !== undefined && (
+        <input
+          ref={focusRenameInput}
+          aria-label="Locator name"
+          className="absolute top-0.5 left-2 h-6 w-40 rounded border border-sky-300 bg-neutral-900 px-1 text-[11px] text-neutral-100 outline-none"
+          value={draft}
+          onPointerDown={(event) => event.stopPropagation()}
+          onChange={(event) => setDraft(event.target.value)}
+          onBlur={finishRename}
+          onKeyDown={(event) => {
+            event.stopPropagation();
+            if (event.key === "Enter") {
+              event.preventDefault();
+              finishRename();
+            } else if (event.key === "Escape") {
+              event.preventDefault();
+              cancelled.current = true;
+              setDraft(undefined);
+            }
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function focusRenameInput(element: HTMLInputElement | null) {
+  element?.focus();
+  element?.select();
+}

--- a/src/components/recorder/recorder-locators.tsx
+++ b/src/components/recorder/recorder-locators.tsx
@@ -6,6 +6,7 @@ import type {
   RecorderRuntime,
   RecorderRuntimeState,
   RecorderLocator,
+  RecorderLocatorUpdate,
 } from "../../lib/recorder/runtime";
 import { secondsToBeats } from "../../lib/timeline";
 import { Button } from "../ui/button";
@@ -43,11 +44,8 @@ export function useRecorderLocators({
     setSelectedId(id);
   }
 
-  function update(
-    id: string,
-    changes: Partial<Pick<RecorderLocator, "beat" | "label">>,
-  ) {
-    runtime.updateLocator({ id, ...changes });
+  function update(update: RecorderLocatorUpdate) {
+    runtime.updateLocator(update);
   }
 
   function removeSelected() {
@@ -115,7 +113,9 @@ export function RecorderLocatorRow({
             subdivisionsPerBeat={subdivisionsPerBeat}
             onSelect={() => onSelect(locator.id)}
             onSeek={() => onSeek(locator.beat)}
-            onUpdate={(changes) => locators.update(locator.id, changes)}
+            onUpdate={(changes) =>
+              locators.update({ id: locator.id, ...changes })
+            }
           />
         ))}
       </div>
@@ -140,7 +140,7 @@ function LocatorMarker({
   subdivisionsPerBeat: number;
   onSelect: () => void;
   onSeek: () => void;
-  onUpdate: (changes: Partial<Pick<RecorderLocator, "beat" | "label">>) => void;
+  onUpdate: (changes: Omit<RecorderLocatorUpdate, "id">) => void;
 }) {
   const [dragging, setDragging] = useState(false);
   const dragRef = usePointerGesture({

--- a/src/components/recorder/recorder-locators.tsx
+++ b/src/components/recorder/recorder-locators.tsx
@@ -81,16 +81,6 @@ export function RecorderLocatorRow({
             return;
           }
           locators.select(undefined);
-          const rect = event.currentTarget.getBoundingClientRect();
-          onSeek(
-            Math.max(
-              0,
-              snapToGrid(
-                viewportStartBeat + (event.clientX - rect.left) / pixelsPerBeat,
-                1 / subdivisionsPerBeat,
-              ),
-            ),
-          );
         }}
       >
         {sorted.map((locator, index) => (

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -78,7 +78,7 @@ export function TimelineHeader({
   onPunchRangeClear: () => void;
 }) {
   return (
-    <div className="sticky top-0 z-40 grid h-10 grid-cols-[15rem_1fr] border-b border-neutral-700 bg-neutral-800">
+    <div className="grid h-10 grid-cols-[15rem_1fr] border-b border-neutral-700 bg-neutral-800">
       <div className="sticky left-0 z-20 flex items-center border-r border-neutral-700 bg-neutral-800 px-3 text-xs font-semibold">
         <span>Tracks</span>
         <div className="flex-1" />

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -78,7 +78,7 @@ export function TimelineHeader({
   onPunchRangeClear: () => void;
 }) {
   return (
-    <div className="grid h-10 grid-cols-[15rem_1fr] border-b border-neutral-700 bg-neutral-800">
+    <div className="sticky top-0 z-40 grid h-10 grid-cols-[15rem_1fr] border-b border-neutral-700 bg-neutral-800">
       <div className="sticky left-0 z-20 flex items-center border-r border-neutral-700 bg-neutral-800 px-3 text-xs font-semibold">
         <span>Tracks</span>
         <div className="flex-1" />

--- a/src/components/recorder/use-recorder-clip-interaction.ts
+++ b/src/components/recorder/use-recorder-clip-interaction.ts
@@ -24,6 +24,7 @@ export function useRecorderClipInteraction({
 }: {
   runtime: RecorderRuntime;
   state: RecorderRuntimeState;
+  /** Only coordinates selection domains by clearing selection in the other domain. */
   onSelect: () => void;
 }) {
   const [keys, setKeys] = useState(() => new Set<string>());

--- a/src/components/recorder/use-recorder-clip-interaction.ts
+++ b/src/components/recorder/use-recorder-clip-interaction.ts
@@ -20,9 +20,11 @@ export type RecorderClipTrimSnapshot = {
 export function useRecorderClipInteraction({
   runtime,
   state,
+  onSelect,
 }: {
   runtime: RecorderRuntime;
   state: RecorderRuntimeState;
+  onSelect: () => void;
 }) {
   const [keys, setKeys] = useState(() => new Set<string>());
 
@@ -61,6 +63,7 @@ export function useRecorderClipInteraction({
   }, [state.audioTracks, state.recordingTrack.takes, state.referenceVideo]);
 
   function select(clip: RecorderClipId, additive: boolean): void {
+    onSelect();
     const key = getKey(clip);
     if (!additive) {
       const next = keys.has(key) ? keys : new Set([key]);
@@ -83,6 +86,7 @@ export function useRecorderClipInteraction({
     clip: RecorderClipId;
     additive: boolean;
   }): RecorderClipMoveSnapshot {
+    onSelect();
     const draggedKey = getKey(clip);
     // Dragging a selected clip preserves the group; an unselected clip joins
     // with Ctrl/Cmd or replaces the selection otherwise.
@@ -161,6 +165,7 @@ export function useRecorderClipInteraction({
     if (!selected) {
       throw new Error("Recorder clip state is missing.");
     }
+    onSelect();
     return {
       clip,
       edge,

--- a/src/lib/recorder/persistence.ts
+++ b/src/lib/recorder/persistence.ts
@@ -3,10 +3,13 @@ import {
   WAVEFORM_POINTS_PER_SECOND,
   type PersistableRecorderRuntimeState,
   type RecorderRuntimeState,
+  type RecorderLocator,
 } from "./runtime.ts";
 
 export interface SerializedRecorderRuntimeState {
   title: string;
+  // Optional for recorder projects saved before locator support.
+  locators?: RecorderLocator[];
   audioTracks: SerializedAudioTrackState[];
   recordingTrack: {
     height: number;
@@ -87,6 +90,7 @@ export function serializeRecorderRuntimeState(
 ): SerializedRecorderRuntimeState {
   return {
     title: state.title,
+    locators: state.locators,
     audioTracks: state.audioTracks.map((track) => ({
       id: track.id,
       height: track.height,
@@ -145,6 +149,7 @@ export function deserializeRecorderRuntimeState({
 }): PersistableRecorderRuntimeState {
   return {
     title: project.title,
+    locators: project.locators ?? [],
     audioTracks: project.audioTracks.map((track) => {
       const buffer = track.clip
         ? deserializeAudioBuffer(context, track.clip.pcm)

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -92,8 +92,15 @@ export interface ReferenceVideoState {
   duration: number;
 }
 
+export interface RecorderLocator {
+  id: string;
+  beat: number;
+  label: string;
+}
+
 export interface RecorderRuntimeState {
   title: string;
+  locators: RecorderLocator[];
   // Transport
   position: number;
   isPlaying: boolean;
@@ -123,6 +130,7 @@ export interface RecorderRuntimeState {
 export type PersistableRecorderRuntimeState = Pick<
   RecorderRuntimeState,
   | "title"
+  | "locators"
   | "tempo"
   | "timeSignature"
   | "masterGain"
@@ -151,6 +159,7 @@ export type RecorderClipTrim = Extract<RecorderClipId, { id: string }> & {
 export function createDefaultRecorderRuntimeState(): RecorderRuntimeState {
   return {
     title: "Untitled recording",
+    locators: [],
     position: 0,
     isPlaying: false,
     playbackRate: 1,
@@ -766,6 +775,46 @@ export class RecorderRuntime {
     this.store.update({ title });
   }
 
+  addLocator(beat: number): string {
+    const { locators } = this.store.get();
+    let number = locators.length + 1;
+    while (locators.some((locator) => locator.label === `Section ${number}`)) {
+      number += 1;
+    }
+    const locator = {
+      id: crypto.randomUUID(),
+      beat,
+      label: `Section ${number}`,
+    };
+    this.store.update({ locators: [...locators, locator] });
+    return locator.id;
+  }
+
+  updateLocator({
+    id,
+    ...changes
+  }: {
+    id: string;
+    beat?: number;
+    label?: string;
+  }): void {
+    this.store.update({
+      locators: this.store
+        .get()
+        .locators.map((locator) =>
+          locator.id === id ? { ...locator, ...changes } : locator,
+        ),
+    });
+  }
+
+  deleteLocator(id: string): void {
+    this.store.update({
+      locators: this.store
+        .get()
+        .locators.filter((locator) => locator.id !== id),
+    });
+  }
+
   attachYouTubePlayer({
     videoId,
     player,
@@ -938,6 +987,7 @@ export class RecorderRuntime {
       selector: (state) =>
         ({
           title: state.title,
+          locators: state.locators,
           tempo: state.tempo,
           timeSignature: state.timeSignature,
           masterGain: state.masterGain,

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -98,6 +98,12 @@ export interface RecorderLocator {
   label: string;
 }
 
+type RecorderLocatorUpdate = {
+  id: string;
+  beat?: number;
+  label?: string;
+};
+
 export interface RecorderRuntimeState {
   title: string;
   locators: RecorderLocator[];
@@ -790,14 +796,7 @@ export class RecorderRuntime {
     return locator.id;
   }
 
-  updateLocator({
-    id,
-    ...changes
-  }: {
-    id: string;
-    beat?: number;
-    label?: string;
-  }): void {
+  updateLocator({ id, ...changes }: RecorderLocatorUpdate): void {
     this.store.update({
       locators: this.store
         .get()

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -797,20 +797,18 @@ export class RecorderRuntime {
   }
 
   updateLocator({ id, ...changes }: RecorderLocatorUpdate): void {
+    const { locators } = this.store.get();
     this.store.update({
-      locators: this.store
-        .get()
-        .locators.map((locator) =>
-          locator.id === id ? { ...locator, ...changes } : locator,
-        ),
+      locators: locators.map((locator) =>
+        locator.id === id ? { ...locator, ...changes } : locator,
+      ),
     });
   }
 
   deleteLocator(id: string): void {
+    const { locators } = this.store.get();
     this.store.update({
-      locators: this.store
-        .get()
-        .locators.filter((locator) => locator.id !== id),
+      locators: locators.filter((locator) => locator.id !== id),
     });
   }
 

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -98,7 +98,7 @@ export interface RecorderLocator {
   label: string;
 }
 
-type RecorderLocatorUpdate = {
+export type RecorderLocatorUpdate = {
   id: string;
   beat?: number;
   label?: string;


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/toy-midi/issues/403
- playhead fix split into https://github.com/hi-ogawa/toy-midi/pull/448
- explain diff https://gisthost.github.io/?8b11b458533ebb202d8911fed1c424ce/toy-midi-pr-447-explain-diff.html

This PR adds named section locators in a compact row above the recorder ruler. Create with `+` or `L`, click to select and seek, double-click to rename with a browser prompt, drag to move on the grid, and use Delete/Backspace to remove. Clip and locator selections clear each other so Delete targets only one selection type.

Locators are recorder project state, so creating, moving, renaming, or deleting them marks the project unsaved. IDs, labels, and beat positions persist through saving, reloading, and project archives. Tempo changes preserve musical positions, older projects load with an empty locator list, and selection remains temporary UI state.
