### PR TITLE
feat: add recorder quick reference

### DIFF
--- a/src/components/recorder/help.tsx
+++ b/src/components/recorder/help.tsx
@@ -117,11 +117,8 @@ export function RecorderHelp({
             <HelpSection key={section.title} section={section} />
           ))}
         </div>
-        <footer className="flex items-center justify-between gap-4 border-t border-neutral-700 px-8 py-4 text-xs text-neutral-400">
-          <span>Recorder shortcuts are inactive while help is open.</span>
-          <span>
-            Toggle this reference with <kbd className={keyClassName}>?</kbd>
-          </span>
+        <footer className="border-t border-neutral-700 px-8 py-4 text-xs text-neutral-400">
+          Recorder shortcuts are inactive while help is open.
         </footer>
       </div>
     </dialog>

--- a/src/components/recorder/help.tsx
+++ b/src/components/recorder/help.tsx
@@ -1,11 +1,13 @@
 import { XIcon } from "lucide-react";
 import { useEffect, useRef } from "react";
 
-const sections: {
+type HelpSectionData = {
   title: string;
   items: { action: string; keys?: string; gesture?: string }[];
   note?: string;
-}[] = [
+};
+
+const sections: HelpSectionData[] = [
   {
     title: "Play and record",
     items: [
@@ -122,7 +124,7 @@ export function RecorderHelp({
   );
 }
 
-function HelpSection({ section }: { section: (typeof sections)[number] }) {
+function HelpSection({ section }: { section: HelpSectionData }) {
   return (
     <section>
       <h3 className="mb-3 text-sm font-semibold text-emerald-300">

--- a/src/components/recorder/help.tsx
+++ b/src/components/recorder/help.tsx
@@ -1,5 +1,4 @@
-import { XIcon } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { Dialog } from "../ui/dialog";
 
 type HelpSectionData = {
   title: string;
@@ -69,56 +68,21 @@ export function RecorderHelp({
   isOpen: boolean;
   onClose: () => void;
 }) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-
-  useEffect(() => {
-    const dialog = dialogRef.current!;
-    if (isOpen) {
-      dialog.showModal();
-    } else {
-      dialog.close();
-    }
-  }, [isOpen]);
-
   return (
-    <dialog
-      ref={dialogRef}
-      aria-labelledby="recorder-help-title"
-      className="fixed inset-0 m-auto max-h-[90vh] w-[960px] max-w-[calc(100vw-3rem)] overflow-y-auto rounded-xl border border-neutral-600 bg-neutral-800 p-0 text-neutral-100 shadow-2xl backdrop:bg-black/60"
-      onCancel={(event) => {
-        event.preventDefault();
-        onClose();
-      }}
-      onClick={(event) => {
-        if (event.target === event.currentTarget) {
-          onClose();
-        }
-      }}
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Recorder quick reference"
+      widthClassName="max-w-[960px]"
     >
-      <div>
-        <header className="flex items-center justify-between gap-5 border-b border-neutral-700 px-8 py-6">
-          <h2
-            id="recorder-help-title"
-            className="text-2xl font-semibold tracking-tight"
-          >
-            Recorder quick reference
-          </h2>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close help"
-            className="text-neutral-400 hover:text-neutral-100"
-          >
-            <XIcon className="size-5" />
-          </button>
-        </header>
-        <div className="columns-2 gap-10 px-8 py-7">
+      <div className="max-h-[calc(90vh-8rem)] overflow-y-auto">
+        <div className="columns-2 gap-10">
           {sections.map((section) => (
             <HelpSection key={section.title} section={section} />
           ))}
         </div>
       </div>
-    </dialog>
+    </Dialog>
   );
 }
 

--- a/src/components/recorder/help.tsx
+++ b/src/components/recorder/help.tsx
@@ -1,0 +1,154 @@
+import { XIcon } from "lucide-react";
+import { useEffect, useRef } from "react";
+
+const sections: {
+  title: string;
+  items: { action: string; keys?: string; gesture?: string }[];
+  note?: string;
+}[] = [
+  {
+    title: "Play and record",
+    items: [
+      { action: "Play / pause", keys: "Space" },
+      { action: "Start / stop recording", keys: "R" },
+      { action: "Seek backward / forward 5 seconds", keys: "Left / Right" },
+      { action: "Toggle metronome", keys: "M" },
+    ],
+    note: "Space also stops an active recording. Arrow-key seeking is unavailable while recording or processing.",
+  },
+  {
+    title: "Move around",
+    items: [
+      { action: "Scroll timeline horizontally", gesture: "Wheel over timeline" },
+      { action: "Zoom at pointer", keys: "Ctrl", gesture: " + wheel" },
+      { action: "Seek to a position", gesture: "Click ruler / empty lane" },
+      { action: "Toggle follow playhead", keys: "F" },
+    ],
+  },
+  {
+    title: "Work with clips",
+    items: [
+      { action: "Select a clip", gesture: "Click clip" },
+      {
+        action: "Add / remove from selection",
+        keys: "Ctrl / Cmd",
+        gesture: " + click",
+      },
+      { action: "Move selected clips", gesture: "Drag clip body" },
+      { action: "Trim audio clips and takes", gesture: "Drag clip edge" },
+      { action: "Remove selected clips", keys: "Delete / Backspace" },
+      { action: "Clear selection", keys: "Esc" },
+    ],
+    note: "Drag a selected clip to move the group together.",
+  },
+  {
+    title: "Mark and save",
+    items: [
+      { action: "Add locator at playhead", keys: "L" },
+      { action: "Remove selected locator", keys: "Delete / Backspace" },
+      { action: "Save project", keys: "Ctrl / Cmd + S" },
+    ],
+  },
+];
+
+const keyClassName =
+  "whitespace-nowrap rounded border border-b-2 border-neutral-600 bg-neutral-700/60 px-1.5 py-0.5 font-sans text-[11px] text-neutral-300";
+
+export function RecorderHelp({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+}) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current!;
+    if (isOpen) {
+      dialog.showModal();
+    } else {
+      dialog.close();
+    }
+  }, [isOpen]);
+
+  return (
+    <dialog
+      ref={dialogRef}
+      aria-labelledby="recorder-help-title"
+      className="fixed inset-0 m-auto max-h-[90vh] w-[960px] max-w-[calc(100vw-3rem)] overflow-y-auto rounded-xl border border-neutral-600 bg-neutral-800 p-0 text-neutral-100 shadow-2xl backdrop:bg-black/60"
+      onCancel={(event) => {
+        event.preventDefault();
+        onClose();
+      }}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div>
+        <header className="flex items-start justify-between gap-5 border-b border-neutral-700 px-8 py-6">
+          <div>
+            <h2
+              id="recorder-help-title"
+              className="text-2xl font-semibold tracking-tight"
+            >
+              Recorder quick reference
+            </h2>
+            <p className="mt-2 text-[13px] text-neutral-400">
+              The keys and gestures for recording, navigating, and editing.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close help"
+            className="flex items-center gap-2.5 text-neutral-400 hover:text-neutral-100"
+          >
+            <kbd className={keyClassName}>Esc</kbd>
+            <XIcon className="size-5" />
+          </button>
+        </header>
+        <div className="grid grid-cols-2 gap-x-10 gap-y-7 px-8 py-7">
+          {sections.map((section) => (
+            <section key={section.title}>
+              <h3 className="mb-3 text-sm font-semibold text-emerald-300">
+                {section.title}
+              </h3>
+              <dl>
+                {section.items.map((item) => (
+                  <div
+                    key={item.action}
+                    className="flex min-h-[34px] items-center justify-between gap-3"
+                  >
+                    <dt className="text-[13px] text-neutral-200">
+                      {item.action}
+                    </dt>
+                    <dd className="flex shrink-0 items-center gap-1 whitespace-nowrap text-xs text-neutral-400">
+                      {item.keys && (
+                        <kbd className={keyClassName}>{item.keys}</kbd>
+                      )}
+                      {item.gesture}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+              {section.note && (
+                <p className="mt-2 text-xs leading-relaxed text-neutral-400">
+                  {section.note}
+                </p>
+              )}
+            </section>
+          ))}
+        </div>
+        <footer className="flex items-center justify-between gap-4 border-t border-neutral-700 px-8 py-4 text-xs text-neutral-400">
+          <span>Recorder shortcuts are inactive while help is open.</span>
+          <span>
+            Toggle this reference with <kbd className={keyClassName}>?</kbd>
+          </span>
+        </footer>
+      </div>
+    </dialog>
+  );
+}

--- a/src/components/recorder/help.tsx
+++ b/src/components/recorder/help.tsx
@@ -117,9 +117,6 @@ export function RecorderHelp({
             <HelpSection key={section.title} section={section} />
           ))}
         </div>
-        <footer className="border-t border-neutral-700 px-8 py-4 text-xs text-neutral-400">
-          Recorder shortcuts are inactive while help is open.
-        </footer>
       </div>
     </dialog>
   );

--- a/src/components/recorder/help.tsx
+++ b/src/components/recorder/help.tsx
@@ -4,7 +4,6 @@ import { useEffect, useRef } from "react";
 type HelpSectionData = {
   title: string;
   items: { action: string; keys?: string; gesture?: string }[];
-  note?: string;
 };
 
 const sections: HelpSectionData[] = [
@@ -16,7 +15,6 @@ const sections: HelpSectionData[] = [
       { action: "Seek backward / forward 5 seconds", keys: "Left / Right" },
       { action: "Toggle metronome", keys: "M" },
     ],
-    note: "Space also stops an active recording. Arrow-key seeking is unavailable while recording or processing.",
   },
   {
     title: "Move around",
@@ -44,7 +42,6 @@ const sections: HelpSectionData[] = [
       { action: "Remove selected clips", keys: "Delete / Backspace" },
       { action: "Clear selection", keys: "Esc" },
     ],
-    note: "Drag a selected clip to move the group together.",
   },
   {
     title: "Mark and save",
@@ -93,18 +90,13 @@ export function RecorderHelp({
       }}
     >
       <div>
-        <header className="flex items-start justify-between gap-5 border-b border-neutral-700 px-8 py-6">
-          <div>
-            <h2
-              id="recorder-help-title"
-              className="text-2xl font-semibold tracking-tight"
-            >
-              Recorder quick reference
-            </h2>
-            <p className="mt-2 text-[13px] text-neutral-400">
-              The keys and gestures for recording, navigating, and editing.
-            </p>
-          </div>
+        <header className="flex items-center justify-between gap-5 border-b border-neutral-700 px-8 py-6">
+          <h2
+            id="recorder-help-title"
+            className="text-2xl font-semibold tracking-tight"
+          >
+            Recorder quick reference
+          </h2>
           <button
             type="button"
             onClick={onClose}
@@ -144,11 +136,6 @@ function HelpSection({ section }: { section: HelpSectionData }) {
           </div>
         ))}
       </dl>
-      {section.note && (
-        <p className="mt-2 text-xs leading-relaxed text-neutral-400">
-          {section.note}
-        </p>
-      )}
     </section>
   );
 }

--- a/src/components/recorder/help.tsx
+++ b/src/components/recorder/help.tsx
@@ -19,7 +19,10 @@ const sections: {
   {
     title: "Move around",
     items: [
-      { action: "Scroll timeline horizontally", gesture: "Wheel over timeline" },
+      {
+        action: "Scroll timeline horizontally",
+        gesture: "Wheel over timeline",
+      },
       { action: "Zoom at pointer", keys: "Ctrl", gesture: " + wheel" },
       { action: "Seek to a position", gesture: "Click ruler / empty lane" },
       { action: "Toggle follow playhead", keys: "F" },

--- a/src/components/recorder/help.tsx
+++ b/src/components/recorder/help.tsx
@@ -8,28 +8,28 @@ type HelpSectionData = {
 
 const sections: HelpSectionData[] = [
   {
-    title: "Play and record",
+    title: "Transport",
     items: [
       { action: "Play / pause", keys: "Space" },
       { action: "Start / stop recording", keys: "R" },
-      { action: "Seek backward / forward 5 seconds", keys: "Left / Right" },
       { action: "Toggle metronome", keys: "M" },
     ],
   },
   {
-    title: "Move around",
+    title: "Timeline",
     items: [
+      { action: "Seek to a position", gesture: "Click ruler / empty lane" },
+      { action: "Seek backward / forward 5 seconds", keys: "Left / Right" },
       {
         action: "Scroll timeline horizontally",
         gesture: "Wheel over timeline",
       },
       { action: "Zoom at pointer", keys: "Ctrl", gesture: " + wheel" },
-      { action: "Seek to a position", gesture: "Click ruler / empty lane" },
       { action: "Toggle follow playhead", keys: "F" },
     ],
   },
   {
-    title: "Work with clips",
+    title: "Clips",
     items: [
       { action: "Select a clip", gesture: "Click clip" },
       {
@@ -44,11 +44,16 @@ const sections: HelpSectionData[] = [
     ],
   },
   {
-    title: "Mark and save",
+    title: "Locators",
     items: [
       { action: "Add locator at playhead", keys: "L" },
+      { action: "Select and seek to locator", gesture: "Click locator" },
+      { action: "Move locator", gesture: "Drag locator" },
+      {
+        action: "Rename locator",
+        gesture: "Hover / select, then click pencil",
+      },
       { action: "Remove selected locator", keys: "Delete / Backspace" },
-      { action: "Save project", keys: "Ctrl / Cmd + S" },
     ],
   },
 ];
@@ -106,10 +111,18 @@ export function RecorderHelp({
             <XIcon className="size-5" />
           </button>
         </header>
-        <div className="grid grid-cols-2 gap-x-10 gap-y-7 px-8 py-7">
-          {sections.map((section) => (
-            <HelpSection key={section.title} section={section} />
-          ))}
+        <div className="px-8 py-7">
+          <div className="columns-2 gap-10">
+            {sections.map((section) => (
+              <HelpSection key={section.title} section={section} />
+            ))}
+          </div>
+          <dl className="flex items-center justify-between gap-3 border-t border-neutral-700 pt-4">
+            <dt className="text-[13px] text-neutral-200">Save project</dt>
+            <dd>
+              <kbd className={keyClassName}>Ctrl / Cmd + S</kbd>
+            </dd>
+          </dl>
         </div>
       </div>
     </dialog>
@@ -118,7 +131,7 @@ export function RecorderHelp({
 
 function HelpSection({ section }: { section: HelpSectionData }) {
   return (
-    <section>
+    <section className="mb-7 break-inside-avoid">
       <h3 className="mb-3 text-sm font-semibold text-emerald-300">
         {section.title}
       </h3>

--- a/src/components/recorder/help.tsx
+++ b/src/components/recorder/help.tsx
@@ -56,6 +56,10 @@ const sections: HelpSectionData[] = [
       { action: "Remove selected locator", keys: "Delete / Backspace" },
     ],
   },
+  {
+    title: "Project",
+    items: [{ action: "Save project", keys: "Ctrl / Cmd + S" }],
+  },
 ];
 
 const keyClassName =
@@ -111,18 +115,10 @@ export function RecorderHelp({
             <XIcon className="size-5" />
           </button>
         </header>
-        <div className="px-8 py-7">
-          <div className="columns-2 gap-10">
-            {sections.map((section) => (
-              <HelpSection key={section.title} section={section} />
-            ))}
-          </div>
-          <dl className="flex items-center justify-between gap-3 border-t border-neutral-700 pt-4">
-            <dt className="text-[13px] text-neutral-200">Save project</dt>
-            <dd>
-              <kbd className={keyClassName}>Ctrl / Cmd + S</kbd>
-            </dd>
-          </dl>
+        <div className="columns-2 gap-10 px-8 py-7">
+          {sections.map((section) => (
+            <HelpSection key={section.title} section={section} />
+          ))}
         </div>
       </div>
     </dialog>

--- a/src/components/recorder/help.tsx
+++ b/src/components/recorder/help.tsx
@@ -107,9 +107,8 @@ export function RecorderHelp({
             type="button"
             onClick={onClose}
             aria-label="Close help"
-            className="flex items-center gap-2.5 text-neutral-400 hover:text-neutral-100"
+            className="text-neutral-400 hover:text-neutral-100"
           >
-            <kbd className={keyClassName}>Esc</kbd>
             <XIcon className="size-5" />
           </button>
         </header>

--- a/src/components/recorder/help.tsx
+++ b/src/components/recorder/help.tsx
@@ -115,34 +115,7 @@ export function RecorderHelp({
         </header>
         <div className="grid grid-cols-2 gap-x-10 gap-y-7 px-8 py-7">
           {sections.map((section) => (
-            <section key={section.title}>
-              <h3 className="mb-3 text-sm font-semibold text-emerald-300">
-                {section.title}
-              </h3>
-              <dl>
-                {section.items.map((item) => (
-                  <div
-                    key={item.action}
-                    className="flex min-h-[34px] items-center justify-between gap-3"
-                  >
-                    <dt className="text-[13px] text-neutral-200">
-                      {item.action}
-                    </dt>
-                    <dd className="flex shrink-0 items-center gap-1 whitespace-nowrap text-xs text-neutral-400">
-                      {item.keys && (
-                        <kbd className={keyClassName}>{item.keys}</kbd>
-                      )}
-                      {item.gesture}
-                    </dd>
-                  </div>
-                ))}
-              </dl>
-              {section.note && (
-                <p className="mt-2 text-xs leading-relaxed text-neutral-400">
-                  {section.note}
-                </p>
-              )}
-            </section>
+            <HelpSection key={section.title} section={section} />
           ))}
         </div>
         <footer className="flex items-center justify-between gap-4 border-t border-neutral-700 px-8 py-4 text-xs text-neutral-400">
@@ -153,5 +126,34 @@ export function RecorderHelp({
         </footer>
       </div>
     </dialog>
+  );
+}
+
+function HelpSection({ section }: { section: (typeof sections)[number] }) {
+  return (
+    <section>
+      <h3 className="mb-3 text-sm font-semibold text-emerald-300">
+        {section.title}
+      </h3>
+      <dl>
+        {section.items.map((item) => (
+          <div
+            key={item.action}
+            className="flex min-h-[34px] items-center justify-between gap-3"
+          >
+            <dt className="text-[13px] text-neutral-200">{item.action}</dt>
+            <dd className="flex shrink-0 items-center gap-1 whitespace-nowrap text-xs text-neutral-400">
+              {item.keys && <kbd className={keyClassName}>{item.keys}</kbd>}
+              {item.gesture}
+            </dd>
+          </div>
+        ))}
+      </dl>
+      {section.note && (
+        <p className="mt-2 text-xs leading-relaxed text-neutral-400">
+          {section.note}
+        </p>
+      )}
+    </section>
   );
 }

--- a/src/components/recorder/help.tsx
+++ b/src/components/recorder/help.tsx
@@ -62,9 +62,6 @@ const sections: HelpSectionData[] = [
   },
 ];
 
-const keyClassName =
-  "whitespace-nowrap rounded border border-b-2 border-neutral-600 bg-neutral-700/60 px-1.5 py-0.5 font-sans text-[11px] text-neutral-300";
-
 export function RecorderHelp({
   isOpen,
   onClose,
@@ -139,7 +136,11 @@ function HelpSection({ section }: { section: HelpSectionData }) {
           >
             <dt className="text-[13px] text-neutral-200">{item.action}</dt>
             <dd className="flex shrink-0 items-center gap-1 whitespace-nowrap text-xs text-neutral-400">
-              {item.keys && <kbd className={keyClassName}>{item.keys}</kbd>}
+              {item.keys && (
+                <kbd className="whitespace-nowrap rounded border border-b-2 border-neutral-600 bg-neutral-700/60 px-1.5 py-0.5 font-sans text-[11px] text-neutral-300">
+                  {item.keys}
+                </kbd>
+              )}
               {item.gesture}
             </dd>
           </div>

--- a/src/components/recorder/help.tsx
+++ b/src/components/recorder/help.tsx
@@ -73,7 +73,7 @@ export function RecorderHelp({
       isOpen={isOpen}
       onClose={onClose}
       title="Recorder quick reference"
-      widthClassName="max-w-[960px]"
+      size="wide"
     >
       <div className="max-h-[calc(90vh-8rem)] overflow-y-auto">
         <div className="columns-2 gap-10">

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -600,7 +600,10 @@ export function Recorder({ projectId }: { projectId: string }) {
           </div>
         </section>
 
-        <RecorderHelp isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} />
+        <RecorderHelp
+          isOpen={isHelpOpen}
+          onClose={() => setIsHelpOpen(false)}
+        />
         <RecorderExportDialog
           runtime={runtime}
           state={state}

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -154,10 +154,7 @@ export function Recorder({ projectId }: { projectId: string }) {
 
   useWindowEvent("keydown", (event) => {
     if (isHelpOpen) {
-      if (
-        !event.repeat &&
-        (event.key === "?" || matchKeyboardEvent(event, "Escape"))
-      ) {
+      if (!event.repeat && matchKeyboardEvent(event, "Escape")) {
         event.preventDefault();
         setIsHelpOpen(false);
       }
@@ -177,11 +174,6 @@ export function Recorder({ projectId }: { projectId: string }) {
       return;
     }
     if (isShortcutTextInputTarget(event.target) || event.repeat) {
-      return;
-    }
-    if (event.key === "?") {
-      event.preventDefault();
-      setIsHelpOpen(true);
       return;
     }
     if (matchKeyboardEvent(event, "L")) {

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -13,6 +13,7 @@ import { beatsToSeconds } from "../../lib/timeline";
 import { encodeWav } from "../../lib/wav";
 import { parseTimeSignature } from "../../types";
 import { Dialog } from "../ui/dialog";
+import { RecorderHelp } from "./help";
 import { RecorderExportDialog } from "./recorder-export-dialog";
 import { RecorderHeader } from "./recorder-header";
 import { InputSetup } from "./recorder-input";
@@ -45,6 +46,7 @@ export function Recorder({ projectId }: { projectId: string }) {
   const [takesExpanded, setTakesExpanded] = useState(false);
   const [isMixerOpen, setIsMixerOpen] = useState(false);
   const [isAudioExportOpen, setIsAudioExportOpen] = useState(false);
+  const [isHelpOpen, setIsHelpOpen] = useState(false);
   const state = useSyncExternalStore(
     runtime.store.subscribe,
     runtime.store.get,
@@ -151,6 +153,19 @@ export function Recorder({ projectId }: { projectId: string }) {
     isProcessing;
 
   useWindowEvent("keydown", (event) => {
+    if (isHelpOpen) {
+      if (
+        !event.repeat &&
+        (event.key === "?" || matchKeyboardEvent(event, "Escape"))
+      ) {
+        event.preventDefault();
+        setIsHelpOpen(false);
+      }
+      if (matchKeyboardEvent(event, "Ctrl+S")) {
+        event.preventDefault();
+      }
+      return;
+    }
     if (isAudioExportOpen) {
       return;
     }
@@ -162,6 +177,11 @@ export function Recorder({ projectId }: { projectId: string }) {
       return;
     }
     if (isShortcutTextInputTarget(event.target) || event.repeat) {
+      return;
+    }
+    if (event.key === "?") {
+      event.preventDefault();
+      setIsHelpOpen(true);
       return;
     }
     if (matchKeyboardEvent(event, "L")) {
@@ -262,6 +282,7 @@ export function Recorder({ projectId }: { projectId: string }) {
         onReferenceVideoOpenChange={setIsReferenceVideoOpen}
         mixerOpen={isMixerOpen}
         onMixerToggle={() => setIsMixerOpen((open) => !open)}
+        onHelpOpen={() => setIsHelpOpen(true)}
       />
 
       <div className="flex min-h-0 flex-1 flex-col">
@@ -579,6 +600,7 @@ export function Recorder({ projectId }: { projectId: string }) {
           </div>
         </section>
 
+        <RecorderHelp isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} />
         <RecorderExportDialog
           runtime={runtime}
           state={state}

--- a/src/components/recorder/recorder-header.tsx
+++ b/src/components/recorder/recorder-header.tsx
@@ -1,6 +1,7 @@
 import {
   ChevronDownIcon,
   CircleAlertIcon,
+  CircleHelpIcon,
   CircleIcon,
   CircleStopIcon,
   DownloadIcon,
@@ -86,6 +87,7 @@ export function RecorderHeader({
   onExportAudio,
   onReferenceVideoOpenChange,
   onMixerToggle,
+  onHelpOpen,
   mixerOpen,
 }: {
   title: string;
@@ -123,6 +125,7 @@ export function RecorderHeader({
   onExportAudio: () => void;
   onReferenceVideoOpenChange: (open: boolean) => void;
   onMixerToggle: () => void;
+  onHelpOpen: () => void;
   mixerOpen: boolean;
 }) {
   const timeSignatureValue = `${timeSignature.numerator}/${timeSignature.denominator}`;
@@ -434,6 +437,10 @@ export function RecorderHeader({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={onHelpOpen}>
+            <CircleHelpIcon />
+            Help &amp; Shortcuts
+          </DropdownMenuItem>
           <DropdownMenuItem
             disabled={isRecording || isProcessing}
             onSelect={onExportAudio}

--- a/src/components/recorder/recorder-header.tsx
+++ b/src/components/recorder/recorder-header.tsx
@@ -394,7 +394,7 @@ export function RecorderHeader({
         <DropdownMenuContent align="end">
           <DropdownMenuItem onSelect={onHelpOpen}>
             <CircleHelpIcon />
-            Help &amp; Shortcuts
+            Help & Shortcuts
           </DropdownMenuItem>
           <DropdownMenuItem
             disabled={isRecording || isProcessing}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,5 +1,6 @@
 import { XIcon } from "lucide-react";
 import type { ReactNode } from "react";
+import { cn } from "./utils";
 
 type DialogProps = {
   isOpen: boolean;
@@ -7,6 +8,7 @@ type DialogProps = {
   title: string;
   children: ReactNode;
   testId?: string;
+  widthClassName?: string;
 };
 
 export function Dialog({
@@ -15,6 +17,7 @@ export function Dialog({
   title,
   children,
   testId,
+  widthClassName = "max-w-md",
 }: DialogProps) {
   if (!isOpen) {
     return null;
@@ -27,7 +30,10 @@ export function Dialog({
       onClick={onClose}
     >
       <div
-        className="bg-neutral-800 rounded-lg shadow-2xl w-full max-w-md"
+        className={cn(
+          "bg-neutral-800 rounded-lg shadow-2xl w-full",
+          widthClassName,
+        )}
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -8,7 +8,7 @@ type DialogProps = {
   title: string;
   children: ReactNode;
   testId?: string;
-  widthClassName?: string;
+  size?: "default" | "wide";
 };
 
 export function Dialog({
@@ -17,7 +17,7 @@ export function Dialog({
   title,
   children,
   testId,
-  widthClassName = "max-w-md",
+  size = "default",
 }: DialogProps) {
   if (!isOpen) {
     return null;
@@ -32,7 +32,7 @@ export function Dialog({
       <div
         className={cn(
           "bg-neutral-800 rounded-lg shadow-2xl w-full",
-          widthClassName,
+          size === "wide" ? "max-w-[960px]" : "max-w-md",
         )}
         onClick={(e) => e.stopPropagation()}
       >


### PR DESCRIPTION
- related to https://github.com/hi-ogawa/toy-midi/issues/338

Recorder shortcuts and clip gestures are not easy to discover from the visible controls alone. This PR adds a compact quick reference organized around transport, timeline, clips, locators, and project controls. The content stays local to the recorder and uses the shared Dialog with a width override.

Open it from More > Help & Shortcuts, and close it with Escape, the close button, or the backdrop. Recorder shortcuts are blocked while help is open without interrupting playback or recording or clearing selection.