### PR TITLE
fix: tighten recorder track layout and align control styling

### DIFF
--- a/e2e/fake-audio/recorder-audio-track.test.ts
+++ b/e2e/fake-audio/recorder-audio-track.test.ts
@@ -59,7 +59,7 @@ test("uploads and plays a backing track", async ({ page }) => {
   await page.keyboard.press("Delete");
   await expect(clip).toHaveCount(0);
   await expect(page.getByText("Load an audio file")).toBeVisible();
-  await expect(page.getByText("No file loaded")).toBeVisible();
+  await expect(page.getByText("Audio 1", { exact: true })).toBeVisible();
 });
 
 test("scrolls overflowing tracks from the track list", async ({ page }) => {

--- a/e2e/fake-audio/recorder-audio-track.test.ts
+++ b/e2e/fake-audio/recorder-audio-track.test.ts
@@ -59,7 +59,7 @@ test("uploads and plays a backing track", async ({ page }) => {
   await page.keyboard.press("Delete");
   await expect(clip).toHaveCount(0);
   await expect(page.getByText("Load an audio file")).toBeVisible();
-  await expect(page.getByText("Audio 1", { exact: true })).toBeVisible();
+  await expect(page.getByTestId("recorder-audio-track-row")).toBeVisible();
 });
 
 test("scrolls overflowing tracks from the track list", async ({ page }) => {

--- a/e2e/fake-audio/recorder-clip-selection.test.ts
+++ b/e2e/fake-audio/recorder-clip-selection.test.ts
@@ -55,5 +55,5 @@ test("selects and moves audio and take clips together", async ({ page }) => {
   await expect(audio).toHaveCount(0);
   await expect(take).toHaveCount(0);
   await expect(page.getByText("Load an audio file")).toBeVisible();
-  await expect(page.getByText("No file loaded")).toBeVisible();
+  await expect(page.getByText("Audio 1", { exact: true })).toBeVisible();
 });

--- a/e2e/fake-audio/recorder-clip-selection.test.ts
+++ b/e2e/fake-audio/recorder-clip-selection.test.ts
@@ -55,5 +55,5 @@ test("selects and moves audio and take clips together", async ({ page }) => {
   await expect(audio).toHaveCount(0);
   await expect(take).toHaveCount(0);
   await expect(page.getByText("Load an audio file")).toBeVisible();
-  await expect(page.getByText("Audio 1", { exact: true })).toBeVisible();
+  await expect(page.getByTestId("recorder-audio-track-row")).toBeVisible();
 });

--- a/e2e/fake-audio/recorder-recording.test.ts
+++ b/e2e/fake-audio/recorder-recording.test.ts
@@ -173,5 +173,5 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   await takeLane.nth(1).click({ modifiers: ["Control"] });
   await page.keyboard.press("Delete");
   await expect(take).toHaveCount(0);
-  await expect(page.getByText("No takes")).toBeVisible();
+  await expect(takesToggle).toHaveText("Takes0");
 });

--- a/e2e/fake-audio/recorder-recording.test.ts
+++ b/e2e/fake-audio/recorder-recording.test.ts
@@ -173,5 +173,5 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   await takeLane.nth(1).click({ modifiers: ["Control"] });
   await page.keyboard.press("Delete");
   await expect(take).toHaveCount(0);
-  await expect(takesToggle).toHaveText("Takes0");
+  await expect(takeRows).toHaveCount(0);
 });

