### PR TITLE
test: share recorder audio import helper

### DIFF
--- a/e2e/fake-audio/recorder-archive.test.ts
+++ b/e2e/fake-audio/recorder-archive.test.ts
@@ -1,5 +1,6 @@
 import { expect, type Page, test } from "@playwright/test";
 import {
+  addRecorderAudio,
   createRecorderProject,
   enableInput,
   seekRecorderByPixels,
@@ -10,12 +11,7 @@ test("exports and imports a recorder project archive", async ({ page }) => {
   await createRecorderProject(page);
 
   // Build an editable project with backing audio and two retained takes.
-  const fileChooserPromise = page.waitForEvent("filechooser");
-  await page.getByTestId("recorder-add-audio-file").click();
-  await (await fileChooserPromise).setFiles("e2e/fixtures/test-audio.wav");
-  await expect(
-    page.getByTestId("recorder-clip-audio").locator("svg"),
-  ).toBeVisible();
+  await addRecorderAudio(page, "e2e/fixtures/test-audio.wav");
 
   await enableInput(page);
   const recordButton = page.getByTestId("recorder-record-button");

--- a/e2e/fake-audio/recorder-audio-track.test.ts
+++ b/e2e/fake-audio/recorder-audio-track.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import {
+  addRecorderAudio,
   createRecorderProject,
   dragBy,
   getRecorderPosition,
@@ -9,15 +10,11 @@ test("uploads and plays a backing track", async ({ page }) => {
   await createRecorderProject(page);
 
   // Load a backing track through the recorder's file picker.
-  const fileChooserPromise = page.waitForEvent("filechooser");
-  await page.getByTestId("recorder-add-audio-file").click();
-  const fileChooser = await fileChooserPromise;
-  await fileChooser.setFiles("e2e/fixtures/test-audio.wav");
+  await addRecorderAudio(page, "e2e/fixtures/test-audio.wav");
 
-  // Decoding produces both a named timeline clip and its waveform preview.
+  // The imported clip retains its source filename.
   const clip = page.getByTestId("recorder-clip-audio");
   await expect(clip).toContainText("test-audio.wav");
-  await expect(clip.locator("svg")).toBeVisible();
 
   // Move and trim backing audio without changing its source.
   const beforeEdit = await clip.boundingBox();
@@ -93,9 +90,7 @@ test("mixes recorder outputs in a floating panel", async ({ page }) => {
   await createRecorderProject(page);
 
   // Load backing audio so its channel appears in the mixer.
-  const fileChooserPromise = page.waitForEvent("filechooser");
-  await page.getByTestId("recorder-add-audio-file").click();
-  await (await fileChooserPromise).setFiles("e2e/fixtures/test-audio.wav");
+  await addRecorderAudio(page, "e2e/fixtures/test-audio.wav");
 
   // Open the floating mixer and inspect every recorder output channel.
   await page.getByTestId("recorder-mixer-button").click();

--- a/e2e/fake-audio/recorder-clip-selection.test.ts
+++ b/e2e/fake-audio/recorder-clip-selection.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import {
+  addRecorderAudio,
   createRecorderProject,
   enableInput,
   seekRecorderByPixels,
@@ -10,11 +11,8 @@ test("selects and moves audio and take clips together", async ({ page }) => {
   await createRecorderProject(page);
 
   // Import a backing track.
-  const fileChooserPromise = page.waitForEvent("filechooser");
-  await page.getByTestId("recorder-add-audio-file").click();
-  await (await fileChooserPromise).setFiles("e2e/fixtures/test-audio.wav");
+  await addRecorderAudio(page, "e2e/fixtures/test-audio.wav");
   const audio = page.getByTestId("recorder-clip-audio");
-  await expect(audio).toBeVisible();
 
   // Record a take away from zero.
   await enableInput(page);

--- a/e2e/fake-audio/recorder-helpers.ts
+++ b/e2e/fake-audio/recorder-helpers.ts
@@ -8,6 +8,19 @@ export async function createRecorderProject(page: Page): Promise<void> {
   await expect(page.getByTestId("recorder-project-name")).toBeVisible();
 }
 
+export async function addRecorderAudio(
+  page: Page,
+  filePath: string,
+): Promise<void> {
+  const clips = page.getByTestId("recorder-clip-audio");
+  const count = await clips.count();
+  const fileChooser = page.waitForEvent("filechooser");
+  await page.getByTestId("recorder-add-audio-file").click();
+  await (await fileChooser).setFiles(filePath);
+  await expect(clips).toHaveCount(count + 1);
+  await expect(clips.nth(count).locator("svg")).toBeVisible();
+}
+
 export async function seekRecorderByPixels(page: Page, pixels: number) {
   const ruler = page.getByTestId("recorder-timeline-ruler");
   const box = await ruler.boundingBox();

--- a/e2e/fake-audio/recorder-persistence.test.ts
+++ b/e2e/fake-audio/recorder-persistence.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "@playwright/test";
-import { createRecorderProject, getRecorderPosition } from "./recorder-helpers";
+import {
+  addRecorderAudio,
+  createRecorderProject,
+  getRecorderPosition,
+} from "./recorder-helpers";
 
 test("saves and restores a recorder project", async ({ page }) => {
   // Create a project and give it a recognizable name.
@@ -30,13 +34,9 @@ test("saves and restores a recorder project", async ({ page }) => {
   );
 
   // Load a backing track, including its decoded waveform.
-  const fileChooserPromise = page.waitForEvent("filechooser");
-  await page.getByTestId("recorder-add-audio-file").click();
-  const fileChooser = await fileChooserPromise;
-  await fileChooser.setFiles("e2e/fixtures/test-audio.wav");
+  await addRecorderAudio(page, "e2e/fixtures/test-audio.wav");
   const clip = page.getByTestId("recorder-clip-audio");
   await expect(clip).toContainText("test-audio.wav");
-  await expect(clip.locator("svg")).toBeVisible();
 
   // They change the session tempo.
   await page.getByTestId("recorder-tempo-input").fill("140");

--- a/e2e/fake-audio/recorder-selection-domains.test.ts
+++ b/e2e/fake-audio/recorder-selection-domains.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import {
+  addRecorderAudio,
   createRecorderProject,
   dragBy,
   seekRecorderByPixels,
@@ -16,11 +17,8 @@ test("keeps recorder clip and locator selection domains exclusive", async ({
   await add.click();
 
   // Selecting a locator after a waveform makes Delete remove only the locator.
-  const fileChooser = page.waitForEvent("filechooser");
-  await page.getByTestId("recorder-add-audio-file").click();
-  await (await fileChooser).setFiles("e2e/fixtures/test-audio.wav");
+  await addRecorderAudio(page, "e2e/fixtures/test-audio.wav");
   const audio = page.getByTestId("recorder-clip-audio");
-  await expect(audio).toBeVisible();
   await audio.click();
   await expect(audio).toHaveAttribute("data-selected", "true");
   await marker.click();


### PR DESCRIPTION
- split from https://github.com/hi-ogawa/toy-midi/pull/454

This PR extracts the repeated recorder file-picker flow into `addRecorderAudio(page, filePath)` and uses it in six existing audio-import flows. The helper waits for the new clip and its decoded waveform, while each test keeps its scenario-specific assertions.