### PR TITLE
feat: add tri-state recorder range split controls

### DIFF
--- a/e2e/fake-audio/recorder-loop-range.test.ts
+++ b/e2e/fake-audio/recorder-loop-range.test.ts
@@ -12,7 +12,8 @@ test("creates and edits a persisted loop range", async ({ page }) => {
 
   const toggle = page.getByTestId("recorder-loop-toggle");
   const range = page.getByTestId("recorder-loop-range");
-  await expect(toggle).toHaveAttribute("aria-pressed", "false");
+  await expect(toggle).toHaveAccessibleName("Loop: no range");
+  await expect(toggle).not.toHaveAttribute("aria-pressed");
   await expect(range).toHaveCount(0);
 
   // First activation creates and enables a loop range at the current bar.

--- a/e2e/fake-audio/recorder-range-controls.test.ts
+++ b/e2e/fake-audio/recorder-range-controls.test.ts
@@ -15,6 +15,7 @@ for (const kind of ["loop", "punch"] as const) {
     const range = page.getByTestId(`recorder-${kind}-range`);
     const menu = page.getByRole("button", { name: `${label} range actions` });
 
+    // With no range to clear, New creates and enables one bar at the playhead.
     await expect(toggle).toHaveAccessibleName(`${label}: no range`);
     await expect(toggle).not.toHaveAttribute("aria-pressed");
     await menu.click();
@@ -40,6 +41,7 @@ for (const kind of ["loop", "punch"] as const) {
     await expect(range).toHaveCSS("width", "320px");
     await expect.poll(() => getRecorderBeat(page)).toBe(5);
 
+    // Clear returns to the unset state without moving the playhead.
     await menu.click();
     await page.getByRole("menuitem", { name: "Clear", exact: true }).click();
     await expect(range).toHaveCount(0);

--- a/e2e/fake-audio/recorder-range-controls.test.ts
+++ b/e2e/fake-audio/recorder-range-controls.test.ts
@@ -5,6 +5,8 @@ import {
   seekRecorderByPixels,
 } from "./recorder-helpers";
 
+const BEAT_WIDTH = 80;
+
 for (const kind of ["loop", "punch"] as const) {
   test(`${kind} menu creates, replaces, and clears its range`, async ({
     page,
@@ -25,20 +27,20 @@ for (const kind of ["loop", "punch"] as const) {
     await page.getByRole("menuitem", { name: "New", exact: true }).click();
     await expect(toggle).toHaveAttribute("aria-pressed", "true");
     await expect(range).toHaveCSS("left", "0px");
-    await expect(range).toHaveCSS("width", "320px");
+    await expect(range).toHaveCSS("width", `${BEAT_WIDTH * 4}px`);
     await expect.poll(() => getRecorderBeat(page)).toBe(0);
 
     // New replaces the disabled range at the playhead's bar and enables it.
     await toggle.click();
     await expect(toggle).toHaveAttribute("aria-pressed", "false");
-    await seekRecorderByPixels(page, 400);
+    await seekRecorderByPixels(page, BEAT_WIDTH * 5);
     await expect.poll(() => getRecorderBeat(page)).toBe(5);
     await menu.click();
     await page.getByRole("menuitem", { name: "New", exact: true }).click();
     await expect(toggle).toHaveAttribute("aria-pressed", "true");
     await expect(range).toHaveCount(1);
-    await expect(range).toHaveCSS("left", "320px");
-    await expect(range).toHaveCSS("width", "320px");
+    await expect(range).toHaveCSS("left", `${BEAT_WIDTH * 4}px`);
+    await expect(range).toHaveCSS("width", `${BEAT_WIDTH * 4}px`);
     await expect.poll(() => getRecorderBeat(page)).toBe(5);
 
     // Clear returns to the unset state without moving the playhead.

--- a/e2e/fake-audio/recorder-range-controls.test.ts
+++ b/e2e/fake-audio/recorder-range-controls.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+import {
+  createRecorderProject,
+  getRecorderBeat,
+  seekRecorderByPixels,
+} from "./recorder-helpers";
+
+for (const kind of ["loop", "punch"] as const) {
+  test(`${kind} menu creates, replaces, and clears its range`, async ({
+    page,
+  }) => {
+    await createRecorderProject(page);
+    const label = kind === "loop" ? "Loop" : "Punch";
+    const toggle = page.getByTestId(`recorder-${kind}-toggle`);
+    const range = page.getByTestId(`recorder-${kind}-range`);
+    const menu = page.getByRole("button", { name: `${label} range actions` });
+
+    await expect(toggle).toHaveAccessibleName(`${label}: no range`);
+    await expect(toggle).not.toHaveAttribute("aria-pressed");
+    await menu.click();
+    await expect(
+      page.getByRole("menuitem", { name: "Clear", exact: true }),
+    ).toBeDisabled();
+    await page.getByRole("menuitem", { name: "New", exact: true }).click();
+    await expect(toggle).toHaveAttribute("aria-pressed", "true");
+    await expect(range).toHaveCSS("left", "0px");
+    await expect(range).toHaveCSS("width", "320px");
+    await expect.poll(() => getRecorderBeat(page)).toBe(0);
+
+    // New replaces the disabled range at the playhead's bar and enables it.
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-pressed", "false");
+    await seekRecorderByPixels(page, 400);
+    await expect.poll(() => getRecorderBeat(page)).toBe(5);
+    await menu.click();
+    await page.getByRole("menuitem", { name: "New", exact: true }).click();
+    await expect(toggle).toHaveAttribute("aria-pressed", "true");
+    await expect(range).toHaveCount(1);
+    await expect(range).toHaveCSS("left", "320px");
+    await expect(range).toHaveCSS("width", "320px");
+    await expect.poll(() => getRecorderBeat(page)).toBe(5);
+
+    await menu.click();
+    await page.getByRole("menuitem", { name: "Clear", exact: true }).click();
+    await expect(range).toHaveCount(0);
+    await expect(toggle).toHaveAccessibleName(`${label}: no range`);
+    await expect(toggle).not.toHaveAttribute("aria-pressed");
+    await expect.poll(() => getRecorderBeat(page)).toBe(5);
+  });
+}

--- a/src/components/recorder/recorder-header.tsx
+++ b/src/components/recorder/recorder-header.tsx
@@ -7,7 +7,6 @@ import {
   HouseIcon,
   LoaderCircleIcon,
   LocateFixedIcon,
-  Repeat2Icon,
   Mic2Icon,
   MoreVerticalIcon,
   PauseIcon,
@@ -19,7 +18,7 @@ import {
 } from "lucide-react";
 import { useDraftInput } from "../../hooks/use-draft-input";
 import { useTapTempo } from "../../hooks/use-tap-tempo";
-import { formatGainDb, snapToGrid } from "../../lib/music";
+import { formatGainDb } from "../../lib/music";
 import type {
   RecorderLoopState,
   RecorderPunchState,
@@ -28,7 +27,6 @@ import { routes } from "../../lib/routes";
 import { formatTimeWithMilliseconds } from "../../lib/time-format";
 import {
   formatBarBeatAtTime,
-  getBeatsPerBar,
   secondsToBeats,
   type GridDivision,
   GRID_DIVISIONS,
@@ -46,6 +44,7 @@ import {
 } from "../ui/dropdown-menu";
 import { cn } from "../ui/utils";
 import { RecorderGainSlider } from "./recorder-mixer";
+import { RecorderRangeControl } from "./recorder-range-control";
 import type { SaveStatus } from "./use-recorder-project";
 
 const PLAYBACK_RATES = [0.5, 0.75, 1, 1.25, 1.5];
@@ -181,66 +180,22 @@ export function RecorderHeader({
         )}
       </Button>
       <div className="mx-1 h-5 w-px bg-neutral-600" />
-      <Button
-        data-testid="recorder-loop-toggle"
-        onClick={() => {
-          const enabled = !loop.enabled;
-          const beatsPerBar = getBeatsPerBar(timeSignature);
-          const startBeat = snapToGrid(
-            secondsToBeats(position, tempo),
-            beatsPerBar,
-            { floor: true },
-          );
-          onLoopChange({
-            enabled,
-            range:
-              loop.range ??
-              (enabled
-                ? { startBeat, endBeat: startBeat + beatsPerBar }
-                : undefined),
-          });
-        }}
-        aria-pressed={loop.enabled}
-        title={loop.range ? "Toggle loop playback" : "Create loop range"}
-        className={cn(
-          "size-9",
-          loop.enabled
-            ? "bg-violet-500/20 text-violet-200 hover:bg-violet-500/30"
-            : "text-neutral-300 hover:bg-neutral-700/50 hover:text-neutral-100",
-        )}
-      >
-        <Repeat2Icon className="size-5" />
-      </Button>
-      <Button
-        data-testid="recorder-punch-toggle"
-        onClick={() => {
-          const enabled = !punch.enabled;
-          const beatsPerBar = getBeatsPerBar(timeSignature);
-          const startBeat = snapToGrid(
-            secondsToBeats(position, tempo),
-            beatsPerBar,
-            { floor: true },
-          );
-          onPunchChange({
-            enabled,
-            range:
-              punch.range ??
-              (enabled
-                ? { startBeat, endBeat: startBeat + beatsPerBar }
-                : undefined),
-          });
-        }}
-        aria-pressed={punch.enabled}
-        title={punch.range ? "Toggle punch recording" : "Create punch range"}
-        className={cn(
-          "h-9 gap-1.5 px-2.5 text-xs font-medium",
-          punch.enabled
-            ? "bg-amber-500/20 text-amber-300 hover:bg-amber-500/25"
-            : "text-neutral-300 hover:bg-neutral-700/50 hover:text-neutral-100",
-        )}
-      >
-        Punch
-      </Button>
+      <RecorderRangeControl
+        kind="loop"
+        state={loop}
+        position={position}
+        tempo={tempo}
+        timeSignature={timeSignature}
+        onChange={onLoopChange}
+      />
+      <RecorderRangeControl
+        kind="punch"
+        state={punch}
+        position={position}
+        tempo={tempo}
+        timeSignature={timeSignature}
+        onChange={onPunchChange}
+      />
       <Button
         onClick={() => onMetronomeChange(!metronomeEnabled)}
         aria-pressed={metronomeEnabled}

--- a/src/components/recorder/recorder-range-control.tsx
+++ b/src/components/recorder/recorder-range-control.tsx
@@ -72,7 +72,7 @@ export function RecorderRangeControl({
             <ChevronDownIcon className="size-3" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="min-w-0!">
+        <DropdownMenuContent align="end" className="w-15 min-w-0!">
           <DropdownMenuItem onSelect={setAtPlayhead}>New</DropdownMenuItem>
           <DropdownMenuItem
             disabled={!state.range}

--- a/src/components/recorder/recorder-range-control.tsx
+++ b/src/components/recorder/recorder-range-control.tsx
@@ -72,10 +72,7 @@ export function RecorderRangeControl({
             <ChevronDownIcon className="size-3" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent
-          align="center"
-          className="relative -left-[17px] min-w-0!"
-        >
+        <DropdownMenuContent align="end" className="min-w-0!">
           <DropdownMenuItem onSelect={setAtPlayhead}>New</DropdownMenuItem>
           <DropdownMenuItem
             disabled={!state.range}

--- a/src/components/recorder/recorder-range-control.tsx
+++ b/src/components/recorder/recorder-range-control.tsx
@@ -73,9 +73,7 @@ export function RecorderRangeControl({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start">
-          <DropdownMenuItem onSelect={setAtPlayhead}>
-            {state.range ? "Recreate" : "Create"}
-          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={setAtPlayhead}>New</DropdownMenuItem>
           <DropdownMenuItem
             disabled={!state.range}
             onSelect={() => onChange({ range: undefined, enabled: false })}

--- a/src/components/recorder/recorder-range-control.tsx
+++ b/src/components/recorder/recorder-range-control.tsx
@@ -1,0 +1,112 @@
+import { ChevronDownIcon, Repeat2Icon } from "lucide-react";
+import type { RecorderLoopState } from "../../lib/recorder/runtime";
+import { getBeatsPerBar, secondsToBeats } from "../../lib/timeline";
+import type { TimeSignature } from "../../types";
+import { Button } from "../ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
+import { cn } from "../ui/utils";
+
+export function RecorderRangeControl({
+  kind,
+  state,
+  position,
+  tempo,
+  timeSignature,
+  onChange,
+}: {
+  kind: "loop" | "punch";
+  state: RecorderLoopState;
+  position: number;
+  tempo: number;
+  timeSignature: TimeSignature;
+  onChange: (update: Partial<RecorderLoopState>) => void;
+}) {
+  const label = kind === "loop" ? "Loop" : "Punch";
+  const status = !state.range ? "No range" : state.enabled ? "On" : "Off";
+  const description = state.range
+    ? `${label}: ${status.toLowerCase()}. Range ${formatPosition(state.range.startBeat)} to ${formatPosition(state.range.endBeat)} (bar:beat). Click to ${state.enabled ? "disable" : "enable"}.`
+    : `${label}: no range. Click to create and enable one bar at the playhead.`;
+
+  return (
+    <div
+      className={cn(
+        "flex h-9 shrink-0 rounded-md border border-neutral-600",
+        kind === "loop" ? "w-15" : "w-22",
+      )}
+    >
+      <Button
+        data-testid={`recorder-${kind}-toggle`}
+        aria-label={description}
+        aria-pressed={state.range ? state.enabled : undefined}
+        title={description}
+        onClick={() => {
+          if (state.range) {
+            onChange({ enabled: !state.enabled });
+          } else {
+            setAtPlayhead();
+          }
+        }}
+        className={cn(
+          "min-w-0 flex-1 rounded-r-none border-0 px-2 text-xs font-medium",
+          !state.range
+            ? "text-neutral-400 hover:bg-neutral-700"
+            : kind === "loop"
+              ? state.enabled
+                ? "bg-violet-500/20 text-violet-200 hover:bg-violet-500/30"
+                : "text-violet-300 hover:bg-neutral-700"
+              : state.enabled
+                ? "bg-amber-500/20 text-amber-300 hover:bg-amber-500/30"
+                : "text-amber-300 hover:bg-neutral-700",
+        )}
+      >
+        {kind === "loop" ? <Repeat2Icon className="size-5 shrink-0" /> : label}
+      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            aria-label={`${label} range actions`}
+            className="w-6 shrink-0 rounded-l-none border-0 border-l border-neutral-600 text-neutral-400 hover:bg-neutral-700"
+          >
+            <ChevronDownIcon className="size-3" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuItem onSelect={setAtPlayhead}>
+            {state.range
+              ? "Reset at playhead (one bar)"
+              : "Set at playhead (one bar)"}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            disabled={!state.range}
+            onSelect={() => onChange({ range: undefined, enabled: false })}
+          >
+            Clear range
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+
+  function setAtPlayhead() {
+    const beatsPerBar = getBeatsPerBar(timeSignature);
+    const startBeat =
+      Math.floor(secondsToBeats(position, tempo) / beatsPerBar) * beatsPerBar;
+    onChange({
+      range: { startBeat, endBeat: startBeat + beatsPerBar },
+      enabled: state.range ? state.enabled : true,
+    });
+  }
+
+  function formatPosition(beat: number) {
+    const beatsPerBar = getBeatsPerBar(timeSignature);
+    const bar = Math.floor(beat / beatsPerBar);
+    const beatInBar =
+      1 + (beat - bar * beatsPerBar) / (4 / timeSignature.denominator);
+    return `${bar + 1}:${Number(beatInBar.toFixed(6))}`;
+  }
+}

--- a/src/components/recorder/recorder-range-control.tsx
+++ b/src/components/recorder/recorder-range-control.tsx
@@ -72,7 +72,7 @@ export function RecorderRangeControl({
             <ChevronDownIcon className="size-3" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start">
+        <DropdownMenuContent align="end">
           <DropdownMenuItem onSelect={setAtPlayhead}>New</DropdownMenuItem>
           <DropdownMenuItem
             disabled={!state.range}

--- a/src/components/recorder/recorder-range-control.tsx
+++ b/src/components/recorder/recorder-range-control.tsx
@@ -1,4 +1,9 @@
-import { ChevronDownIcon, Repeat2Icon, ScanLineIcon } from "lucide-react";
+import {
+  ChevronDownIcon,
+  PlusIcon,
+  Repeat2Icon,
+  ScanLineIcon,
+} from "lucide-react";
 import type { RecorderLoopState } from "../../lib/recorder/runtime";
 import { getBeatsPerBar, secondsToBeats } from "../../lib/timeline";
 import type { TimeSignature } from "../../types";
@@ -55,22 +60,25 @@ export function RecorderRangeControl({
           }
         }}
         className={cn(
-          "min-w-0 flex-1 rounded-r-none border-0 px-2 text-xs font-medium",
-          !state.range
-            ? "text-neutral-400 hover:bg-neutral-700"
-            : kind === "loop"
-              ? state.enabled
-                ? "bg-violet-500/20 text-violet-200 hover:bg-violet-500/30"
-                : "text-violet-300 hover:bg-neutral-700"
-              : state.enabled
-                ? "bg-amber-500/20 text-amber-300 hover:bg-amber-500/30"
-                : "text-amber-300 hover:bg-neutral-700",
+          "relative min-w-0 flex-1 rounded-r-none border-0 px-2 text-xs font-medium",
+          state.range && state.enabled
+            ? kind === "loop"
+              ? "bg-violet-500/20 text-violet-200 hover:bg-violet-500/30"
+              : "bg-amber-500/20 text-amber-300 hover:bg-amber-500/30"
+            : "text-neutral-300 hover:bg-neutral-700",
         )}
       >
         {kind === "loop" ? (
           <Repeat2Icon className="size-5 shrink-0" />
         ) : (
           <ScanLineIcon className="size-5 shrink-0" />
+        )}
+        {!state.range && (
+          <PlusIcon
+            aria-hidden="true"
+            className="absolute right-0.5 bottom-0.5 size-3 rounded-sm bg-neutral-800"
+            strokeWidth={3}
+          />
         )}
       </Button>
       <DropdownMenu>

--- a/src/components/recorder/recorder-range-control.tsx
+++ b/src/components/recorder/recorder-range-control.tsx
@@ -72,7 +72,10 @@ export function RecorderRangeControl({
             <ChevronDownIcon className="size-3" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
+        <DropdownMenuContent
+          align="center"
+          className="relative -left-[17px] min-w-24"
+        >
           <DropdownMenuItem onSelect={setAtPlayhead}>New</DropdownMenuItem>
           <DropdownMenuItem
             disabled={!state.range}

--- a/src/components/recorder/recorder-range-control.tsx
+++ b/src/components/recorder/recorder-range-control.tsx
@@ -1,9 +1,4 @@
-import {
-  ChevronDownIcon,
-  PlusIcon,
-  Repeat2Icon,
-  ScanLineIcon,
-} from "lucide-react";
+import { ChevronDownIcon, Repeat2Icon, ScanLineIcon } from "lucide-react";
 import type { RecorderLoopState } from "../../lib/recorder/runtime";
 import { getBeatsPerBar, secondsToBeats } from "../../lib/timeline";
 import type { TimeSignature } from "../../types";
@@ -60,25 +55,20 @@ export function RecorderRangeControl({
           }
         }}
         className={cn(
-          "relative min-w-0 flex-1 rounded-r-none border-0 px-2 text-xs font-medium",
-          state.range && state.enabled
-            ? kind === "loop"
-              ? "bg-violet-500/20 text-violet-200 hover:bg-violet-500/30"
-              : "bg-amber-500/20 text-amber-300 hover:bg-amber-500/30"
-            : "text-neutral-300 hover:bg-neutral-700",
+          "min-w-0 flex-1 rounded-r-none border-0 px-2 text-xs font-medium",
+          !state.range
+            ? "text-neutral-500 hover:bg-neutral-700 hover:text-neutral-300"
+            : !state.enabled
+              ? "bg-neutral-400/10 text-neutral-300 hover:bg-neutral-400/20"
+              : kind === "loop"
+                ? "bg-violet-500/20 text-violet-200 hover:bg-violet-500/30"
+                : "bg-amber-500/20 text-amber-300 hover:bg-amber-500/30",
         )}
       >
         {kind === "loop" ? (
           <Repeat2Icon className="size-5 shrink-0" />
         ) : (
           <ScanLineIcon className="size-5 shrink-0" />
-        )}
-        {!state.range && (
-          <PlusIcon
-            aria-hidden="true"
-            className="absolute right-0.5 bottom-0.5 size-3 rounded-sm bg-neutral-800"
-            strokeWidth={3}
-          />
         )}
       </Button>
       <DropdownMenu>

--- a/src/components/recorder/recorder-range-control.tsx
+++ b/src/components/recorder/recorder-range-control.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon, Repeat2Icon } from "lucide-react";
+import { ChevronDownIcon, Repeat2Icon, ScanLineIcon } from "lucide-react";
 import type { RecorderLoopState } from "../../lib/recorder/runtime";
 import { getBeatsPerBar, secondsToBeats } from "../../lib/timeline";
 import type { TimeSignature } from "../../types";
@@ -31,12 +31,7 @@ export function RecorderRangeControl({
   const description = `${label}: ${status.toLowerCase()}`;
 
   return (
-    <div
-      className={cn(
-        "flex h-9 shrink-0 rounded-md border border-neutral-600",
-        kind === "loop" ? "w-15" : "w-22",
-      )}
-    >
+    <div className="flex h-9 w-15 shrink-0 rounded-md border border-neutral-600">
       <Button
         data-testid={`recorder-${kind}-toggle`}
         aria-label={description}
@@ -62,7 +57,11 @@ export function RecorderRangeControl({
                 : "text-amber-300 hover:bg-neutral-700",
         )}
       >
-        {kind === "loop" ? <Repeat2Icon className="size-5 shrink-0" /> : label}
+        {kind === "loop" ? (
+          <Repeat2Icon className="size-5 shrink-0" />
+        ) : (
+          <ScanLineIcon className="size-5 shrink-0" />
+        )}
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>

--- a/src/components/recorder/recorder-range-control.tsx
+++ b/src/components/recorder/recorder-range-control.tsx
@@ -77,15 +77,13 @@ export function RecorderRangeControl({
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start">
           <DropdownMenuItem onSelect={setAtPlayhead}>
-            {state.range
-              ? "Reset at playhead (one bar)"
-              : "Set at playhead (one bar)"}
+            {state.range ? "Recreate" : "Create"}
           </DropdownMenuItem>
           <DropdownMenuItem
             disabled={!state.range}
             onSelect={() => onChange({ range: undefined, enabled: false })}
           >
-            Clear range
+            Clear
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/components/recorder/recorder-range-control.tsx
+++ b/src/components/recorder/recorder-range-control.tsx
@@ -74,7 +74,7 @@ export function RecorderRangeControl({
         </DropdownMenuTrigger>
         <DropdownMenuContent
           align="center"
-          className="relative -left-[17px] min-w-24"
+          className="relative -left-[17px] min-w-0!"
         >
           <DropdownMenuItem onSelect={setAtPlayhead}>New</DropdownMenuItem>
           <DropdownMenuItem

--- a/src/components/recorder/recorder-range-control.tsx
+++ b/src/components/recorder/recorder-range-control.tsx
@@ -96,7 +96,7 @@ export function RecorderRangeControl({
       Math.floor(secondsToBeats(position, tempo) / beatsPerBar) * beatsPerBar;
     onChange({
       range: { startBeat, endBeat: startBeat + beatsPerBar },
-      enabled: state.range ? state.enabled : true,
+      enabled: true,
     });
   }
 

--- a/src/components/recorder/recorder-range-control.tsx
+++ b/src/components/recorder/recorder-range-control.tsx
@@ -28,9 +28,7 @@ export function RecorderRangeControl({
 }) {
   const label = kind === "loop" ? "Loop" : "Punch";
   const status = !state.range ? "No range" : state.enabled ? "On" : "Off";
-  const description = state.range
-    ? `${label}: ${status.toLowerCase()}. Range ${formatPosition(state.range.startBeat)} to ${formatPosition(state.range.endBeat)} (bar:beat). Click to ${state.enabled ? "disable" : "enable"}.`
-    : `${label}: no range. Click to create and enable one bar at the playhead.`;
+  const description = `${label}: ${status.toLowerCase()}`;
 
   return (
     <div
@@ -98,13 +96,5 @@ export function RecorderRangeControl({
       range: { startBeat, endBeat: startBeat + beatsPerBar },
       enabled: true,
     });
-  }
-
-  function formatPosition(beat: number) {
-    const beatsPerBar = getBeatsPerBar(timeSignature);
-    const bar = Math.floor(beat / beatsPerBar);
-    const beatInBar =
-      1 + (beat - bar * beatsPerBar) / (4 / timeSignature.denominator);
-    return `${bar + 1}:${Number(beatInBar.toFixed(6))}`;
   }
 }

--- a/src/components/recorder/recorder-range-control.tsx
+++ b/src/components/recorder/recorder-range-control.tsx
@@ -30,6 +30,16 @@ export function RecorderRangeControl({
   const status = !state.range ? "No range" : state.enabled ? "On" : "Off";
   const description = `${label}: ${status.toLowerCase()}`;
 
+  function setAtPlayhead() {
+    const beatsPerBar = getBeatsPerBar(timeSignature);
+    const startBeat =
+      Math.floor(secondsToBeats(position, tempo) / beatsPerBar) * beatsPerBar;
+    onChange({
+      range: { startBeat, endBeat: startBeat + beatsPerBar },
+      enabled: true,
+    });
+  }
+
   return (
     <div className="flex h-9 w-15 shrink-0 rounded-md border border-neutral-600">
       <Button
@@ -88,14 +98,4 @@ export function RecorderRangeControl({
       </DropdownMenu>
     </div>
   );
-
-  function setAtPlayhead() {
-    const beatsPerBar = getBeatsPerBar(timeSignature);
-    const startBeat =
-      Math.floor(secondsToBeats(position, tempo) / beatsPerBar) * beatsPerBar;
-    onChange({
-      range: { startBeat, endBeat: startBeat + beatsPerBar },
-      enabled: true,
-    });
-  }
 }

--- a/src/components/recorder/recorder-range-control.tsx
+++ b/src/components/recorder/recorder-range-control.tsx
@@ -72,7 +72,11 @@ export function RecorderRangeControl({
             <ChevronDownIcon className="size-3" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-15 min-w-0!">
+        <DropdownMenuContent
+          align="end"
+          alignOffset={-1}
+          className="w-15 min-w-0!"
+        >
           <DropdownMenuItem onSelect={setAtPlayhead}>New</DropdownMenuItem>
           <DropdownMenuItem
             disabled={!state.range}


### PR DESCRIPTION
Loop and Punch previously looked the same when no range existed and when a saved range was off, even though clicking performed different actions. Replacing an offscreen range also required finding it first.

This PR adds compact split controls that distinguish unset, off, and enabled ranges. The main button creates or toggles the range, while New replaces it at the playhead and enables it, and Clear removes it. Fixed widths avoid layout shifts, and tooltips identify the current state.

E2E coverage now checks the unset state and New/Clear behavior for both controls, including enabling a replacement range without moving the playhead.