### PR TITLE
fix: show recorder playhead over timeline ruler

### DIFF
--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -240,7 +240,7 @@ export function Recorder({ projectId }: { projectId: string }) {
           />
           <div className="relative">
             {timeline.showPlayhead && (
-              <div className="pointer-events-none absolute inset-y-0 left-[15rem] right-0 z-30 overflow-hidden">
+              <div className="pointer-events-none absolute inset-y-0 left-[15rem] right-0 z-50 overflow-hidden">
                 <div
                   data-testid="recorder-playhead"
                   className="absolute inset-y-0 w-px bg-sky-400"


### PR DESCRIPTION
- split from https://github.com/hi-ogawa/toy-midi/pull/447

The recorder's sticky ruler hides the top of the blue playhead. This PR raises the existing playhead overlay above the ruler so the line remains continuous through the ruler and tracks. It stays bounded by the track content and does not intercept pointer events.
