### PR TITLE
feat: persist reference video size

### DIFF
--- a/e2e/fake-audio/recorder-reference-video.test.ts
+++ b/e2e/fake-audio/recorder-reference-video.test.ts
@@ -24,6 +24,20 @@ test("configures an ephemeral YouTube reference", async ({ page }) => {
   expect(resizedPanelBox!.width).toBeCloseTo(initialPanelBox!.width + 80, -1);
   expect(resizedPanelBox!.height).toBeCloseTo(initialPanelBox!.height + 60, -1);
 
+  await setup.getByRole("button", { name: "Close Reference Video" }).click();
+  await toggle.click();
+  const restoredPanelBox = await setup.boundingBox();
+  expect(restoredPanelBox).not.toBeNull();
+  expect(restoredPanelBox!.width).toBeCloseTo(resizedPanelBox!.width, -1);
+  expect(restoredPanelBox!.height).toBeCloseTo(resizedPanelBox!.height, -1);
+
+  await page.reload();
+  await page.getByTestId("recorder-reference-video-button").click();
+  const reloadedPanelBox = await setup.boundingBox();
+  expect(reloadedPanelBox).not.toBeNull();
+  expect(reloadedPanelBox!.width).toBeCloseTo(resizedPanelBox!.width, -1);
+  expect(reloadedPanelBox!.height).toBeCloseTo(resizedPanelBox!.height, -1);
+
   // The preview fits the resized space while preserving the player's 16:9 frame.
   const preview = setup.getByTestId("recorder-reference-video-preview");
   const containedPlayer = preview.locator(":scope > div");

--- a/src/components/recorder/reference-video.tsx
+++ b/src/components/recorder/reference-video.tsx
@@ -7,6 +7,7 @@ import {
   RecorderRuntime,
   type ReferenceVideoState,
 } from "../../lib/recorder/runtime";
+import { recorderStorage } from "../../lib/recorder/storage";
 import {
   createYouTubePlayer,
   loadYouTubeApi,
@@ -17,6 +18,17 @@ import { Button } from "../ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import { RecorderPanel } from "./recorder-panel";
 
+const DEFAULT_SIZE = { width: 640, height: 480 };
+const MIN_WIDTH = 360;
+const MIN_HEIGHT = 300;
+
+function clampSize({ width, height }: { width: number; height: number }) {
+  return {
+    width: clamp(width, MIN_WIDTH, window.innerWidth - 32),
+    height: clamp(height, MIN_HEIGHT, window.innerHeight - 32),
+  };
+}
+
 export function ReferenceVideoPanel({
   referenceVideo,
   runtime,
@@ -26,7 +38,11 @@ export function ReferenceVideoPanel({
   runtime: RecorderRuntime;
   onClose: () => void;
 }) {
-  const [size, setSize] = useState({ width: 640, height: 480 });
+  const [size, setSize] = useState(() =>
+    clampSize(
+      recorderStorage.readPreferences().referenceVideoSize ?? DEFAULT_SIZE,
+    ),
+  );
   const resizeHandleRef = usePointerDrag({
     onStart: (event) => {
       const target = event.target;
@@ -38,21 +54,18 @@ export function ReferenceVideoPanel({
         x: event.clientX,
         y: event.clientY,
         panelRect: panel.getBoundingClientRect(),
+        size,
       };
     },
     onMove: (event, drag) => {
-      setSize({
-        width: clamp(
-          drag.panelRect.width + drag.x - event.clientX,
-          360,
-          window.innerWidth - 32,
-        ),
-        height: clamp(
-          drag.panelRect.height + drag.y - event.clientY,
-          300,
-          window.innerHeight - 32,
-        ),
+      drag.size = clampSize({
+        width: drag.panelRect.width + drag.x - event.clientX,
+        height: drag.panelRect.height + drag.y - event.clientY,
       });
+      setSize(drag.size);
+    },
+    onEnd: (_event, drag) => {
+      recorderStorage.updatePreferences({ referenceVideoSize: drag.size });
     },
   });
 

--- a/src/lib/recorder/storage.ts
+++ b/src/lib/recorder/storage.ts
@@ -12,6 +12,12 @@ const recorderPreferencesSchema = z.object({
     .number()
     .min(MIN_PIXELS_PER_BEAT)
     .max(MAX_PIXELS_PER_BEAT),
+  referenceVideoSize: z
+    .object({
+      width: z.number().positive(),
+      height: z.number().positive(),
+    })
+    .optional(),
   input: z
     .object({
       deviceId: z.string(),


### PR DESCRIPTION
Resizing the reference video currently resets to the default whenever the panel is closed or the page reloads, even though the size is part of the musician's recorder workspace setup.

This PR stores the panel dimensions alongside the existing recorder preferences used for timeline zoom. Restored dimensions are clamped to the available viewport, and the reference-video E2E flow verifies persistence across close/reopen and reload.