--- a/e2e/fake-audio/recorder-reference-video.test.ts
+++ b/e2e/fake-audio/recorder-reference-video.test.ts
@@ -83,6 +83,17 @@ test("configures an ephemeral YouTube reference", async ({ page }) => {
   const referenceTrack = page.getByTestId("recorder-reference-track");
   await expect(referenceTrack).toContainText("Reference");
   await expect(referenceTrack).toContainText("0:00");
+  // The header background must leave the row's bottom border exposed.
+  expect(
+    await referenceTrack.evaluate((row) => {
+      const border = Number.parseFloat(getComputedStyle(row).borderBottomWidth);
+      const header = row.firstElementChild!;
+      return (
+        header.getBoundingClientRect().bottom <=
+        row.getBoundingClientRect().bottom - border
+      );
+    }),
+  ).toBe(true);
   const referenceClip = referenceTrack.getByTestId("recorder-clip-reference");
   const initialReferenceClipBox = await referenceClip.boundingBox();
   expect(initialReferenceClipBox).not.toBeNull();

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -9,7 +9,6 @@ import {
 } from "../../lib/keyboard";
 import { exportRecorderProjectArchive } from "../../lib/recorder/project-archive";
 import { RecorderRuntime } from "../../lib/recorder/runtime";
-import { formatTimeWithMilliseconds } from "../../lib/time-format";
 import { beatsToSeconds } from "../../lib/timeline";
 import { encodeWav } from "../../lib/wav";
 import { parseTimeSignature } from "../../types";
@@ -346,7 +345,6 @@ export function Recorder({ projectId }: { projectId: string }) {
               <TrackRow
                 key={track.id}
                 title={`Audio ${index + 1}`}
-                subtitle={track.clip ? "" : "No file loaded"}
                 height={track.height}
                 gain={track.gain}
                 muted={track.muted}
@@ -429,15 +427,6 @@ export function Recorder({ projectId }: { projectId: string }) {
             <CaptureTrackRow
               route={input.route.label}
               routeNeedsSetup={input.route.needsSetup}
-              subtitle={
-                isProcessing
-                  ? "Finalizing take…"
-                  : isRecording
-                    ? `Recording · ${formatTimeWithMilliseconds(state.pendingRecording?.duration ?? 0)}`
-                    : takes.length > 0
-                      ? ""
-                      : "No takes"
-              }
               gain={state.recordingTrack.gain}
               height={state.recordingTrack.height}
               inputActive={input.active}

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -344,7 +344,7 @@ export function Recorder({ projectId }: { projectId: string }) {
               <TrackRow
                 key={track.id}
                 title={`Audio ${index + 1}`}
-                subtitle={track.clip?.name ?? "No file loaded"}
+                subtitle={track.clip ? "" : "No file loaded"}
                 height={track.height}
                 gain={track.gain}
                 muted={track.muted}
@@ -433,7 +433,7 @@ export function Recorder({ projectId }: { projectId: string }) {
                   : isRecording
                     ? `Recording · ${formatTimeWithMilliseconds(state.pendingRecording?.duration ?? 0)}`
                     : takes.length > 0
-                      ? `${takes.length} ${takes.length === 1 ? "take" : "takes"}`
+                      ? ""
                       : "No takes"
               }
               gain={state.recordingTrack.gain}

--- a/src/components/recorder/recorder-header.tsx
+++ b/src/components/recorder/recorder-header.tsx
@@ -169,7 +169,7 @@ export function RecorderHeader({
         className={cn(
           "size-9",
           isRecording
-            ? "bg-red-600 text-white hover:bg-red-500"
+            ? "border-red-500/60 bg-red-500/20 text-red-200 hover:bg-red-500/30"
             : "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         )}
         title={isRecording ? "Stop recording (R)" : "Record (R)"}

--- a/src/components/recorder/recorder-mix-toggle.tsx
+++ b/src/components/recorder/recorder-mix-toggle.tsx
@@ -16,7 +16,7 @@ export function RecorderMixToggle({
       {...props}
       aria-pressed={active}
       className={cn(
-        "border-neutral-600 text-neutral-300 hover:bg-neutral-700",
+        "border-neutral-600 text-xs font-semibold text-neutral-300 hover:bg-neutral-700",
         active &&
           (kind === "mute"
             ? "border-amber-500/60 bg-amber-500/35 text-amber-300 hover:!bg-amber-500/40 hover:!text-amber-300"

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -640,20 +640,11 @@ export function ReferenceTimelineRow({
       data-testid="recorder-reference-track"
       className="grid h-15 grid-cols-[15rem_1fr] border-b border-neutral-700"
     >
-      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] items-start gap-2 border-r border-neutral-700 bg-neutral-800 p-3">
-        <div className="min-w-0">
-          <div className="truncate text-xs font-semibold">Reference</div>
-          <div className="mt-0.5 flex items-center gap-1.5 font-mono text-[11px] text-neutral-400">
-            <span>
-              {formatTimeMinutes(
-                Math.max(0, position - referenceVideo.timelineStart),
-              )}
-            </span>
-            <span className="text-neutral-600">/</span>
-            <span>{formatTimeMinutes(referenceVideo.duration)}</span>
-          </div>
+      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[1.75rem_auto] content-start gap-x-2 border-r border-neutral-700 bg-neutral-800 px-3 py-2">
+        <div className="min-w-0 self-center truncate text-xs font-semibold">
+          Reference
         </div>
-        <div className="flex gap-1">
+        <div className="flex self-center gap-1">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -678,6 +669,15 @@ export function ReferenceTimelineRow({
             className="size-7"
             title={muted ? "Unmute Reference" : "Mute Reference"}
           />
+        </div>
+        <div className="col-span-2 flex items-center gap-1.5 font-mono text-[11px] text-neutral-400">
+          <span>
+            {formatTimeMinutes(
+              Math.max(0, position - referenceVideo.timelineStart),
+            )}
+          </span>
+          <span className="text-neutral-600">/</span>
+          <span>{formatTimeMinutes(referenceVideo.duration)}</span>
         </div>
       </div>
       <div

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -638,7 +638,7 @@ export function ReferenceTimelineRow({
   return (
     <div
       data-testid="recorder-reference-track"
-      className="grid h-20 grid-cols-[15rem_1fr] border-b border-neutral-700"
+      className="grid h-17 grid-cols-[15rem_1fr] border-b border-neutral-700"
     >
       <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] items-start gap-2 border-r border-neutral-700 bg-neutral-800 p-3">
         <div className="min-w-0">

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -670,7 +670,7 @@ export function ReferenceTimelineRow({
             title={muted ? "Unmute Reference" : "Mute Reference"}
           />
         </div>
-        <div className="col-span-2 flex items-center gap-1.5 font-mono text-[11px] text-neutral-400">
+        <div className="col-span-2 flex items-center gap-1.5 font-mono text-[11px] leading-3.5 text-neutral-400">
           <span>
             {formatTimeMinutes(
               Math.max(0, position - referenceVideo.timelineStart),

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -638,7 +638,7 @@ export function ReferenceTimelineRow({
   return (
     <div
       data-testid="recorder-reference-track"
-      className="grid h-17 grid-cols-[15rem_1fr] border-b border-neutral-700"
+      className="grid h-15 grid-cols-[15rem_1fr] border-b border-neutral-700"
     >
       <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] items-start gap-2 border-r border-neutral-700 bg-neutral-800 p-3">
         <div className="min-w-0">

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -229,8 +229,8 @@ export function CaptureTrackRow({
             onClick={onInputToggle}
             className={
               inputActive
-                ? "size-7 border-red-500/60 bg-red-500/25 text-red-300 hover:bg-red-500/35"
-                : "size-7 border-neutral-600 text-neutral-300 hover:bg-neutral-700"
+                ? "size-7 border-red-500/60 bg-red-500/25 text-xs font-semibold text-red-300 hover:bg-red-500/35"
+                : "size-7 border-neutral-600 text-xs font-semibold text-neutral-300 hover:bg-neutral-700"
             }
             title={inputActive ? "Disarm capture" : "Arm capture"}
             aria-label={inputActive ? "Disarm capture" : "Arm capture"}

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -103,7 +103,7 @@ export function TrackRow({
       className="relative grid grid-cols-[15rem_1fr] border-b border-neutral-700"
       style={{ height }}
     >
-      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] gap-2 border-r border-neutral-700 bg-neutral-800 p-3">
+      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[auto_auto] content-start gap-2 border-r border-neutral-700 bg-neutral-800 px-3 py-2">
         <div className="min-w-0 self-center truncate text-xs font-semibold">
           {title}
         </div>
@@ -124,7 +124,7 @@ export function TrackRow({
             title={soloed ? `Disable ${title} solo` : `Solo ${title}`}
           />
         </div>
-        <label className="col-span-2 mt-auto grid grid-cols-[1fr_3.5rem] items-center gap-2 text-[10px] text-neutral-400">
+        <label className="col-span-2 grid grid-cols-[1fr_3.5rem] items-center gap-2 text-[10px] text-neutral-400">
           <RecorderGainSlider
             label={`${title} gain`}
             gain={gain}

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -104,10 +104,10 @@ export function TrackRow({
       style={{ height }}
     >
       <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] gap-2 border-r border-neutral-700 bg-neutral-800 p-3">
-        <div className="min-w-0 truncate text-xs leading-7 font-semibold">
+        <div className="min-w-0 self-center truncate text-xs font-semibold">
           {title}
         </div>
-        <div className="flex gap-1">
+        <div className="flex self-center gap-1">
           {action}
           <RecorderMixToggle
             active={muted}
@@ -198,10 +198,10 @@ export function CaptureTrackRow({
   return (
     <div className="relative grid grid-cols-[15rem_1fr]" style={{ height }}>
       <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[2rem_1.5rem_0.75rem_1.5rem] content-start gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 p-3">
-        <div className="min-w-0 truncate text-xs leading-7 font-semibold">
+        <div className="min-w-0 self-center truncate text-xs font-semibold">
           Capture
         </div>
-        <div className="flex gap-1">
+        <div className="flex self-center gap-1">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -380,8 +380,8 @@ export function TakeTrackRow({
       data-testid="recorder-take-row"
       className="grid h-20 grid-cols-[15rem_1fr] border-b border-neutral-700"
     >
-      <div className="sticky left-0 z-20 flex items-start gap-1 border-r border-neutral-700 bg-neutral-900 px-3 py-3 text-xs font-semibold text-neutral-300">
-        <span className="mr-auto px-4 leading-7">Take {number}</span>
+      <div className="sticky left-0 z-20 flex items-center gap-1 border-r border-neutral-700 bg-neutral-900 px-3 py-3 text-xs font-semibold text-neutral-300">
+        <span className="mr-auto px-4">Take {number}</span>
         <RecorderMixToggle
           data-testid="recorder-take-mute"
           aria-label={`Mute Take ${number}`}

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -229,7 +229,7 @@ export function CaptureTrackRow({
             onClick={onInputToggle}
             className={
               inputActive
-                ? "size-7 border-red-500/60 bg-red-500/25 text-xs font-semibold text-red-300 hover:bg-red-500/35"
+                ? "size-7 border-neutral-600 bg-red-500/35 text-xs font-semibold text-neutral-300 hover:!bg-red-500/40 hover:!text-red-300"
                 : "size-7 border-neutral-600 text-xs font-semibold text-neutral-300 hover:bg-neutral-700"
             }
             title={inputActive ? "Disarm capture" : "Arm capture"}

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -65,7 +65,6 @@ export function AudioTrackActions({
 
 export function TrackRow({
   title,
-  subtitle,
   height,
   gain,
   muted,
@@ -78,7 +77,6 @@ export function TrackRow({
   children,
 }: {
   title: string;
-  subtitle: string;
   height: number;
   gain: number;
   muted: boolean;
@@ -105,14 +103,7 @@ export function TrackRow({
       style={{ height }}
     >
       <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] gap-2 border-r border-neutral-700 bg-neutral-800 p-3">
-        <div className="min-w-0">
-          <div className="truncate text-xs font-semibold">{title}</div>
-          {subtitle && (
-            <div className="mt-0.5 truncate text-[11px] text-neutral-400">
-              {subtitle}
-            </div>
-          )}
-        </div>
+        <div className="min-w-0 truncate text-xs font-semibold">{title}</div>
         <div className="flex gap-1">
           {action}
           <RecorderMixToggle
@@ -152,7 +143,6 @@ export function TrackRow({
 export function CaptureTrackRow({
   route,
   routeNeedsSetup,
-  subtitle,
   height,
   gain,
   inputActive,
@@ -174,7 +164,6 @@ export function CaptureTrackRow({
 }: {
   route: string;
   routeNeedsSetup: boolean;
-  subtitle: string;
   height: number;
   gain: number;
   inputActive: boolean;
@@ -206,14 +195,7 @@ export function CaptureTrackRow({
   return (
     <div className="relative grid grid-cols-[15rem_1fr]" style={{ height }}>
       <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[2rem_1.5rem_0.75rem_1.5rem] content-start gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 p-3">
-        <div className="min-w-0">
-          <div className="truncate text-xs font-semibold">Capture</div>
-          {subtitle && (
-            <div className="mt-0.5 truncate text-[11px] text-neutral-400">
-              {subtitle}
-            </div>
-          )}
-        </div>
+        <div className="min-w-0 truncate text-xs font-semibold">Capture</div>
         <div className="flex gap-1">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -381,7 +381,7 @@ export function TakeTrackRow({
       className="grid h-20 grid-cols-[15rem_1fr] border-b border-neutral-700"
     >
       <div className="sticky left-0 z-20 flex items-start gap-1 border-r border-neutral-700 bg-neutral-900 px-3 py-3 text-xs font-semibold text-neutral-300">
-        <span className="mr-auto px-4">Take {number}</span>
+        <span className="mr-auto px-4 leading-7">Take {number}</span>
         <RecorderMixToggle
           data-testid="recorder-take-mute"
           aria-label={`Mute Take ${number}`}

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -104,7 +104,9 @@ export function TrackRow({
       style={{ height }}
     >
       <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] gap-2 border-r border-neutral-700 bg-neutral-800 p-3">
-        <div className="min-w-0 truncate text-xs font-semibold">{title}</div>
+        <div className="min-w-0 truncate text-xs leading-7 font-semibold">
+          {title}
+        </div>
         <div className="flex gap-1">
           {action}
           <RecorderMixToggle
@@ -196,7 +198,9 @@ export function CaptureTrackRow({
   return (
     <div className="relative grid grid-cols-[15rem_1fr]" style={{ height }}>
       <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[2rem_1.5rem_0.75rem_1.5rem] content-start gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 p-3">
-        <div className="min-w-0 truncate text-xs font-semibold">Capture</div>
+        <div className="min-w-0 truncate text-xs leading-7 font-semibold">
+          Capture
+        </div>
         <div className="flex gap-1">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -103,7 +103,7 @@ export function TrackRow({
       className="relative grid grid-cols-[15rem_1fr] border-b border-neutral-700"
       style={{ height }}
     >
-      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[auto_auto] content-start gap-2 border-r border-neutral-700 bg-neutral-800 px-3 py-2">
+      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[1.75rem_auto] content-start gap-2 border-r border-neutral-700 bg-neutral-800 px-3 py-2">
         <div className="min-w-0 self-center truncate text-xs font-semibold">
           {title}
         </div>
@@ -197,7 +197,7 @@ export function CaptureTrackRow({
   });
   return (
     <div className="relative grid grid-cols-[15rem_1fr]" style={{ height }}>
-      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[2rem_1.5rem_0.75rem_1.5rem] content-start gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 p-3">
+      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[1.75rem_1.5rem_0.75rem_1.5rem] content-start gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 px-3 py-2">
         <div className="min-w-0 self-center truncate text-xs font-semibold">
           Capture
         </div>

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -382,6 +382,19 @@ export function TakeTrackRow({
     >
       <div className="sticky left-0 z-20 flex items-center gap-1 border-r border-neutral-700 bg-neutral-900 px-3 py-3 text-xs font-semibold text-neutral-300">
         <span className="mr-auto px-4">Take {number}</span>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button aria-label={`Take ${number} actions`} className="size-7">
+              <MoreVerticalIcon className="size-3.5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={onDelete}>
+              <Trash2Icon />
+              Delete take
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
         <RecorderMixToggle
           data-testid="recorder-take-mute"
           aria-label={`Mute Take ${number}`}
@@ -400,19 +413,6 @@ export function TakeTrackRow({
           className="size-7"
           title="Solo take"
         />
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button aria-label={`Take ${number} actions`} className="size-7">
-              <MoreVerticalIcon className="size-3.5" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onSelect={onDelete}>
-              <Trash2Icon />
-              Delete take
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
       </div>
       {children}
     </div>

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -378,7 +378,7 @@ export function TakeTrackRow({
   return (
     <div
       data-testid="recorder-take-row"
-      className="grid h-20 grid-cols-[15rem_1fr] border-b border-neutral-700"
+      className="grid h-16 grid-cols-[15rem_1fr] border-b border-neutral-700"
     >
       <div className="sticky left-0 z-20 flex items-center gap-1 border-r border-neutral-700 bg-neutral-900 px-3 py-3 text-xs font-semibold text-neutral-300">
         <span className="mr-auto px-4">Take {number}</span>

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -99,6 +99,7 @@ export function TrackRow({
   });
   return (
     <div
+      data-testid="recorder-audio-track-row"
       className="relative grid grid-cols-[15rem_1fr] border-b border-neutral-700"
       style={{ height }}
     >

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -111,9 +111,11 @@ export function TrackRow({
       <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] gap-2 border-r border-neutral-700 bg-neutral-800 p-3">
         <div className="min-w-0">
           <div className="truncate text-xs font-semibold">{title}</div>
-          <div className="mt-0.5 truncate text-[11px] text-neutral-400">
-            {subtitle}
-          </div>
+          {subtitle && (
+            <div className="mt-0.5 truncate text-[11px] text-neutral-400">
+              {subtitle}
+            </div>
+          )}
         </div>
         <div className="flex gap-1">
           {action}
@@ -223,9 +225,11 @@ export function CaptureTrackRow({
       <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[2rem_1.5rem_0.75rem_1.5rem] content-start gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 p-3">
         <div className="min-w-0">
           <div className="truncate text-xs font-semibold">Capture</div>
-          <div className="mt-0.5 truncate text-[11px] text-neutral-400">
-            {subtitle}
-          </div>
+          {subtitle && (
+            <div className="mt-0.5 truncate text-[11px] text-neutral-400">
+              {subtitle}
+            </div>
+          )}
         </div>
         <div className="flex gap-1">
           <DropdownMenu>

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -30,7 +30,7 @@ const MIN_TAKE_DURATION = 0.01;
 export const WAVEFORM_POINTS_PER_SECOND = 800;
 const DEFAULT_TRACK_HEIGHT = 72;
 const MIN_TRACK_HEIGHT = DEFAULT_TRACK_HEIGHT;
-const MIN_RECORDING_TRACK_HEIGHT = 128;
+const MIN_RECORDING_TRACK_HEIGHT = 116;
 const MAX_TRACK_HEIGHT = 300;
 
 type CaptureStatus = "disabled" | "ready" | "recording" | "processing";

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -28,7 +28,7 @@ import { YouTubePlayerPlayback } from "./youtube-player-playback.ts";
 const MAX_RECORDING_SECONDS = 5 * 60;
 const MIN_TAKE_DURATION = 0.01;
 export const WAVEFORM_POINTS_PER_SECOND = 800;
-const DEFAULT_TRACK_HEIGHT = 96;
+const DEFAULT_TRACK_HEIGHT = 72;
 const MIN_TRACK_HEIGHT = DEFAULT_TRACK_HEIGHT;
 const MIN_RECORDING_TRACK_HEIGHT = 128;
 const MAX_TRACK_HEIGHT = 300;


### PR DESCRIPTION
The recorder track column had duplicate subtitles, excess vertical space, and inconsistent control alignment and styling.

This PR removes Audio and Capture subtitles, reduces track heights, and aligns main-track header spacing and per-take M/S positions. It also standardizes R/M/S typography, softens the recording transport's solid red fill, and aligns the armed button's active and hover colors with the existing mute/solo treatment.

Audio and Capture default/minimum heights are now 72 px and 116 px, while saved heights remain unchanged. Reference rows are 60 px and take rows are 64 px. Existing track controls remain available.