### PR TITLE
feat: improve recorder gain controls

### DIFF
--- a/e2e/fake-audio/recorder-audio-track.test.ts
+++ b/e2e/fake-audio/recorder-audio-track.test.ts
@@ -100,10 +100,12 @@ test("mixes recorder outputs in a floating panel", async ({ page }) => {
 
   // Track gain uses the same dB keyboard step without seeking the timeline.
   const position = page.getByTestId("recorder-position");
+  await position.click();
+  await page.keyboard.press("ArrowRight");
   const initialPosition = await position.getAttribute("data-position");
   const audioGain = page.getByRole("slider", { name: "Audio 1 gain" });
-  await audioGain.press("ArrowDown");
-  await expect(audioGain).toHaveValue("-0.5");
+  await audioGain.press("ArrowRight");
+  await expect(audioGain).toHaveValue("0.5");
   await expect(position).toHaveAttribute("data-position", initialPosition!);
 
   // Open the floating mixer and inspect every recorder output channel.

--- a/e2e/fake-audio/recorder-audio-track.test.ts
+++ b/e2e/fake-audio/recorder-audio-track.test.ts
@@ -94,9 +94,11 @@ test("mixes recorder outputs in a floating panel", async ({ page }) => {
 
   // Master gain stays available without opening the mixer and steps by 0.5 dB.
   const masterGain = page.getByRole("slider", { name: "Master gain" });
-  await expect(masterGain).toHaveValue("0");
+  await expect(masterGain).toHaveAttribute("aria-valuenow", "0");
   await masterGain.press("ArrowDown");
-  await expect(masterGain).toHaveValue("-0.5");
+  expect(Number(await masterGain.getAttribute("aria-valuenow"))).toBeCloseTo(
+    -0.5,
+  );
 
   // Track gain uses the same dB keyboard step without seeking the timeline.
   const position = page.getByTestId("recorder-position");
@@ -105,7 +107,9 @@ test("mixes recorder outputs in a floating panel", async ({ page }) => {
   const initialPosition = await position.getAttribute("data-position");
   const audioGain = page.getByRole("slider", { name: "Audio 1 gain" });
   await audioGain.press("ArrowRight");
-  await expect(audioGain).toHaveValue("0.5");
+  expect(Number(await audioGain.getAttribute("aria-valuenow"))).toBeCloseTo(
+    0.5,
+  );
   await expect(position).toHaveAttribute("data-position", initialPosition!);
 
   // Open the floating mixer and inspect every recorder output channel.

--- a/e2e/fake-audio/recorder-audio-track.test.ts
+++ b/e2e/fake-audio/recorder-audio-track.test.ts
@@ -97,6 +97,20 @@ test("mixes recorder outputs in a floating panel", async ({ page }) => {
   await page.getByTestId("recorder-add-audio-file").click();
   await (await fileChooserPromise).setFiles("e2e/fixtures/test-audio.wav");
 
+  // Master gain stays available without opening the mixer and steps by 0.5 dB.
+  const masterGain = page.getByRole("slider", { name: "Master gain" });
+  await expect(masterGain).toHaveValue("0");
+  await masterGain.press("ArrowDown");
+  await expect(masterGain).toHaveValue("-0.5");
+
+  // Track gain uses the same dB keyboard step without seeking the timeline.
+  const position = page.getByTestId("recorder-position");
+  const initialPosition = await position.getAttribute("data-position");
+  const audioGain = page.getByRole("slider", { name: "Audio 1 gain" });
+  await audioGain.press("ArrowDown");
+  await expect(audioGain).toHaveValue("-0.5");
+  await expect(position).toHaveAttribute("data-position", initialPosition!);
+
   // Open the floating mixer and inspect every recorder output channel.
   await page.getByTestId("recorder-mixer-button").click();
   const panel = page.getByTestId("recorder-mixer-panel");
@@ -110,6 +124,7 @@ test("mixes recorder outputs in a floating panel", async ({ page }) => {
   const masterLevel = panel.getByRole("textbox", {
     name: "Master level in dB",
   });
+  await expect(masterLevel).toHaveValue("-0.5");
   await masterLevel.fill("-6");
   await masterLevel.press("Enter");
   await expect(masterLevel).toHaveValue("-6.0");

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -225,6 +225,7 @@ export function Recorder({ projectId }: { projectId: string }) {
         isExporting={exportProjectMutation.isPending}
         autoScrollEnabled={timeline.autoScrollEnabled}
         metronomeEnabled={state.metronomeEnabled}
+        masterGain={state.masterGain}
         loop={state.loop}
         punch={state.punch}
         position={state.position}
@@ -245,6 +246,7 @@ export function Recorder({ projectId }: { projectId: string }) {
         }}
         onTempoChange={(tempo) => runtime.setTempo(tempo)}
         onMetronomeChange={(enabled) => runtime.setMetronomeEnabled(enabled)}
+        onMasterGainChange={(gain) => runtime.setMasterGain(gain)}
         onLoopChange={(update) => runtime.setLoop(update)}
         onPunchChange={(update) => runtime.setPunch(update)}
         onTimeSignatureChange={(timeSignature) =>

--- a/src/components/recorder/recorder-header.tsx
+++ b/src/components/recorder/recorder-header.tsx
@@ -19,7 +19,7 @@ import {
 } from "lucide-react";
 import { useDraftInput } from "../../hooks/use-draft-input";
 import { useTapTempo } from "../../hooks/use-tap-tempo";
-import { snapToGrid } from "../../lib/music";
+import { formatGainDb, snapToGrid } from "../../lib/music";
 import type {
   RecorderLoopState,
   RecorderPunchState,
@@ -45,7 +45,7 @@ import {
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
 import { cn } from "../ui/utils";
-import { RecorderGainControl } from "./recorder-mixer";
+import { RecorderGainSlider } from "./recorder-mixer";
 import type { SaveStatus } from "./use-recorder-project";
 
 const PLAYBACK_RATES = [0.5, 0.75, 1, 1.25, 1.5];
@@ -365,11 +365,19 @@ export function RecorderHeader({
         </DropdownMenuContent>
       </DropdownMenu>
       <div className="h-5 w-px bg-neutral-600" />
-      <RecorderGainControl
-        label="Master"
-        gain={masterGain}
-        onGainChange={onMasterGainChange}
-      />
+      <label className="flex items-center gap-2 text-[10px] text-neutral-400">
+        <span className="font-medium uppercase tracking-wide">Master</span>
+        <RecorderGainSlider
+          data-testid="recorder-master-gain"
+          label="Master gain"
+          gain={masterGain}
+          onGainChange={onMasterGainChange}
+          className="w-24"
+        />
+        <span className="w-12 text-right font-mono">
+          {formatGainDb(masterGain)}
+        </span>
+      </label>
       <div className="flex-1" />
       <RecorderSaveButton status={saveStatus} onSave={onSave} />
       <button

--- a/src/components/recorder/recorder-header.tsx
+++ b/src/components/recorder/recorder-header.tsx
@@ -45,6 +45,7 @@ import {
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
 import { cn } from "../ui/utils";
+import { RecorderGainControl } from "./recorder-mixer";
 import type { SaveStatus } from "./use-recorder-project";
 
 const PLAYBACK_RATES = [0.5, 0.75, 1, 1.25, 1.5];
@@ -58,6 +59,7 @@ export function RecorderHeader({
   isRecording,
   isExporting,
   metronomeEnabled,
+  masterGain,
   loop,
   punch,
   position,
@@ -75,6 +77,7 @@ export function RecorderHeader({
   onPlaybackRateChange,
   onTempoChange,
   onMetronomeChange,
+  onMasterGainChange,
   onLoopChange,
   onPunchChange,
   onTimeSignatureChange,
@@ -92,6 +95,7 @@ export function RecorderHeader({
   isRecording: boolean;
   isExporting: boolean;
   metronomeEnabled: boolean;
+  masterGain: number;
   loop: RecorderLoopState;
   punch: RecorderPunchState;
   position: number;
@@ -109,6 +113,7 @@ export function RecorderHeader({
   onPlaybackRateChange: (playbackRate: number) => void;
   onTempoChange: (tempo: number) => void;
   onMetronomeChange: (enabled: boolean) => void;
+  onMasterGainChange: (gain: number) => void;
   onLoopChange: (update: Partial<RecorderLoopState>) => void;
   onPunchChange: (update: Partial<RecorderPunchState>) => void;
   onTimeSignatureChange: (value: string) => void;
@@ -357,6 +362,12 @@ export function RecorderHeader({
           </DropdownMenuRadioGroup>
         </DropdownMenuContent>
       </DropdownMenu>
+      <div className="h-5 w-px bg-neutral-600" />
+      <RecorderGainControl
+        label="Master"
+        gain={masterGain}
+        onGainChange={onMasterGainChange}
+      />
       <div className="flex-1" />
       <RecorderSaveButton status={saveStatus} onSave={onSave} />
       <button

--- a/src/components/recorder/recorder-mixer.tsx
+++ b/src/components/recorder/recorder-mixer.tsx
@@ -28,21 +28,57 @@ export function RecorderGainControl({
   return (
     <label className="flex items-center gap-2 text-[10px] text-neutral-400">
       <span className="font-medium uppercase tracking-wide">{label}</span>
-      <input
-        data-testid={`recorder-${label.toLowerCase()}-gain`}
-        aria-label={`${label} gain`}
-        type="range"
-        min={MIN_DB}
-        max={MAX_DB}
-        step={0.5}
-        value={gainToDb(gain)}
-        onChange={(event) =>
-          onGainChange(dbToGain(event.currentTarget.valueAsNumber))
-        }
-        className="w-24 accent-emerald-600"
+      <RecorderGainSlider
+        testId={`recorder-${label.toLowerCase()}-gain`}
+        label={`${label} gain`}
+        gain={gain}
+        onGainChange={onGainChange}
+        className="w-24"
       />
       <span className="w-12 text-right font-mono">{formatGainDb(gain)}</span>
     </label>
+  );
+}
+
+export function RecorderGainSlider({
+  label,
+  gain,
+  onGainChange,
+  orientation = "horizontal",
+  className,
+  testId,
+  ...props
+}: {
+  label: string;
+  gain: number;
+  onGainChange: (gain: number) => void;
+  orientation?: "horizontal" | "vertical";
+  className?: string;
+  testId?: string;
+} & Omit<ComponentProps<typeof Slider>, "value" | "onValueChange">) {
+  const markerPosition = `${(-MIN_DB / (MAX_DB - MIN_DB)) * 100}%`;
+  return (
+    <div data-testid={testId} className={`relative ${className ?? ""}`}>
+      <div
+        className={
+          orientation === "vertical"
+            ? "pointer-events-none absolute bottom-(--marker-position) left-1/2 h-px w-3 -translate-x-1/2 bg-neutral-500/70"
+            : "pointer-events-none absolute top-1/2 left-(--marker-position) h-3 w-px -translate-y-1/2 bg-neutral-500/70"
+        }
+        style={{ "--marker-position": markerPosition } as React.CSSProperties}
+      />
+      <Slider
+        value={[gainToDb(gain)]}
+        onValueChange={([value]) => onGainChange(dbToGain(value))}
+        min={MIN_DB}
+        max={MAX_DB}
+        step={0.5}
+        orientation={orientation}
+        thumbProps={{ "aria-label": label }}
+        className={orientation === "vertical" ? "h-full" : "w-full"}
+        {...props}
+      />
+    </div>
   );
 }
 
@@ -219,22 +255,13 @@ function MixerChannel({
           {label}
         </span>
       </div>
-      <div className="relative h-48">
-        <div
-          className="pointer-events-none absolute left-1/2 h-px w-3 -translate-x-1/2 bg-neutral-500/70"
-          style={{ bottom: `${(-MIN_DB / (MAX_DB - MIN_DB)) * 100}%` }}
-        />
-        <Slider
-          value={[gainToDb(gain)]}
-          onValueChange={([value]) => onGainChange(dbToGain(value))}
-          min={MIN_DB}
-          max={MAX_DB}
-          step={0.5}
-          orientation="vertical"
-          aria-label={`${label === "Metro" ? "Metronome" : label} gain`}
-          className="h-48"
-        />
-      </div>
+      <RecorderGainSlider
+        label={`${label === "Metro" ? "Metronome" : label} gain`}
+        gain={gain}
+        onGainChange={onGainChange}
+        orientation="vertical"
+        className="h-48"
+      />
       <label className="flex items-center gap-1 text-xs text-muted-foreground tabular-nums">
         <input
           type="text"

--- a/src/components/recorder/recorder-mixer.tsx
+++ b/src/components/recorder/recorder-mixer.tsx
@@ -6,9 +6,8 @@ import {
   MIN_DB,
   dbToGain,
   dbToPercent,
+  formatGainDb,
   gainToDb,
-  gainToPercent,
-  percentToGain,
 } from "../../lib/music";
 import type {
   RecorderRuntime,
@@ -17,6 +16,36 @@ import type {
 import { MetronomeIcon } from "../icons";
 import { Slider } from "../ui/slider";
 import { RecorderMixToggle } from "./recorder-mix-toggle";
+
+export function RecorderGainControl({
+  label,
+  gain,
+  onGainChange,
+}: {
+  label: string;
+  gain: number;
+  onGainChange: (gain: number) => void;
+}) {
+  return (
+    <label className="flex items-center gap-2 text-[10px] text-neutral-400">
+      <span className="font-medium uppercase tracking-wide">{label}</span>
+      <input
+        data-testid={`recorder-${label.toLowerCase()}-gain`}
+        aria-label={`${label} gain`}
+        type="range"
+        min={MIN_DB}
+        max={MAX_DB}
+        step={0.5}
+        value={gainToDb(gain)}
+        onChange={(event) =>
+          onGainChange(dbToGain(event.currentTarget.valueAsNumber))
+        }
+        className="w-24 accent-emerald-600"
+      />
+      <span className="w-12 text-right font-mono">{formatGainDb(gain)}</span>
+    </label>
+  );
+}
 
 export function RecorderMixer({
   runtime,
@@ -197,11 +226,13 @@ function MixerChannel({
           style={{ bottom: `${dbToPercent(0)}%` }}
         />
         <Slider
-          value={[gainToPercent(gain)]}
-          onValueChange={([value]) => onGainChange(percentToGain(value))}
-          max={100}
-          step={1}
+          value={[gainToDb(gain)]}
+          onValueChange={([value]) => onGainChange(dbToGain(value))}
+          min={MIN_DB}
+          max={MAX_DB}
+          step={0.5}
           orientation="vertical"
+          aria-label={`${label === "Metro" ? "Metronome" : label} gain`}
           className="h-48"
         />
       </div>

--- a/src/components/recorder/recorder-mixer.tsx
+++ b/src/components/recorder/recorder-mixer.tsx
@@ -1,13 +1,7 @@
 import { GaugeIcon, Mic2Icon, Volume2Icon } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 import { useDraftInput } from "../../hooks/use-draft-input";
-import {
-  MAX_DB,
-  MIN_DB,
-  dbToGain,
-  formatGainDb,
-  gainToDb,
-} from "../../lib/music";
+import { MAX_DB, MIN_DB, dbToGain, gainToDb } from "../../lib/music";
 import type {
   RecorderRuntime,
   RecorderRuntimeState,
@@ -208,30 +202,6 @@ function MixerChannel({
       </label>
       {action ?? <div className="h-8" />}
     </div>
-  );
-}
-
-export function RecorderGainControl({
-  label,
-  gain,
-  onGainChange,
-}: {
-  label: string;
-  gain: number;
-  onGainChange: (gain: number) => void;
-}) {
-  return (
-    <label className="flex items-center gap-2 text-[10px] text-neutral-400">
-      <span className="font-medium uppercase tracking-wide">{label}</span>
-      <RecorderGainSlider
-        data-testid={`recorder-${label.toLowerCase()}-gain`}
-        label={`${label} gain`}
-        gain={gain}
-        onGainChange={onGainChange}
-        className="w-24"
-      />
-      <span className="w-12 text-right font-mono">{formatGainDb(gain)}</span>
-    </label>
   );
 }
 

--- a/src/components/recorder/recorder-mixer.tsx
+++ b/src/components/recorder/recorder-mixer.tsx
@@ -29,7 +29,7 @@ export function RecorderGainControl({
     <label className="flex items-center gap-2 text-[10px] text-neutral-400">
       <span className="font-medium uppercase tracking-wide">{label}</span>
       <RecorderGainSlider
-        testId={`recorder-${label.toLowerCase()}-gain`}
+        data-testid={`recorder-${label.toLowerCase()}-gain`}
         label={`${label} gain`}
         gain={gain}
         onGainChange={onGainChange}
@@ -46,7 +46,7 @@ export function RecorderGainSlider({
   onGainChange,
   orientation = "horizontal",
   className,
-  testId,
+  "data-testid": testId,
   ...props
 }: {
   label: string;
@@ -54,7 +54,7 @@ export function RecorderGainSlider({
   onGainChange: (gain: number) => void;
   orientation?: "horizontal" | "vertical";
   className?: string;
-  testId?: string;
+  "data-testid"?: string;
 } & Omit<ComponentProps<typeof Slider>, "value" | "onValueChange">) {
   const markerPosition = `${(-MIN_DB / (MAX_DB - MIN_DB)) * 100}%`;
   return (

--- a/src/components/recorder/recorder-mixer.tsx
+++ b/src/components/recorder/recorder-mixer.tsx
@@ -74,7 +74,7 @@ export function RecorderGainSlider({
         max={MAX_DB}
         step={0.5}
         orientation={orientation}
-        thumbProps={{ "aria-label": label }}
+        aria-label={label}
         className={orientation === "vertical" ? "h-full" : "w-full"}
         {...props}
       />

--- a/src/components/recorder/recorder-mixer.tsx
+++ b/src/components/recorder/recorder-mixer.tsx
@@ -5,7 +5,6 @@ import {
   MAX_DB,
   MIN_DB,
   dbToGain,
-  dbToPercent,
   formatGainDb,
   gainToDb,
 } from "../../lib/music";
@@ -223,7 +222,7 @@ function MixerChannel({
       <div className="relative h-48">
         <div
           className="pointer-events-none absolute left-1/2 h-px w-3 -translate-x-1/2 bg-neutral-500/70"
-          style={{ bottom: `${dbToPercent(0)}%` }}
+          style={{ bottom: `${(-MIN_DB / (MAX_DB - MIN_DB)) * 100}%` }}
         />
         <Slider
           value={[gainToDb(gain)]}

--- a/src/components/recorder/recorder-mixer.tsx
+++ b/src/components/recorder/recorder-mixer.tsx
@@ -16,72 +16,6 @@ import { MetronomeIcon } from "../icons";
 import { Slider } from "../ui/slider";
 import { RecorderMixToggle } from "./recorder-mix-toggle";
 
-export function RecorderGainControl({
-  label,
-  gain,
-  onGainChange,
-}: {
-  label: string;
-  gain: number;
-  onGainChange: (gain: number) => void;
-}) {
-  return (
-    <label className="flex items-center gap-2 text-[10px] text-neutral-400">
-      <span className="font-medium uppercase tracking-wide">{label}</span>
-      <RecorderGainSlider
-        data-testid={`recorder-${label.toLowerCase()}-gain`}
-        label={`${label} gain`}
-        gain={gain}
-        onGainChange={onGainChange}
-        className="w-24"
-      />
-      <span className="w-12 text-right font-mono">{formatGainDb(gain)}</span>
-    </label>
-  );
-}
-
-export function RecorderGainSlider({
-  label,
-  gain,
-  onGainChange,
-  orientation = "horizontal",
-  className,
-  "data-testid": testId,
-  ...props
-}: {
-  label: string;
-  gain: number;
-  onGainChange: (gain: number) => void;
-  orientation?: "horizontal" | "vertical";
-  className?: string;
-  "data-testid"?: string;
-} & Omit<ComponentProps<typeof Slider>, "value" | "onValueChange">) {
-  const markerPosition = `${(-MIN_DB / (MAX_DB - MIN_DB)) * 100}%`;
-  return (
-    <div data-testid={testId} className={`relative ${className ?? ""}`}>
-      <div
-        className={
-          orientation === "vertical"
-            ? "pointer-events-none absolute bottom-(--marker-position) left-1/2 h-px w-3 -translate-x-1/2 bg-neutral-500/70"
-            : "pointer-events-none absolute top-1/2 left-(--marker-position) h-3 w-px -translate-y-1/2 bg-neutral-500/70"
-        }
-        style={{ "--marker-position": markerPosition } as React.CSSProperties}
-      />
-      <Slider
-        value={[gainToDb(gain)]}
-        onValueChange={([value]) => onGainChange(dbToGain(value))}
-        min={MIN_DB}
-        max={MAX_DB}
-        step={0.5}
-        orientation={orientation}
-        aria-label={label}
-        className={orientation === "vertical" ? "h-full" : "w-full"}
-        {...props}
-      />
-    </div>
-  );
-}
-
 export function RecorderMixer({
   runtime,
   state,
@@ -273,6 +207,72 @@ function MixerChannel({
         <span>dB</span>
       </label>
       {action ?? <div className="h-8" />}
+    </div>
+  );
+}
+
+export function RecorderGainControl({
+  label,
+  gain,
+  onGainChange,
+}: {
+  label: string;
+  gain: number;
+  onGainChange: (gain: number) => void;
+}) {
+  return (
+    <label className="flex items-center gap-2 text-[10px] text-neutral-400">
+      <span className="font-medium uppercase tracking-wide">{label}</span>
+      <RecorderGainSlider
+        data-testid={`recorder-${label.toLowerCase()}-gain`}
+        label={`${label} gain`}
+        gain={gain}
+        onGainChange={onGainChange}
+        className="w-24"
+      />
+      <span className="w-12 text-right font-mono">{formatGainDb(gain)}</span>
+    </label>
+  );
+}
+
+export function RecorderGainSlider({
+  label,
+  gain,
+  onGainChange,
+  orientation = "horizontal",
+  className,
+  "data-testid": testId,
+  ...props
+}: {
+  label: string;
+  gain: number;
+  onGainChange: (gain: number) => void;
+  orientation?: "horizontal" | "vertical";
+  className?: string;
+  "data-testid"?: string;
+} & Omit<ComponentProps<typeof Slider>, "value" | "onValueChange">) {
+  const markerPosition = `${(-MIN_DB / (MAX_DB - MIN_DB)) * 100}%`;
+  return (
+    <div data-testid={testId} className={`relative ${className ?? ""}`}>
+      <div
+        className={
+          orientation === "vertical"
+            ? "pointer-events-none absolute bottom-(--marker-position) left-1/2 h-px w-3 -translate-x-1/2 bg-neutral-500/70"
+            : "pointer-events-none absolute top-1/2 left-(--marker-position) h-3 w-px -translate-y-1/2 bg-neutral-500/70"
+        }
+        style={{ "--marker-position": markerPosition } as React.CSSProperties}
+      />
+      <Slider
+        value={[gainToDb(gain)]}
+        onValueChange={([value]) => onGainChange(dbToGain(value))}
+        min={MIN_DB}
+        max={MAX_DB}
+        step={0.5}
+        orientation={orientation}
+        aria-label={label}
+        className={orientation === "vertical" ? "h-full" : "w-full"}
+        {...props}
+      />
     </div>
   );
 }

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -14,7 +14,6 @@ import {
   MAX_DB,
   MIN_DB,
   dbToGain,
-  dbToPercent,
   formatGainDb,
   gainToDb,
 } from "../../lib/music";
@@ -138,7 +137,7 @@ export function TrackRow({
           <div className="relative">
             <div
               className="pointer-events-none absolute top-1/2 h-3 w-px -translate-y-1/2 bg-neutral-500/70"
-              style={{ left: `${dbToPercent(0)}%` }}
+              style={{ left: `${(-MIN_DB / (MAX_DB - MIN_DB)) * 100}%` }}
             />
             <input
               aria-label={`${title} gain`}
@@ -338,7 +337,7 @@ export function CaptureTrackRow({
           <div className="relative">
             <div
               className="pointer-events-none absolute top-1/2 h-3 w-px -translate-y-1/2 bg-neutral-500/70"
-              style={{ left: `${dbToPercent(0)}%` }}
+              style={{ left: `${(-MIN_DB / (MAX_DB - MIN_DB)) * 100}%` }}
             />
             <input
               aria-label="Capture gain"

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -11,10 +11,12 @@ import {
 import { usePointerDrag } from "../../hooks/use-pointer-drag";
 import type { AudioAnalyser } from "../../lib/audio-analyser";
 import {
+  MAX_DB,
+  MIN_DB,
+  dbToGain,
   dbToPercent,
   formatGainDb,
-  gainToPercent,
-  percentToGain,
+  gainToDb,
 } from "../../lib/music";
 import { openFilePicker } from "../file-drop-input";
 import { InputMeter } from "../input-meter";
@@ -141,12 +143,12 @@ export function TrackRow({
             <input
               aria-label={`${title} gain`}
               type="range"
-              min={0}
-              max={100}
-              step={1}
-              value={gainToPercent(gain)}
+              min={MIN_DB}
+              max={MAX_DB}
+              step={0.5}
+              value={gainToDb(gain)}
               onChange={(event) =>
-                onGainChange(percentToGain(event.currentTarget.valueAsNumber))
+                onGainChange(dbToGain(event.currentTarget.valueAsNumber))
               }
               className="w-full accent-emerald-600"
             />
@@ -341,12 +343,12 @@ export function CaptureTrackRow({
             <input
               aria-label="Capture gain"
               type="range"
-              min={0}
-              max={100}
-              step={1}
-              value={gainToPercent(gain)}
+              min={MIN_DB}
+              max={MAX_DB}
+              step={0.5}
+              value={gainToDb(gain)}
               onChange={(event) =>
-                onGainChange(percentToGain(event.currentTarget.valueAsNumber))
+                onGainChange(dbToGain(event.currentTarget.valueAsNumber))
               }
               className="block w-full accent-emerald-600"
             />

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -10,13 +10,7 @@ import {
 } from "lucide-react";
 import { usePointerDrag } from "../../hooks/use-pointer-drag";
 import type { AudioAnalyser } from "../../lib/audio-analyser";
-import {
-  MAX_DB,
-  MIN_DB,
-  dbToGain,
-  formatGainDb,
-  gainToDb,
-} from "../../lib/music";
+import { formatGainDb } from "../../lib/music";
 import { openFilePicker } from "../file-drop-input";
 import { InputMeter } from "../input-meter";
 import { Button } from "../ui/button";
@@ -29,6 +23,7 @@ import {
 } from "../ui/dropdown-menu";
 import { cn } from "../ui/utils";
 import { RecorderMixToggle } from "./recorder-mix-toggle";
+import { RecorderGainSlider } from "./recorder-mixer";
 
 export function AudioTrackActions({
   label,
@@ -134,24 +129,11 @@ export function TrackRow({
           />
         </div>
         <label className="col-span-2 mt-auto grid grid-cols-[1fr_3.5rem] items-center gap-2 text-[10px] text-neutral-400">
-          <div className="relative">
-            <div
-              className="pointer-events-none absolute top-1/2 h-3 w-px -translate-y-1/2 bg-neutral-500/70"
-              style={{ left: `${(-MIN_DB / (MAX_DB - MIN_DB)) * 100}%` }}
-            />
-            <input
-              aria-label={`${title} gain`}
-              type="range"
-              min={MIN_DB}
-              max={MAX_DB}
-              step={0.5}
-              value={gainToDb(gain)}
-              onChange={(event) =>
-                onGainChange(dbToGain(event.currentTarget.valueAsNumber))
-              }
-              className="w-full accent-emerald-600"
-            />
-          </div>
+          <RecorderGainSlider
+            label={`${title} gain`}
+            gain={gain}
+            onGainChange={onGainChange}
+          />
           <span className="text-right font-mono">{formatGainDb(gain)}</span>
         </label>
       </div>
@@ -334,24 +316,11 @@ export function CaptureTrackRow({
           <InputMeter active={inputActive} analyser={inputAnalyser} compact />
         </div>
         <label className="col-span-2 grid grid-cols-[1fr_3.5rem] items-center gap-2 text-[10px] text-neutral-400">
-          <div className="relative">
-            <div
-              className="pointer-events-none absolute top-1/2 h-3 w-px -translate-y-1/2 bg-neutral-500/70"
-              style={{ left: `${(-MIN_DB / (MAX_DB - MIN_DB)) * 100}%` }}
-            />
-            <input
-              aria-label="Capture gain"
-              type="range"
-              min={MIN_DB}
-              max={MAX_DB}
-              step={0.5}
-              value={gainToDb(gain)}
-              onChange={(event) =>
-                onGainChange(dbToGain(event.currentTarget.valueAsNumber))
-              }
-              className="block w-full accent-emerald-600"
-            />
-          </div>
+          <RecorderGainSlider
+            label="Capture gain"
+            gain={gain}
+            onGainChange={onGainChange}
+          />
           <span className="text-right font-mono">{formatGainDb(gain)}</span>
         </label>
       </div>

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -74,7 +74,7 @@ export function Slider({
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
-          className="block size-4 shrink-0 rounded-full border border-primary bg-white shadow-sm outline-none transition-[color,box-shadow] hover:ring-2 hover:ring-emerald-400/40 active:ring-4 active:ring-emerald-400/60 focus:ring-2 focus:ring-emerald-400/60 focus-visible:ring-4 focus-visible:ring-emerald-400 disabled:pointer-events-none disabled:opacity-50"
+          className="block size-4 shrink-0 rounded-full border border-primary bg-white shadow-sm outline-none transition-[color,box-shadow] hover:ring-2 hover:ring-emerald-400/40 active:ring-3 active:ring-emerald-400/60 focus:ring-2 focus:ring-emerald-400/60 focus-visible:ring-4 focus-visible:ring-emerald-400 disabled:pointer-events-none disabled:opacity-50"
           {...thumbProps}
         />
       ))}

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -74,7 +74,7 @@ export function Slider({
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
-          className="border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+          className="block size-4 shrink-0 rounded-full border border-primary bg-white shadow-sm outline-none transition-[color,box-shadow] hover:ring-2 hover:ring-emerald-400/40 active:ring-4 active:ring-emerald-400/60 focus:ring-2 focus:ring-emerald-400/60 focus-visible:ring-4 focus-visible:ring-emerald-400 disabled:pointer-events-none disabled:opacity-50"
           {...thumbProps}
         />
       ))}

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -10,8 +10,11 @@ export function Slider({
   min = 0,
   max = 100,
   onValueChange,
+  thumbProps,
   ...props
-}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+}: React.ComponentProps<typeof SliderPrimitive.Root> & {
+  thumbProps?: React.ComponentProps<typeof SliderPrimitive.Thumb>;
+}) {
   const _values = React.useMemo(
     () =>
       Array.isArray(value)
@@ -72,6 +75,7 @@ export function Slider({
           data-slot="slider-thumb"
           key={index}
           className="border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+          {...thumbProps}
         />
       ))}
     </SliderPrimitive.Root>

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -10,11 +10,10 @@ export function Slider({
   min = 0,
   max = 100,
   onValueChange,
-  thumbProps,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
   ...props
-}: React.ComponentProps<typeof SliderPrimitive.Root> & {
-  thumbProps?: React.ComponentProps<typeof SliderPrimitive.Thumb>;
-}) {
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
   const _values = React.useMemo(
     () =>
       Array.isArray(value)
@@ -75,7 +74,8 @@ export function Slider({
           data-slot="slider-thumb"
           key={index}
           className="block size-4 shrink-0 rounded-full border border-primary bg-white shadow-sm outline-none transition-[color,box-shadow] hover:ring-2 hover:ring-emerald-400/40 active:ring-3 active:ring-emerald-400/60 focus:ring-2 focus:ring-emerald-400/60 focus-visible:ring-4 focus-visible:ring-emerald-400 disabled:pointer-events-none disabled:opacity-50"
-          {...thumbProps}
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledBy}
         />
       ))}
     </SliderPrimitive.Root>

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -115,7 +115,7 @@ export function matchKeyboardEvent(
 
 export function isShortcutTextInputTarget(target: EventTarget | null): boolean {
   return (
-    (target instanceof HTMLInputElement && target.type !== "range") ||
+    target instanceof HTMLInputElement ||
     target instanceof HTMLTextAreaElement ||
     target instanceof HTMLSelectElement ||
     (target instanceof HTMLElement && target.isContentEditable)

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -118,6 +118,7 @@ export function isShortcutTextInputTarget(target: EventTarget | null): boolean {
     target instanceof HTMLInputElement ||
     target instanceof HTMLTextAreaElement ||
     target instanceof HTMLSelectElement ||
+    // Custom sliders use arrow keys but are not native form controls.
     (target instanceof HTMLElement &&
       (target.isContentEditable || target.getAttribute("role") === "slider"))
   );

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -118,6 +118,7 @@ export function isShortcutTextInputTarget(target: EventTarget | null): boolean {
     target instanceof HTMLInputElement ||
     target instanceof HTMLTextAreaElement ||
     target instanceof HTMLSelectElement ||
-    (target instanceof HTMLElement && target.isContentEditable)
+    (target instanceof HTMLElement &&
+      (target.isContentEditable || target.getAttribute("role") === "slider"))
   );
 }


### PR DESCRIPTION
Master gain is currently only available in the floating mixer, and recorder faders use percentage-based steps that do not produce predictable keyboard adjustments. Focused horizontal faders also leak Left and Right into timeline seeking.

This PR adds a compact master gain control to the recorder header and moves recorder gain sliders to a direct dB domain with 0.5 dB keyboard steps. Input-focused shortcuts now stay with the fader, while the header and mixer remain synchronized through the existing runtime state. Reset shortcuts are intentionally left for a follow-up.