### PR TITLE
test: add recorder save status locator

### DIFF
--- a/e2e/fake-audio/recorder-loop-range.test.ts
+++ b/e2e/fake-audio/recorder-loop-range.test.ts
@@ -54,10 +54,10 @@ test("creates and edits a persisted loop range", async ({ page }) => {
   await expect(range).toBeVisible();
 
   // The disabled range and its timeline placement persist with the project.
-  await page.getByRole("button", { name: /Unsaved changes/ }).click();
-  await expect(
-    page.getByRole("button", { name: "All changes saved" }),
-  ).toBeVisible();
+  const saveButton = page.getByTestId("recorder-save-button");
+  await expect(saveButton).toHaveAttribute("data-status", "unsaved");
+  await saveButton.click();
+  await expect(saveButton).toHaveAttribute("data-status", "saved");
   await page.reload();
   await expect(toggle).toHaveAttribute("aria-pressed", "false");
   await expect(range).toBeVisible();

--- a/e2e/fake-audio/recorder-persistence.test.ts
+++ b/e2e/fake-audio/recorder-persistence.test.ts
@@ -5,10 +5,8 @@ test("saves and restores a recorder project", async ({ page }) => {
   // Create a project and give it a recognizable name.
   await createRecorderProject(page);
   const projectUrl = page.url();
-  await expect(
-    page.getByRole("button", { name: "All changes saved" }),
-  ).toHaveAttribute("aria-disabled", "true");
-  const saveButton = page.getByRole("button", { name: "All changes saved" });
+  const saveButton = page.getByTestId("recorder-save-button");
+  await expect(saveButton).toHaveAttribute("data-status", "saved");
   const saveTooltip = page.getByRole("tooltip");
   await expect(saveButton).not.toHaveAttribute("title");
   await expect(saveTooltip).toHaveCSS("opacity", "0");
@@ -23,9 +21,7 @@ test("saves and restores a recorder project", async ({ page }) => {
   await page.getByTestId("recorder-play-button").click();
   await expect.poll(() => getRecorderPosition(page)).toBeGreaterThan(0);
   await page.getByTestId("recorder-play-button").click();
-  await expect(
-    page.getByRole("button", { name: "All changes saved" }),
-  ).toHaveAttribute("aria-disabled", "true");
+  await expect(saveButton).toHaveAttribute("data-status", "saved");
 
   page.once("dialog", (dialog) => dialog.accept("Practice take"));
   await page.getByTestId("recorder-project-name").click();
@@ -67,17 +63,9 @@ test("saves and restores a recorder project", async ({ page }) => {
   await metronomeLevel.press("Enter");
 
   // The accumulated project edits are unsaved until explicitly saved.
-  await expect(
-    page.getByRole("button", {
-      name: "Unsaved changes (Ctrl/Cmd+S to save)",
-    }),
-  ).toBeEnabled();
-  await page
-    .getByRole("button", { name: "Unsaved changes (Ctrl/Cmd+S to save)" })
-    .click();
-  await expect(
-    page.getByRole("button", { name: "All changes saved" }),
-  ).toHaveAttribute("aria-disabled", "true");
+  await expect(saveButton).toHaveAttribute("data-status", "unsaved");
+  await saveButton.click();
+  await expect(saveButton).toHaveAttribute("data-status", "saved");
 
   // Reload restores project identity, tempo, and PCM-backed waveform data.
   await page.reload();

--- a/src/components/recorder/recorder-header.tsx
+++ b/src/components/recorder/recorder-header.tsx
@@ -472,6 +472,8 @@ function RecorderSaveButton({
   return (
     <div className="group/save relative">
       <Button
+        data-testid="recorder-save-button"
+        data-status={status}
         aria-label={label}
         aria-describedby="recorder-save-tooltip"
         aria-disabled={!canSave}


### PR DESCRIPTION
Recorder save E2E coverage currently locates the button through status-specific accessible text, coupling unrelated persistence scenarios to user-facing copy.

This PR gives the save button a stable test ID and exposes its existing state through `data-status`, then updates the recorder persistence and loop tests to locate the control directly and assert the saved/unsaved state.