### PR TITLE
refactor: share default timeline scale with e2e

### DIFF
--- a/e2e/audio-tracks.spec.ts
+++ b/e2e/audio-tracks.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Page, test } from "@playwright/test";
+import { DEFAULT_PIXELS_PER_BEAT } from "../src/lib/timeline";
 import {
   clickNewProject,
   evaluateFlushAutoSave,
@@ -137,9 +138,9 @@ test.describe("Multiple Audio Tracks", () => {
       await page.mouse.up();
     }
 
-    // Default 80 px/beat at 120 BPM: 160 px = 2 beats = 1 s.
+    // At 120 BPM, two beats equal one second.
     // Linked (default on): dragging one region moves both tracks.
-    await dragRegionBy(page, 0, 160);
+    await dragRegionBy(page, 0, DEFAULT_PIXELS_PER_BEAT * 2);
     let offsets = await getOffsets(page);
     expect(offsets[0]).toBeCloseTo(1, 5);
     expect(offsets[1]).toBeCloseTo(1, 5);
@@ -151,7 +152,7 @@ test.describe("Multiple Audio Tracks", () => {
     await page.getByRole("button", { name: "Close" }).click();
     await expect(page.getByTestId("settings-dialog")).toBeHidden();
 
-    await dragRegionBy(page, 1, 80);
+    await dragRegionBy(page, 1, DEFAULT_PIXELS_PER_BEAT);
     offsets = await getOffsets(page);
     expect(offsets[0]).toBeCloseTo(1, 5);
     expect(offsets[1]).toBeCloseTo(1.5, 5);

--- a/e2e/copy-paste.spec.ts
+++ b/e2e/copy-paste.spec.ts
@@ -1,8 +1,8 @@
 import { expect, type Page, test } from "@playwright/test";
+import { DEFAULT_PIXELS_PER_BEAT } from "../src/lib/timeline";
 import { clickNewProject } from "./helpers";
 
-// Constants matching piano-roll.tsx
-const BEAT_WIDTH = 80;
+// Row height matches piano-roll.tsx.
 const ROW_HEIGHT = 20;
 
 // TODO: consolidate into fewer user-flow tests (combine paste/snap/preserve/selection)
@@ -16,8 +16,8 @@ async function seekTobeat(page: Page, beat: number): Promise<void> {
   }
 
   // Click at the position corresponding to the beat
-  // Timeline x = beat * BEAT_WIDTH (since scrollX starts at 0)
-  const clickX = timelineBox.x + beat * BEAT_WIDTH;
+  // Timeline x = beat * DEFAULT_PIXELS_PER_BEAT (since scrollX starts at 0)
+  const clickX = timelineBox.x + beat * DEFAULT_PIXELS_PER_BEAT;
   const clickY = timelineBox.y + timelineBox.height / 2;
 
   // Double-click with jitter to ensure transport state syncs reliably
@@ -41,12 +41,12 @@ test.describe("Copy/Paste", () => {
     }
 
     // Create a note starting at beat 0 (click near left edge to snap to 0)
-    const startX = gridBox.x + BEAT_WIDTH * 0.05;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.05;
     const startY = gridBox.y + ROW_HEIGHT * 0.5;
 
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
 
     const notes = page.locator("[data-testid^='note-']");
@@ -71,7 +71,7 @@ test.describe("Copy/Paste", () => {
     }
 
     // Note 1 is at beat 0, Note 2 at beat 2 = 2 beats offset
-    const expectedOffset = 2 * BEAT_WIDTH;
+    const expectedOffset = 2 * DEFAULT_PIXELS_PER_BEAT;
     expect(note2Box.x - note1Box.x).toBeCloseTo(expectedOffset, -1);
 
     // Same pitch (same y position)
@@ -103,12 +103,12 @@ test.describe("Copy/Paste", () => {
     }
 
     // Create a note starting at beat 0
-    const startX = gridBox.x + BEAT_WIDTH * 0.05;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.05;
     const startY = gridBox.y + ROW_HEIGHT * 0.5;
 
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
 
     const notes = page.locator("[data-testid^='note-']");
@@ -133,7 +133,7 @@ test.describe("Copy/Paste", () => {
     }
 
     // Note1 at beat 0, playhead at 1.5 → note2 at beat 1.5
-    const expectedOffset = 1.5 * BEAT_WIDTH;
+    const expectedOffset = 1.5 * DEFAULT_PIXELS_PER_BEAT;
     expect(note2Box.x - note1Box.x).toBeCloseTo(expectedOffset, -1);
   });
 
@@ -149,11 +149,11 @@ test.describe("Copy/Paste", () => {
     const notes = page.locator("[data-testid^='note-']");
 
     // Create first note at beat 0
-    const note1X = gridBox.x + BEAT_WIDTH * 0.5;
+    const note1X = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5;
     const note1Y = gridBox.y + ROW_HEIGHT * 0.5;
     await page.mouse.move(note1X, note1Y);
     await page.mouse.down();
-    await page.mouse.move(note1X + BEAT_WIDTH, note1Y);
+    await page.mouse.move(note1X + DEFAULT_PIXELS_PER_BEAT, note1Y);
     await page.mouse.up();
     await expect(notes).toHaveCount(1);
 
@@ -161,11 +161,11 @@ test.describe("Copy/Paste", () => {
     await page.keyboard.press("Escape");
 
     // Create second note at beat 2, different pitch (2 rows down)
-    const note2X = gridBox.x + BEAT_WIDTH * 2.5;
+    const note2X = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 2.5;
     const note2Y = gridBox.y + ROW_HEIGHT * 2.5;
     await page.mouse.move(note2X, note2Y);
     await page.mouse.down();
-    await page.mouse.move(note2X + BEAT_WIDTH, note2Y);
+    await page.mouse.move(note2X + DEFAULT_PIXELS_PER_BEAT, note2Y);
     await page.mouse.up();
     await expect(notes).toHaveCount(2);
 
@@ -173,9 +173,9 @@ test.describe("Copy/Paste", () => {
     await page.keyboard.press("Escape");
 
     // Box select both notes
-    const boxStartX = gridBox.x + BEAT_WIDTH * 0.2;
+    const boxStartX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.2;
     const boxStartY = gridBox.y + ROW_HEIGHT * 0.2;
-    const boxEndX = gridBox.x + BEAT_WIDTH * 4;
+    const boxEndX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 4;
     const boxEndY = gridBox.y + ROW_HEIGHT * 4;
 
     await page.keyboard.down("Shift");
@@ -233,11 +233,11 @@ test.describe("Copy/Paste", () => {
     const notes = page.locator("[data-testid^='note-']");
 
     // Create a note
-    const startX = gridBox.x + BEAT_WIDTH * 0.5;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5;
     const startY = gridBox.y + ROW_HEIGHT * 0.5;
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
     await expect(notes).toHaveCount(1);
 
@@ -266,11 +266,11 @@ test.describe("Copy/Paste", () => {
     const notes = page.locator("[data-testid^='note-']");
 
     // Create a note with specific duration (2 beats) at a specific pitch
-    const startX = gridBox.x + BEAT_WIDTH * 0.5;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5;
     const startY = gridBox.y + ROW_HEIGHT * 2.5; // Different row
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH * 2, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT * 2, startY);
     await page.mouse.up();
     await expect(notes).toHaveCount(1);
 
@@ -310,11 +310,11 @@ test.describe("Copy/Paste", () => {
     const notes = page.locator("[data-testid^='note-']");
 
     // Create a note at beat 0 (click near left edge to snap to 0)
-    const startX = gridBox.x + BEAT_WIDTH * 0.05;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.05;
     const startY = gridBox.y + ROW_HEIGHT * 0.5;
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
     await expect(notes).toHaveCount(1);
 
@@ -361,11 +361,11 @@ test.describe("Copy/Paste", () => {
     }
 
     // Create a note
-    const startX = gridBox.x + BEAT_WIDTH * 0.5;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5;
     const startY = gridBox.y + ROW_HEIGHT * 0.5;
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
 
     const notes = page.locator("[data-testid^='note-']");

--- a/e2e/fake-audio/recorder-archive.test.ts
+++ b/e2e/fake-audio/recorder-archive.test.ts
@@ -1,4 +1,5 @@
 import { expect, type Page, test } from "@playwright/test";
+import { DEFAULT_PIXELS_PER_BEAT } from "../../src/lib/timeline";
 import {
   addRecorderAudio,
   createRecorderProject,
@@ -15,8 +16,8 @@ test("exports and imports a recorder project archive", async ({ page }) => {
 
   await enableInput(page);
   const recordButton = page.getByTestId("recorder-record-button");
-  for (const position of [160, 320]) {
-    await seekRecorderByPixels(page, position);
+  for (const beat of [2, 4]) {
+    await seekRecorderByPixels(page, DEFAULT_PIXELS_PER_BEAT * beat);
     await recordButton.click();
     await waitForRecordingSamples(page.getByTestId("recorder-clip-recording"));
     await recordButton.click();

--- a/e2e/fake-audio/recorder-audio-track.test.ts
+++ b/e2e/fake-audio/recorder-audio-track.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { DEFAULT_PIXELS_PER_BEAT } from "../../src/lib/timeline";
 import {
   addRecorderAudio,
   createRecorderProject,
@@ -19,10 +20,10 @@ test("uploads and plays a backing track", async ({ page }) => {
   // Move and trim backing audio without changing its source.
   const beforeEdit = await clip.boundingBox();
   expect(beforeEdit).not.toBeNull();
-  await dragBy(page, clip, 80);
+  await dragBy(page, clip, DEFAULT_PIXELS_PER_BEAT);
   const afterMove = await clip.boundingBox();
   expect(afterMove).not.toBeNull();
-  expect(afterMove!.x).toBeCloseTo(beforeEdit!.x + 80, -1);
+  expect(afterMove!.x).toBeCloseTo(beforeEdit!.x + DEFAULT_PIXELS_PER_BEAT, -1);
 
   const trimPixels = afterMove!.width / 4;
   await dragBy(page, clip.getByTestId("recorder-take-trim-start"), trimPixels);

--- a/e2e/fake-audio/recorder-clip-selection.test.ts
+++ b/e2e/fake-audio/recorder-clip-selection.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { DEFAULT_PIXELS_PER_BEAT } from "../../src/lib/timeline";
 import {
   addRecorderAudio,
   createRecorderProject,
@@ -16,7 +17,7 @@ test("selects and moves audio and take clips together", async ({ page }) => {
 
   // Record a take away from zero.
   await enableInput(page);
-  await seekRecorderByPixels(page, 160);
+  await seekRecorderByPixels(page, DEFAULT_PIXELS_PER_BEAT * 2);
   const recordButton = page.getByTestId("recorder-record-button");
   await recordButton.click();
   await waitForRecordingSamples(page.getByTestId("recorder-clip-recording"));
@@ -41,14 +42,19 @@ test("selects and moves audio and take clips together", async ({ page }) => {
   };
   await page.mouse.move(takeCenter.x, takeCenter.y);
   await page.mouse.down();
-  await page.mouse.move(takeCenter.x + 80, takeCenter.y, { steps: 4 });
+  await page.mouse.move(takeCenter.x + DEFAULT_PIXELS_PER_BEAT, takeCenter.y, {
+    steps: 4,
+  });
   await page.mouse.up();
 
   // Both clips preserve their relative spacing through the shared movement.
   const audioAfter = await audio.boundingBox();
   const takeAfter = await take.boundingBox();
-  expect(audioAfter!.x - audioBefore!.x).toBeCloseTo(80, -1);
-  expect(takeAfter!.x - takeBefore!.x).toBeCloseTo(80, -1);
+  expect(audioAfter!.x - audioBefore!.x).toBeCloseTo(
+    DEFAULT_PIXELS_PER_BEAT,
+    -1,
+  );
+  expect(takeAfter!.x - takeBefore!.x).toBeCloseTo(DEFAULT_PIXELS_PER_BEAT, -1);
 
   // Delete clears every selected clip while preserving the audio track row.
   await page.keyboard.press("Delete");

--- a/e2e/fake-audio/recorder-locators.test.ts
+++ b/e2e/fake-audio/recorder-locators.test.ts
@@ -1,12 +1,11 @@
 import { expect, test } from "@playwright/test";
+import { DEFAULT_PIXELS_PER_BEAT } from "../../src/lib/timeline";
 import {
   createRecorderProject,
   dragBy,
   getRecorderBeat,
   seekRecorderByPixels,
 } from "./recorder-helpers";
-
-const pixelsPerBeat = 80;
 
 test("edits, seeks, and selects recorder locators", async ({ page }) => {
   await createRecorderProject(page);
@@ -18,10 +17,10 @@ test("edits, seeks, and selects recorder locators", async ({ page }) => {
   const renameVerse = page.getByRole("button", { name: "Rename Verse" });
 
   // Both creation controls use the snapped playhead and select the new marker.
-  await seekRecorderByPixels(page, pixelsPerBeat * 0.9);
+  await seekRecorderByPixels(page, DEFAULT_PIXELS_PER_BEAT * 0.9);
   await page.keyboard.press("l");
   await expect(first).toHaveAttribute("aria-pressed", "true");
-  await seekRecorderByPixels(page, pixelsPerBeat * 4);
+  await seekRecorderByPixels(page, DEFAULT_PIXELS_PER_BEAT * 4);
   await add.click();
   await expect(second).toHaveAttribute("aria-pressed", "true");
   await expect(first).toHaveAttribute("aria-pressed", "false");
@@ -29,7 +28,7 @@ test("edits, seeks, and selects recorder locators", async ({ page }) => {
   await expect.poll(() => getRecorderBeat(page)).toBe(1);
 
   // Rename commits without seeking; cancelling keeps the existing label.
-  await seekRecorderByPixels(page, pixelsPerBeat * 3);
+  await seekRecorderByPixels(page, DEFAULT_PIXELS_PER_BEAT * 3);
   page.once("dialog", (dialog) => dialog.accept("Verse"));
   // Playwright can click the opacity-hidden rename action, avoiding hover setup here.
   await renameFirst.click();
@@ -61,13 +60,13 @@ test("edits, seeks, and selects recorder locators", async ({ page }) => {
   await expect.poll(() => getRecorderBeat(page)).toBe(1);
 
   // Dragging snaps the marker to beat 2.5 without moving the playhead.
-  await seekRecorderByPixels(page, pixelsPerBeat * 6);
+  await seekRecorderByPixels(page, DEFAULT_PIXELS_PER_BEAT * 6);
   const beforeDrag = await verse.boundingBox();
   expect(beforeDrag).not.toBeNull();
-  await dragBy(page, verse, 110);
+  await dragBy(page, verse, DEFAULT_PIXELS_PER_BEAT * 1.375);
   await expect
     .poll(async () => (await verse.boundingBox())?.x)
-    .toBeCloseTo(beforeDrag!.x + pixelsPerBeat * 1.5, 1);
+    .toBeCloseTo(beforeDrag!.x + DEFAULT_PIXELS_PER_BEAT * 1.5, 1);
   await expect(verse).toHaveAttribute("aria-pressed", "true");
   await expect.poll(() => getRecorderBeat(page)).toBe(6);
   await verse.click();
@@ -76,7 +75,7 @@ test("edits, seeks, and selects recorder locators", async ({ page }) => {
   // Locator beats remain stable when tempo changes.
   await page.getByTestId("recorder-tempo-input").fill("90");
   await page.getByTestId("recorder-tempo-input").press("Enter");
-  await seekRecorderByPixels(page, pixelsPerBeat * 4);
+  await seekRecorderByPixels(page, DEFAULT_PIXELS_PER_BEAT * 4);
   await expect.poll(() => getRecorderBeat(page)).toBe(4);
   await verse.click();
   await expect.poll(() => getRecorderBeat(page)).toBe(2.5);
@@ -95,9 +94,9 @@ test("persists recorder locator edits and deletion", async ({ page }) => {
   const saveButton = page.getByTestId("recorder-save-button");
 
   // Create locators at beats 2.5 and 5.
-  await seekRecorderByPixels(page, pixelsPerBeat * 2.5);
+  await seekRecorderByPixels(page, DEFAULT_PIXELS_PER_BEAT * 2.5);
   await page.keyboard.press("l");
-  await seekRecorderByPixels(page, pixelsPerBeat * 5);
+  await seekRecorderByPixels(page, DEFAULT_PIXELS_PER_BEAT * 5);
   await page.keyboard.press("l");
   await expect(saveButton).toHaveAttribute("data-status", "unsaved");
 
@@ -120,7 +119,7 @@ test("persists recorder locator edits and deletion", async ({ page }) => {
   await expect(saveButton).toHaveAttribute("data-status", "saved");
 
   // Moving a locator dirties the project and persists its new beat.
-  await dragBy(page, firstRenamed, pixelsPerBeat * 0.5);
+  await dragBy(page, firstRenamed, DEFAULT_PIXELS_PER_BEAT * 0.5);
   await expect(saveButton).toHaveAttribute("data-status", "unsaved");
   await saveButton.click();
   await expect(saveButton).toHaveAttribute("data-status", "saved");

--- a/e2e/fake-audio/recorder-loop-range.test.ts
+++ b/e2e/fake-audio/recorder-loop-range.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { expect, test } from "@playwright/test";
+import { DEFAULT_PIXELS_PER_BEAT } from "../../src/lib/timeline";
 import {
   createRecorderProject,
   dragBy,
@@ -42,11 +43,11 @@ test("creates and edits a persisted loop range", async ({ page }) => {
   await playButton.click();
 
   // The range label moves it while the range body remains available to seek.
-  await dragBy(page, range.getByText("Loop"), 80);
+  await dragBy(page, range.getByText("Loop"), DEFAULT_PIXELS_PER_BEAT);
   const movedBox = await range.boundingBox();
   assert(movedBox);
-  expect(movedBox.x).toBeCloseTo(initialBox.x + 80, -1);
-  await seekRecorderByPixels(page, 320);
+  expect(movedBox.x).toBeCloseTo(initialBox.x + DEFAULT_PIXELS_PER_BEAT, -1);
+  await seekRecorderByPixels(page, DEFAULT_PIXELS_PER_BEAT * 4);
   await expect.poll(() => getRecorderBeat(page)).toBe(4);
 
   // Disabling playback keeps the edited range available for later use.

--- a/e2e/fake-audio/recorder-punch-recording.test.ts
+++ b/e2e/fake-audio/recorder-punch-recording.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { expect, test } from "@playwright/test";
+import { DEFAULT_PIXELS_PER_BEAT } from "../../src/lib/timeline";
 import {
   createRecorderProject,
   dragBy,
@@ -20,8 +21,16 @@ test("records only the punched interval into the comp", async ({ page }) => {
   await page.getByTestId("recorder-punch-toggle").click();
   const punchRange = page.getByTestId("recorder-punch-range");
   await expect(punchRange).toBeVisible();
-  await dragBy(page, page.getByTestId("recorder-punch-start"), 40);
-  await dragBy(page, page.getByTestId("recorder-punch-end"), -40);
+  await dragBy(
+    page,
+    page.getByTestId("recorder-punch-start"),
+    DEFAULT_PIXELS_PER_BEAT * 0.5,
+  );
+  await dragBy(
+    page,
+    page.getByTestId("recorder-punch-end"),
+    -DEFAULT_PIXELS_PER_BEAT * 0.5,
+  );
   const punchBox = await punchRange.boundingBox();
   assert(punchBox);
 

--- a/e2e/fake-audio/recorder-range-controls.test.ts
+++ b/e2e/fake-audio/recorder-range-controls.test.ts
@@ -1,11 +1,10 @@
 import { expect, test } from "@playwright/test";
+import { DEFAULT_PIXELS_PER_BEAT } from "../../src/lib/timeline";
 import {
   createRecorderProject,
   getRecorderBeat,
   seekRecorderByPixels,
 } from "./recorder-helpers";
-
-const BEAT_WIDTH = 80;
 
 for (const kind of ["loop", "punch"] as const) {
   test(`${kind} menu creates, replaces, and clears its range`, async ({
@@ -27,20 +26,20 @@ for (const kind of ["loop", "punch"] as const) {
     await page.getByRole("menuitem", { name: "New", exact: true }).click();
     await expect(toggle).toHaveAttribute("aria-pressed", "true");
     await expect(range).toHaveCSS("left", "0px");
-    await expect(range).toHaveCSS("width", `${BEAT_WIDTH * 4}px`);
+    await expect(range).toHaveCSS("width", `${DEFAULT_PIXELS_PER_BEAT * 4}px`);
     await expect.poll(() => getRecorderBeat(page)).toBe(0);
 
     // New replaces the disabled range at the playhead's bar and enables it.
     await toggle.click();
     await expect(toggle).toHaveAttribute("aria-pressed", "false");
-    await seekRecorderByPixels(page, BEAT_WIDTH * 5);
+    await seekRecorderByPixels(page, DEFAULT_PIXELS_PER_BEAT * 5);
     await expect.poll(() => getRecorderBeat(page)).toBe(5);
     await menu.click();
     await page.getByRole("menuitem", { name: "New", exact: true }).click();
     await expect(toggle).toHaveAttribute("aria-pressed", "true");
     await expect(range).toHaveCount(1);
-    await expect(range).toHaveCSS("left", `${BEAT_WIDTH * 4}px`);
-    await expect(range).toHaveCSS("width", `${BEAT_WIDTH * 4}px`);
+    await expect(range).toHaveCSS("left", `${DEFAULT_PIXELS_PER_BEAT * 4}px`);
+    await expect(range).toHaveCSS("width", `${DEFAULT_PIXELS_PER_BEAT * 4}px`);
     await expect.poll(() => getRecorderBeat(page)).toBe(5);
 
     // Clear returns to the unset state without moving the playhead.

--- a/e2e/fake-audio/recorder-recording.test.ts
+++ b/e2e/fake-audio/recorder-recording.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { expect, test } from "@playwright/test";
+import { DEFAULT_PIXELS_PER_BEAT } from "../../src/lib/timeline";
 import {
   createRecorderProject,
   dragBy,
@@ -23,7 +24,7 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   await expect(monitorButton).toHaveAttribute("aria-pressed", "true");
 
   // Place the playhead away from zero to exercise take placement.
-  await seekRecorderByPixels(page, 160);
+  await seekRecorderByPixels(page, DEFAULT_PIXELS_PER_BEAT * 2);
 
   // Recording starts capture and rolls the stopped transport.
   const recordButton = page.getByTestId("recorder-record-button");
@@ -68,15 +69,15 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   await page.keyboard.press("Escape");
   expect(
     Number.parseFloat(await take.evaluate((element) => element.style.left)),
-  ).toBeCloseTo(160, -2);
+  ).toBeCloseTo(DEFAULT_PIXELS_PER_BEAT * 2, -2);
 
   // The take can be moved and trimmed without changing its source audio.
   const beforeEdit = await take.boundingBox();
   expect(beforeEdit).not.toBeNull();
-  await dragBy(page, take, 80);
+  await dragBy(page, take, DEFAULT_PIXELS_PER_BEAT);
   const afterMove = await take.boundingBox();
   expect(afterMove).not.toBeNull();
-  expect(afterMove!.x).toBeCloseTo(beforeEdit!.x + 80, -1);
+  expect(afterMove!.x).toBeCloseTo(beforeEdit!.x + DEFAULT_PIXELS_PER_BEAT, -1);
 
   const trimStart = take.getByTestId("recorder-take-trim-start");
   const trimPixels = Math.max(2, afterMove!.width / 4);
@@ -115,7 +116,7 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   await playButton.click();
 
   // Move later in the song and record another attempt.
-  await seekRecorderByPixels(page, 320);
+  await seekRecorderByPixels(page, DEFAULT_PIXELS_PER_BEAT * 4);
   await recordButton.click();
   const secondRecording = page.getByTestId("recorder-clip-recording");
   await expect(secondRecording).toContainText("Recording...");
@@ -130,7 +131,7 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
     Number.parseFloat(
       await take.nth(1).evaluate((element) => element.style.left),
     ),
-  ).toBeCloseTo(320, -2);
+  ).toBeCloseTo(DEFAULT_PIXELS_PER_BEAT * 4, -2);
 
   // Muting removes a take from Capture without deleting its source lane.
   const muteTake = page.getByTestId("recorder-take-mute");

--- a/e2e/fake-audio/recorder-reference-video.test.ts
+++ b/e2e/fake-audio/recorder-reference-video.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { DEFAULT_PIXELS_PER_BEAT } from "../../src/lib/timeline";
 import { createRecorderProject, dragBy } from "./recorder-helpers";
 
 test("configures an ephemeral YouTube reference", async ({ page }) => {
@@ -97,13 +98,13 @@ test("configures an ephemeral YouTube reference", async ({ page }) => {
   const referenceClip = referenceTrack.getByTestId("recorder-clip-reference");
   const initialReferenceClipBox = await referenceClip.boundingBox();
   expect(initialReferenceClipBox).not.toBeNull();
-  await dragBy(page, referenceClip, 80, {
+  await dragBy(page, referenceClip, DEFAULT_PIXELS_PER_BEAT, {
     anchorXOffset: 20,
   });
   const movedReferenceClipBox = await referenceClip.boundingBox();
   expect(movedReferenceClipBox).not.toBeNull();
   expect(movedReferenceClipBox!.x).toBeCloseTo(
-    initialReferenceClipBox!.x + 80,
+    initialReferenceClipBox!.x + DEFAULT_PIXELS_PER_BEAT,
     -1,
   );
 

--- a/e2e/fake-audio/recorder-selection-domains.test.ts
+++ b/e2e/fake-audio/recorder-selection-domains.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { DEFAULT_PIXELS_PER_BEAT } from "../../src/lib/timeline";
 import {
   addRecorderAudio,
   createRecorderProject,
@@ -10,10 +11,9 @@ test("keeps recorder clip and locator selection domains exclusive", async ({
   page,
 }) => {
   await createRecorderProject(page);
-  const pixelsPerBeat = 80;
   const add = page.getByRole("button", { name: "Add locator at playhead" });
   const marker = page.getByRole("button", { name: "Section 1", exact: true });
-  await seekRecorderByPixels(page, pixelsPerBeat * 4);
+  await seekRecorderByPixels(page, DEFAULT_PIXELS_PER_BEAT * 4);
   await add.click();
 
   // Selecting a locator after a waveform makes Delete remove only the locator.
@@ -29,7 +29,7 @@ test("keeps recorder clip and locator selection domains exclusive", async ({
 
   // Creation also clears clip selection, and clip drag/trim clear locators.
   await audio.click();
-  await seekRecorderByPixels(page, pixelsPerBeat * 8);
+  await seekRecorderByPixels(page, DEFAULT_PIXELS_PER_BEAT * 8);
   await add.click();
   await expect(marker).toHaveAttribute("aria-pressed", "true");
   await expect(audio).not.toHaveAttribute("data-selected", "true");

--- a/e2e/fake-audio/recorder-transport.test.ts
+++ b/e2e/fake-audio/recorder-transport.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { DEFAULT_PIXELS_PER_BEAT } from "../../src/lib/timeline";
 import { createCheckpoint } from "../helpers";
 import {
   createRecorderProject,
@@ -13,12 +14,11 @@ test("snaps recorder timeline seeking to the selected grid", async ({
 }) => {
   await createRecorderProject(page);
 
-  const pixelsPerBeat = 80;
   const position = page.getByTestId("recorder-position");
 
   // The default 1/16 grid has four subdivisions per beat, so 0.9 beats snaps
   // to beat 1 rather than the adjacent 0.75-beat grid point.
-  await seekRecorderByPixels(page, pixelsPerBeat * 0.9);
+  await seekRecorderByPixels(page, DEFAULT_PIXELS_PER_BEAT * 0.9);
   await expect.poll(() => getRecorderBeat(page)).toBe(1);
   // Keep explicit coverage of the combined musical and elapsed-time display.
   await expect(position).toHaveText("01|02 - 00:00.500");
@@ -27,7 +27,7 @@ test("snaps recorder timeline seeking to the selected grid", async ({
   // the raw pointer position.
   await page.getByRole("button", { name: "1/16" }).click();
   await page.getByRole("menuitemradio", { name: "1/4" }).click();
-  await seekRecorderByPixels(page, pixelsPerBeat * 0.4);
+  await seekRecorderByPixels(page, DEFAULT_PIXELS_PER_BEAT * 0.4);
   await expect.poll(() => getRecorderBeat(page)).toBe(0);
 });
 

--- a/e2e/locators.spec.ts
+++ b/e2e/locators.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { DEFAULT_PIXELS_PER_BEAT } from "../src/lib/timeline";
 import {
   clickNewProject,
   evaluateFlushAutoSave,
@@ -36,7 +37,7 @@ test.describe("Locators", () => {
 
     // Seek to beat 4 and add second locator
     await page.mouse.click(
-      timelineBox.x + 320,
+      timelineBox.x + DEFAULT_PIXELS_PER_BEAT * 4,
       timelineBox.y + timelineBox.height / 2,
     );
     await page.keyboard.press("l");
@@ -138,7 +139,7 @@ test.describe("Locators", () => {
 
     // Seek to beat 4 and add second locator
     await page.mouse.click(
-      timelineBox.x + 320,
+      timelineBox.x + DEFAULT_PIXELS_PER_BEAT * 4,
       timelineBox.y + timelineBox.height / 2,
     );
     await page.keyboard.press("l");

--- a/e2e/persistence.spec.ts
+++ b/e2e/persistence.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { DEFAULT_PIXELS_PER_BEAT } from "../src/lib/timeline";
 import {
   waitForEditor,
   clickNewProject,
@@ -6,8 +7,7 @@ import {
   evaluateStore,
 } from "./helpers";
 
-// Constants matching piano-roll.tsx
-const BEAT_WIDTH = 80;
+// Row height matches piano-roll.tsx.
 const ROW_HEIGHT = 20;
 
 test.describe("Project Persistence", () => {
@@ -28,11 +28,11 @@ test.describe("Project Persistence", () => {
     }
 
     // Create a note
-    const startX = gridBox.x + BEAT_WIDTH * 1.5;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 1.5;
     const startY = gridBox.y + ROW_HEIGHT * 3.5;
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH * 2, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT * 2, startY);
     await page.mouse.up();
 
     // Verify note exists
@@ -62,12 +62,12 @@ test.describe("Project Persistence", () => {
 
     // Create first note
     await page.mouse.move(
-      gridBox.x + BEAT_WIDTH * 0.5,
+      gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5,
       gridBox.y + ROW_HEIGHT * 2,
     );
     await page.mouse.down();
     await page.mouse.move(
-      gridBox.x + BEAT_WIDTH * 1.5,
+      gridBox.x + DEFAULT_PIXELS_PER_BEAT * 1.5,
       gridBox.y + ROW_HEIGHT * 2,
     );
     await page.mouse.up();
@@ -76,12 +76,12 @@ test.describe("Project Persistence", () => {
 
     // Create second note
     await page.mouse.move(
-      gridBox.x + BEAT_WIDTH * 2.5,
+      gridBox.x + DEFAULT_PIXELS_PER_BEAT * 2.5,
       gridBox.y + ROW_HEIGHT * 4,
     );
     await page.mouse.down();
     await page.mouse.move(
-      gridBox.x + BEAT_WIDTH * 4,
+      gridBox.x + DEFAULT_PIXELS_PER_BEAT * 4,
       gridBox.y + ROW_HEIGHT * 4,
     );
     await page.mouse.up();
@@ -90,12 +90,12 @@ test.describe("Project Persistence", () => {
 
     // Create third note
     await page.mouse.move(
-      gridBox.x + BEAT_WIDTH * 5,
+      gridBox.x + DEFAULT_PIXELS_PER_BEAT * 5,
       gridBox.y + ROW_HEIGHT * 6,
     );
     await page.mouse.down();
     await page.mouse.move(
-      gridBox.x + BEAT_WIDTH * 6,
+      gridBox.x + DEFAULT_PIXELS_PER_BEAT * 6,
       gridBox.y + ROW_HEIGHT * 6,
     );
     await page.mouse.up();
@@ -197,11 +197,11 @@ test.describe("Project Persistence", () => {
     }
 
     // Create a note
-    const startX = gridBox.x + BEAT_WIDTH * 1;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 1;
     const startY = gridBox.y + ROW_HEIGHT * 5;
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
 
     const note = page.locator("[data-testid^='note-']").first();
@@ -215,7 +215,7 @@ test.describe("Project Persistence", () => {
     await page.mouse.move(noteCenter, initialBox.y + initialBox.height / 2);
     await page.mouse.down();
     await page.mouse.move(
-      noteCenter + BEAT_WIDTH * 3,
+      noteCenter + DEFAULT_PIXELS_PER_BEAT * 3,
       initialBox.y - ROW_HEIGHT * 2,
     );
     await page.mouse.up();
@@ -253,12 +253,12 @@ test.describe("Project Persistence", () => {
 
     // Create two notes
     await page.mouse.move(
-      gridBox.x + BEAT_WIDTH * 0.5,
+      gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5,
       gridBox.y + ROW_HEIGHT * 2,
     );
     await page.mouse.down();
     await page.mouse.move(
-      gridBox.x + BEAT_WIDTH * 1.5,
+      gridBox.x + DEFAULT_PIXELS_PER_BEAT * 1.5,
       gridBox.y + ROW_HEIGHT * 2,
     );
     await page.mouse.up();
@@ -266,12 +266,12 @@ test.describe("Project Persistence", () => {
     await page.keyboard.press("Escape");
 
     await page.mouse.move(
-      gridBox.x + BEAT_WIDTH * 3,
+      gridBox.x + DEFAULT_PIXELS_PER_BEAT * 3,
       gridBox.y + ROW_HEIGHT * 4,
     );
     await page.mouse.down();
     await page.mouse.move(
-      gridBox.x + BEAT_WIDTH * 4,
+      gridBox.x + DEFAULT_PIXELS_PER_BEAT * 4,
       gridBox.y + ROW_HEIGHT * 4,
     );
     await page.mouse.up();
@@ -300,11 +300,11 @@ test.describe("Project Persistence", () => {
     }
 
     // Create a note (auto-selected)
-    const startX = gridBox.x + BEAT_WIDTH * 1;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 1;
     const startY = gridBox.y + ROW_HEIGHT * 3;
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
 
     const note = page.locator("[data-testid^='note-']").first();

--- a/e2e/piano-roll.spec.ts
+++ b/e2e/piano-roll.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "@playwright/test";
+import { DEFAULT_PIXELS_PER_BEAT } from "../src/lib/timeline";
 import { clickNewProject, evaluateStore } from "./helpers";
 
-// Constants matching piano-roll.tsx
-const BEAT_WIDTH = 80;
+// Row height matches piano-roll.tsx.
 const ROW_HEIGHT = 20;
 
 test.describe("Piano Roll", () => {
@@ -28,12 +28,12 @@ test.describe("Piano Roll", () => {
     }
 
     // Create note at beat 0, pitch G3 (top row)
-    const startX = gridBox.x + BEAT_WIDTH * 0.5;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5;
     const startY = gridBox.y + ROW_HEIGHT * 0.5;
 
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
 
     // Note should be created and selected
@@ -46,7 +46,7 @@ test.describe("Piano Roll", () => {
     await expect(note).toHaveAttribute("data-selected", "false");
 
     // Click on note to select
-    await page.mouse.click(startX + BEAT_WIDTH * 0.25, startY);
+    await page.mouse.click(startX + DEFAULT_PIXELS_PER_BEAT * 0.25, startY);
     await expect(note).toHaveAttribute("data-selected", "true");
 
     // Delete with Delete key
@@ -56,7 +56,7 @@ test.describe("Piano Roll", () => {
     // Create another note to test Backspace
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
 
     await expect(note).toHaveCount(1);
@@ -79,12 +79,12 @@ test.describe("Piano Roll", () => {
     }
 
     const clickBeat = 4.6;
-    const clickX = gridBox.x + clickBeat * BEAT_WIDTH;
+    const clickX = gridBox.x + clickBeat * DEFAULT_PIXELS_PER_BEAT;
     const clickY = gridBox.y + ROW_HEIGHT * 2.5;
 
     await page.mouse.move(clickX, clickY);
     await page.mouse.down();
-    await page.mouse.move(clickX + BEAT_WIDTH * 0.1, clickY);
+    await page.mouse.move(clickX + DEFAULT_PIXELS_PER_BEAT * 0.1, clickY);
     await page.mouse.up();
 
     const note = page.locator("[data-testid^='note-']").first();
@@ -95,7 +95,7 @@ test.describe("Piano Roll", () => {
       throw new Error("Note not found");
     }
 
-    const expectedStartX = gridBox.x + 4 * BEAT_WIDTH;
+    const expectedStartX = gridBox.x + 4 * DEFAULT_PIXELS_PER_BEAT;
     expect(noteBox.x).toBeCloseTo(expectedStartX, 1);
   });
 
@@ -115,12 +115,15 @@ test.describe("Piano Roll", () => {
       throw new Error("Grid not found");
     }
 
-    const startX = gridBox.x + BEAT_WIDTH * 0.5;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5;
     const startY = gridBox.y + ROW_HEIGHT * 2.5;
 
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH * tripletGridSize, startY);
+    await page.mouse.move(
+      startX + DEFAULT_PIXELS_PER_BEAT * tripletGridSize,
+      startY,
+    );
     await page.mouse.up();
 
     const notes = await evaluateStore(page, (store) => store.getState().notes);
@@ -137,11 +140,11 @@ test.describe("Piano Roll", () => {
     }
 
     // Create a note at row 5 (to have room to move up)
-    const startX = gridBox.x + BEAT_WIDTH * 0.5;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5;
     const startY = gridBox.y + ROW_HEIGHT * 5.5;
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
 
     const note = page.locator("[data-testid^='note-']").first();
@@ -153,10 +156,10 @@ test.describe("Piano Roll", () => {
     const initialY = initialBox.y;
 
     // Drag note horizontally (time)
-    const noteCenter = startX + BEAT_WIDTH * 0.25;
+    const noteCenter = startX + DEFAULT_PIXELS_PER_BEAT * 0.25;
     await page.mouse.move(noteCenter, startY);
     await page.mouse.down();
-    await page.mouse.move(noteCenter + BEAT_WIDTH * 2, startY);
+    await page.mouse.move(noteCenter + DEFAULT_PIXELS_PER_BEAT * 2, startY);
     await page.mouse.up();
 
     let movedBox = await note.boundingBox();
@@ -192,11 +195,11 @@ test.describe("Piano Roll", () => {
     }
 
     // Create a note at beat 2 (so we have room to resize left)
-    const startX = gridBox.x + BEAT_WIDTH * 2;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 2;
     const startY = gridBox.y + ROW_HEIGHT * 0.5;
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH * 2, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT * 2, startY);
     await page.mouse.up();
 
     const note = page.locator("[data-testid^='note-']").first();
@@ -212,7 +215,7 @@ test.describe("Piano Roll", () => {
     const noteY = initialBox.y + initialBox.height / 2;
     await page.mouse.move(rightEdgeX, noteY);
     await page.mouse.down();
-    await page.mouse.move(rightEdgeX + BEAT_WIDTH, noteY);
+    await page.mouse.move(rightEdgeX + DEFAULT_PIXELS_PER_BEAT, noteY);
     await page.mouse.up();
 
     let resizedBox = await note.boundingBox();
@@ -225,7 +228,7 @@ test.describe("Piano Roll", () => {
     const leftEdgeX = resizedBox.x + 2;
     await page.mouse.move(leftEdgeX, noteY);
     await page.mouse.down();
-    await page.mouse.move(leftEdgeX + BEAT_WIDTH * 0.5, noteY);
+    await page.mouse.move(leftEdgeX + DEFAULT_PIXELS_PER_BEAT * 0.5, noteY);
     await page.mouse.up();
 
     const finalBox = await note.boundingBox();
@@ -269,11 +272,14 @@ test.describe("Piano Roll", () => {
     // Create a 1-beat note at beat 1 (ends at beat 2)
     const noteStartBeat = 1;
     const noteDurationBeats = 1;
-    const startX = gridBox.x + noteStartBeat * BEAT_WIDTH;
+    const startX = gridBox.x + noteStartBeat * DEFAULT_PIXELS_PER_BEAT;
     const startY = gridBox.y + ROW_HEIGHT * 0.5;
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + noteDurationBeats * BEAT_WIDTH, startY);
+    await page.mouse.move(
+      startX + noteDurationBeats * DEFAULT_PIXELS_PER_BEAT,
+      startY,
+    );
     await page.mouse.up();
 
     const note = page.locator("[data-testid^='note-']").first();
@@ -284,48 +290,48 @@ test.describe("Piano Roll", () => {
     const noteY = initialBox.y + initialBox.height / 2;
 
     // Note ends at beat 2
-    const noteEndX = gridBox.x + 2 * BEAT_WIDTH;
+    const noteEndX = gridBox.x + 2 * DEFAULT_PIXELS_PER_BEAT;
 
     // Test 1: Drag to beat 2.1 (cell 4: 2.0-2.5) -> end snaps to 2.5
     await page.mouse.move(noteEndX - 2, noteY);
     await page.mouse.down();
-    await page.mouse.move(gridBox.x + 2.1 * BEAT_WIDTH, noteY);
+    await page.mouse.move(gridBox.x + 2.1 * DEFAULT_PIXELS_PER_BEAT, noteY);
     await page.mouse.up();
 
     let resizedBox = await note.boundingBox();
     if (!resizedBox) {
       throw new Error("Note not found after resize");
     }
-    // End at 2.5 means duration = 1.5 beats = 120px
-    expect(resizedBox.width).toBeCloseTo(BEAT_WIDTH * 1.5, 1);
+    // End at 2.5 means duration = 1.5 beats.
+    expect(resizedBox.width).toBeCloseTo(DEFAULT_PIXELS_PER_BEAT * 1.5, 1);
 
     // Test 2: Drag to beat 1.9 (cell 3: 1.5-2.0) -> end snaps to 2.0 (shrinks)
-    const newEndX = gridBox.x + 2.5 * BEAT_WIDTH;
+    const newEndX = gridBox.x + 2.5 * DEFAULT_PIXELS_PER_BEAT;
     await page.mouse.move(newEndX - 2, noteY);
     await page.mouse.down();
-    await page.mouse.move(gridBox.x + 1.9 * BEAT_WIDTH, noteY);
+    await page.mouse.move(gridBox.x + 1.9 * DEFAULT_PIXELS_PER_BEAT, noteY);
     await page.mouse.up();
 
     resizedBox = await note.boundingBox();
     if (!resizedBox) {
       throw new Error("Note not found after resize");
     }
-    // End at 2.0 means duration = 1.0 beat = 80px
-    expect(resizedBox.width).toBeCloseTo(BEAT_WIDTH, 1);
+    // End at 2.0 means duration = 1.0 beat.
+    expect(resizedBox.width).toBeCloseTo(DEFAULT_PIXELS_PER_BEAT, 1);
 
     // Test 3: Drag to beat 2.6 (cell 5: 2.5-3.0) -> end snaps to 3.0
-    const currentEndX = gridBox.x + 2 * BEAT_WIDTH;
+    const currentEndX = gridBox.x + 2 * DEFAULT_PIXELS_PER_BEAT;
     await page.mouse.move(currentEndX - 2, noteY);
     await page.mouse.down();
-    await page.mouse.move(gridBox.x + 2.6 * BEAT_WIDTH, noteY);
+    await page.mouse.move(gridBox.x + 2.6 * DEFAULT_PIXELS_PER_BEAT, noteY);
     await page.mouse.up();
 
     const finalBox = await note.boundingBox();
     if (!finalBox) {
       throw new Error("Note not found after final resize");
     }
-    // End at 3.0 means duration = 2.0 beats = 160px
-    expect(finalBox.width).toBeCloseTo(BEAT_WIDTH * 2, 1);
+    // End at 3.0 means duration = 2.0 beats.
+    expect(finalBox.width).toBeCloseTo(DEFAULT_PIXELS_PER_BEAT * 2, 1);
   });
 
   test("deselect with Escape", async ({ page }) => {
@@ -336,11 +342,11 @@ test.describe("Piano Roll", () => {
     }
 
     // Create a note (auto-selected after creation)
-    const startX = gridBox.x + BEAT_WIDTH * 0.5;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5;
     const startY = gridBox.y + ROW_HEIGHT * 0.5;
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
 
     const note = page.locator("[data-testid^='note-']").first();
@@ -359,22 +365,22 @@ test.describe("Piano Roll", () => {
     }
 
     // Create first note at beat 0
-    const note1X = gridBox.x + BEAT_WIDTH * 0.5;
+    const note1X = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5;
     const note1Y = gridBox.y + ROW_HEIGHT * 0.5;
     await page.mouse.move(note1X, note1Y);
     await page.mouse.down();
-    await page.mouse.move(note1X + BEAT_WIDTH, note1Y);
+    await page.mouse.move(note1X + DEFAULT_PIXELS_PER_BEAT, note1Y);
     await page.mouse.up();
 
     // Press Escape to deselect before creating second note
     await page.keyboard.press("Escape");
 
     // Create second note at beat 2
-    const note2X = gridBox.x + BEAT_WIDTH * 2.5;
+    const note2X = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 2.5;
     const note2Y = gridBox.y + ROW_HEIGHT * 2.5;
     await page.mouse.move(note2X, note2Y);
     await page.mouse.down();
-    await page.mouse.move(note2X + BEAT_WIDTH, note2Y);
+    await page.mouse.move(note2X + DEFAULT_PIXELS_PER_BEAT, note2Y);
     await page.mouse.up();
 
     const notes = page.locator("[data-testid^='note-']");
@@ -388,7 +394,7 @@ test.describe("Piano Roll", () => {
 
     // Shift+click on first note to add to selection
     await page.keyboard.down("Shift");
-    await page.mouse.click(note1X + BEAT_WIDTH * 0.25, note1Y);
+    await page.mouse.click(note1X + DEFAULT_PIXELS_PER_BEAT * 0.25, note1Y);
     await page.keyboard.up("Shift");
 
     // Both notes should now be selected
@@ -404,20 +410,20 @@ test.describe("Piano Roll", () => {
     }
 
     // Create two notes
-    const note1X = gridBox.x + BEAT_WIDTH * 1;
+    const note1X = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 1;
     const note1Y = gridBox.y + ROW_HEIGHT * 2;
     await page.mouse.move(note1X, note1Y);
     await page.mouse.down();
-    await page.mouse.move(note1X + BEAT_WIDTH, note1Y);
+    await page.mouse.move(note1X + DEFAULT_PIXELS_PER_BEAT, note1Y);
     await page.mouse.up();
 
     await page.keyboard.press("Escape");
 
-    const note2X = gridBox.x + BEAT_WIDTH * 2;
+    const note2X = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 2;
     const note2Y = gridBox.y + ROW_HEIGHT * 3;
     await page.mouse.move(note2X, note2Y);
     await page.mouse.down();
-    await page.mouse.move(note2X + BEAT_WIDTH, note2Y);
+    await page.mouse.move(note2X + DEFAULT_PIXELS_PER_BEAT, note2Y);
     await page.mouse.up();
 
     await page.keyboard.press("Escape");
@@ -430,9 +436,9 @@ test.describe("Piano Roll", () => {
     await expect(notes.last()).toHaveAttribute("data-selected", "false");
 
     // Shift+drag a box that covers both notes
-    const boxStartX = gridBox.x + BEAT_WIDTH * 0.5;
+    const boxStartX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5;
     const boxStartY = gridBox.y + ROW_HEIGHT * 1.5;
-    const boxEndX = gridBox.x + BEAT_WIDTH * 3.5;
+    const boxEndX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 3.5;
     const boxEndY = gridBox.y + ROW_HEIGHT * 4.5;
 
     await page.keyboard.down("Shift");
@@ -494,11 +500,11 @@ test.describe("Piano Roll", () => {
     }
 
     // Create a note at beat 1
-    const startX = gridBox.x + BEAT_WIDTH * 1.5;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 1.5;
     const startY = gridBox.y + ROW_HEIGHT * 2.5;
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
 
     // Verify one note is created and selected
@@ -521,7 +527,10 @@ test.describe("Piano Roll", () => {
     await page.keyboard.down("Control");
     await page.mouse.move(noteCenter, noteMiddleY);
     await page.mouse.down();
-    await page.mouse.move(noteCenter + BEAT_WIDTH * 2, noteMiddleY);
+    await page.mouse.move(
+      noteCenter + DEFAULT_PIXELS_PER_BEAT * 2,
+      noteMiddleY,
+    );
     await page.mouse.up();
     await page.keyboard.up("Control");
 
@@ -559,28 +568,34 @@ test.describe("Piano Roll", () => {
     }
 
     // Create first note
-    const note1X = gridBox.x + BEAT_WIDTH * 1.5;
+    const note1X = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 1.5;
     const note1Y = gridBox.y + ROW_HEIGHT * 2.5;
     await page.mouse.move(note1X, note1Y);
     await page.mouse.down();
-    await page.mouse.move(note1X + BEAT_WIDTH, note1Y);
+    await page.mouse.move(note1X + DEFAULT_PIXELS_PER_BEAT, note1Y);
     await page.mouse.up();
 
     // Create second note at different position
     await page.keyboard.press("Escape");
-    const note2X = gridBox.x + BEAT_WIDTH * 1.5;
+    const note2X = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 1.5;
     const note2Y = gridBox.y + ROW_HEIGHT * 4.5;
     await page.mouse.move(note2X, note2Y);
     await page.mouse.down();
-    await page.mouse.move(note2X + BEAT_WIDTH, note2Y);
+    await page.mouse.move(note2X + DEFAULT_PIXELS_PER_BEAT, note2Y);
     await page.mouse.up();
 
     // Select both notes with box select
     await page.keyboard.press("Escape");
     await page.keyboard.down("Shift");
-    await page.mouse.move(note1X - BEAT_WIDTH * 0.5, note1Y - ROW_HEIGHT * 0.5);
+    await page.mouse.move(
+      note1X - DEFAULT_PIXELS_PER_BEAT * 0.5,
+      note1Y - ROW_HEIGHT * 0.5,
+    );
     await page.mouse.down();
-    await page.mouse.move(note2X + BEAT_WIDTH * 1.5, note2Y + ROW_HEIGHT * 0.5);
+    await page.mouse.move(
+      note2X + DEFAULT_PIXELS_PER_BEAT * 1.5,
+      note2Y + ROW_HEIGHT * 0.5,
+    );
     await page.mouse.up();
     await page.keyboard.up("Shift");
 
@@ -592,9 +607,9 @@ test.describe("Piano Roll", () => {
 
     // Ctrl+drag one of the selected notes to duplicate both
     await page.keyboard.down("Control");
-    await page.mouse.move(note1X + BEAT_WIDTH * 0.5, note1Y);
+    await page.mouse.move(note1X + DEFAULT_PIXELS_PER_BEAT * 0.5, note1Y);
     await page.mouse.down();
-    await page.mouse.move(note1X + BEAT_WIDTH * 3, note1Y);
+    await page.mouse.move(note1X + DEFAULT_PIXELS_PER_BEAT * 3, note1Y);
     await page.mouse.up();
     await page.keyboard.up("Control");
 

--- a/e2e/settings-export.spec.ts
+++ b/e2e/settings-export.spec.ts
@@ -1,10 +1,10 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, type Page, test } from "@playwright/test";
+import { DEFAULT_PIXELS_PER_BEAT } from "../src/lib/timeline";
 import { clickNewProject, evaluateStore } from "./helpers";
 
-// Constants matching piano-roll.tsx
-const BEAT_WIDTH = 80;
+// Row height matches piano-roll.tsx.
 const ROW_HEIGHT = 20;
 
 test.describe("Settings Dialog - Project Export", () => {
@@ -29,12 +29,12 @@ test.describe("Settings Dialog - Project Export", () => {
     }
 
     await page.mouse.move(
-      gridBox.x + BEAT_WIDTH * 1.5,
+      gridBox.x + DEFAULT_PIXELS_PER_BEAT * 1.5,
       gridBox.y + ROW_HEIGHT * 3.5,
     );
     await page.mouse.down();
     await page.mouse.move(
-      gridBox.x + BEAT_WIDTH * 3,
+      gridBox.x + DEFAULT_PIXELS_PER_BEAT * 3,
       gridBox.y + ROW_HEIGHT * 3.5,
     );
     await page.mouse.up();

--- a/e2e/transport.spec.ts
+++ b/e2e/transport.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { DEFAULT_PIXELS_PER_BEAT } from "../src/lib/timeline";
 import {
   clickNewProject,
   evaluateStore,
@@ -6,9 +7,6 @@ import {
   waitForAudioReady,
   waitForEditor,
 } from "./helpers";
-
-// Constants matching piano-roll.tsx
-const BEAT_WIDTH = 80;
 
 test.describe("Transport Controls", () => {
   test.beforeEach(async ({ page }) => {
@@ -373,7 +371,7 @@ test.describe("Timeline Seek", () => {
 
     // Default grid snap is 1/8 note = 0.5 beats
     // Click at beat 2.2 (should snap to beat 2.0 - rounds down)
-    const clickX = timelineBox.x + BEAT_WIDTH * 2.2;
+    const clickX = timelineBox.x + DEFAULT_PIXELS_PER_BEAT * 2.2;
     const clickY = timelineBox.y + timelineBox.height / 2;
     await page.mouse.click(clickX, clickY);
 
@@ -388,12 +386,12 @@ test.describe("Timeline Seek", () => {
     }
 
     // Calculate expected position for beat 2.0
-    const expectedX = timelineBox.x + BEAT_WIDTH * 2;
+    const expectedX = timelineBox.x + DEFAULT_PIXELS_PER_BEAT * 2;
     // Allow 2px tolerance for rounding
     expect(Math.abs(playheadBox.x - expectedX)).toBeLessThan(2);
 
     // Click at beat 2.3 (should snap to beat 2.5 - rounds up to nearest)
-    const clickX2 = timelineBox.x + BEAT_WIDTH * 2.3;
+    const clickX2 = timelineBox.x + DEFAULT_PIXELS_PER_BEAT * 2.3;
     await page.mouse.click(clickX2, clickY);
     await page.waitForTimeout(100);
 
@@ -403,7 +401,7 @@ test.describe("Timeline Seek", () => {
     }
 
     // Calculate expected position for beat 2.5
-    const expectedX2 = timelineBox.x + BEAT_WIDTH * 2.5;
+    const expectedX2 = timelineBox.x + DEFAULT_PIXELS_PER_BEAT * 2.5;
     expect(Math.abs(playheadBox2.x - expectedX2)).toBeLessThan(2);
   });
 
@@ -415,11 +413,11 @@ test.describe("Timeline Seek", () => {
     }
 
     // Create a note at beat 2
-    const noteX = gridBox.x + BEAT_WIDTH * 2;
+    const noteX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 2;
     const noteY = gridBox.y + 100;
     await page.mouse.move(noteX, noteY);
     await page.mouse.down();
-    await page.mouse.move(noteX + BEAT_WIDTH, noteY);
+    await page.mouse.move(noteX + DEFAULT_PIXELS_PER_BEAT, noteY);
     await page.mouse.up();
 
     // Seek to beat 4 (past the note)
@@ -429,7 +427,7 @@ test.describe("Timeline Seek", () => {
       throw new Error("Timeline not found");
     }
 
-    const seekX = timelineBox.x + BEAT_WIDTH * 4;
+    const seekX = timelineBox.x + DEFAULT_PIXELS_PER_BEAT * 4;
     await page.mouse.click(seekX, timelineBox.y + timelineBox.height / 2);
 
     // Start playback (Space is a no-op until audio is ready)
@@ -452,6 +450,8 @@ test.describe("Timeline Seek", () => {
     }
 
     // Playhead should still be around beat 4+ (not reset to 0)
-    expect(playheadBox.x).toBeGreaterThan(timelineBox.x + BEAT_WIDTH * 3);
+    expect(playheadBox.x).toBeGreaterThan(
+      timelineBox.x + DEFAULT_PIXELS_PER_BEAT * 3,
+    );
   });
 });

--- a/e2e/undo-redo.spec.ts
+++ b/e2e/undo-redo.spec.ts
@@ -1,12 +1,12 @@
 import { expect, test } from "@playwright/test";
+import { DEFAULT_PIXELS_PER_BEAT } from "../src/lib/timeline";
 import {
   clickNewProject,
   evaluateFlushAutoSave,
   waitForEditor,
 } from "./helpers";
 
-// Constants matching piano-roll.tsx
-const BEAT_WIDTH = 80;
+// Row height matches piano-roll.tsx.
 const ROW_HEIGHT = 20;
 
 // TODO: add coverage for resize batching (drag through many steps creates a single undo entry)
@@ -25,12 +25,12 @@ test.describe("Undo/Redo", () => {
     }
 
     // Create a note
-    const startX = gridBox.x + BEAT_WIDTH * 0.5;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5;
     const startY = gridBox.y + ROW_HEIGHT * 0.5;
 
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
 
     // Verify note was created
@@ -52,12 +52,12 @@ test.describe("Undo/Redo", () => {
     }
 
     // Create a note
-    const startX = gridBox.x + BEAT_WIDTH * 0.5;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5;
     const startY = gridBox.y + ROW_HEIGHT * 0.5;
 
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
 
     const note = page.locator("[data-testid^='note-']");
@@ -82,12 +82,12 @@ test.describe("Undo/Redo", () => {
     }
 
     // Create a note at row 5
-    const startX = gridBox.x + BEAT_WIDTH * 0.5;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5;
     const startY = gridBox.y + ROW_HEIGHT * 5.5;
 
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
 
     const note = page.locator("[data-testid^='note-']").first();
@@ -99,10 +99,10 @@ test.describe("Undo/Redo", () => {
     const initialY = initialBox.y;
 
     // Move note horizontally
-    const noteCenter = startX + BEAT_WIDTH * 0.5;
+    const noteCenter = startX + DEFAULT_PIXELS_PER_BEAT * 0.5;
     await page.mouse.move(noteCenter, startY);
     await page.mouse.down();
-    await page.mouse.move(noteCenter + BEAT_WIDTH * 2, startY);
+    await page.mouse.move(noteCenter + DEFAULT_PIXELS_PER_BEAT * 2, startY);
     await page.mouse.up();
 
     // Verify note moved
@@ -132,12 +132,12 @@ test.describe("Undo/Redo", () => {
     }
 
     // Create a note
-    const startX = gridBox.x + BEAT_WIDTH * 0.5;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5;
     const startY = gridBox.y + ROW_HEIGHT * 0.5;
 
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
 
     const note = page.locator("[data-testid^='note-']").first();
@@ -154,7 +154,7 @@ test.describe("Undo/Redo", () => {
     );
     await page.mouse.down();
     await page.mouse.move(
-      initialBox.x + initialBox.width + BEAT_WIDTH,
+      initialBox.x + initialBox.width + DEFAULT_PIXELS_PER_BEAT,
       initialBox.y + initialBox.height / 2,
     );
     await page.mouse.up();
@@ -185,12 +185,12 @@ test.describe("Undo/Redo", () => {
     }
 
     // Create a note
-    const startX = gridBox.x + BEAT_WIDTH * 0.5;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5;
     const startY = gridBox.y + ROW_HEIGHT * 0.5;
 
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
 
     const note = page.locator("[data-testid^='note-']");
@@ -223,25 +223,31 @@ test.describe("Undo/Redo", () => {
     const note = page.locator("[data-testid^='note-']");
 
     // Create first note
-    const startX = gridBox.x + BEAT_WIDTH * 0.5;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5;
     const startY = gridBox.y + ROW_HEIGHT * 0.5;
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
     await expect(note).toHaveCount(1);
 
     // Create second note
     await page.mouse.move(startX, startY + ROW_HEIGHT);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY + ROW_HEIGHT);
+    await page.mouse.move(
+      startX + DEFAULT_PIXELS_PER_BEAT,
+      startY + ROW_HEIGHT,
+    );
     await page.mouse.up();
     await expect(note).toHaveCount(2);
 
     // Create third note
     await page.mouse.move(startX, startY + ROW_HEIGHT * 2);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY + ROW_HEIGHT * 2);
+    await page.mouse.move(
+      startX + DEFAULT_PIXELS_PER_BEAT,
+      startY + ROW_HEIGHT * 2,
+    );
     await page.mouse.up();
     await expect(note).toHaveCount(3);
 
@@ -276,11 +282,11 @@ test.describe("Undo/Redo", () => {
     const note = page.locator("[data-testid^='note-']");
 
     // Create a note
-    const startX = gridBox.x + BEAT_WIDTH * 0.5;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5;
     const startY = gridBox.y + ROW_HEIGHT * 0.5;
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
     await expect(note).toHaveCount(1);
 
@@ -291,7 +297,10 @@ test.describe("Undo/Redo", () => {
     // Create a different note (should clear redo stack)
     await page.mouse.move(startX, startY + ROW_HEIGHT);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY + ROW_HEIGHT);
+    await page.mouse.move(
+      startX + DEFAULT_PIXELS_PER_BEAT,
+      startY + ROW_HEIGHT,
+    );
     await page.mouse.up();
     await expect(note).toHaveCount(1);
 
@@ -314,11 +323,11 @@ test.describe("Undo/Redo", () => {
     const note = page.locator("[data-testid^='note-']");
 
     // Create a note
-    const startX = gridBox.x + BEAT_WIDTH * 0.5;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5;
     const startY = gridBox.y + ROW_HEIGHT * 0.5;
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
     await expect(note).toHaveCount(1);
 
@@ -347,11 +356,11 @@ test.describe("Undo/Redo", () => {
     const notes = page.locator("[data-testid^='note-']");
 
     // Create first note at row 5
-    const startX = gridBox.x + BEAT_WIDTH * 0.5;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5;
     const row1Y = gridBox.y + ROW_HEIGHT * 5.5;
     await page.mouse.move(startX, row1Y);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, row1Y);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, row1Y);
     await page.mouse.up();
     await expect(notes).toHaveCount(1);
 
@@ -359,7 +368,7 @@ test.describe("Undo/Redo", () => {
     const row2Y = gridBox.y + ROW_HEIGHT * 6.5;
     await page.mouse.move(startX, row2Y);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, row2Y);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, row2Y);
     await page.mouse.up();
     await expect(notes).toHaveCount(2);
 
@@ -377,7 +386,7 @@ test.describe("Undo/Redo", () => {
     await page.keyboard.down("Shift");
     await page.mouse.down();
     await page.mouse.move(
-      gridBox.x + BEAT_WIDTH * 2,
+      gridBox.x + DEFAULT_PIXELS_PER_BEAT * 2,
       gridBox.y + ROW_HEIGHT * 7.5,
     );
     await page.mouse.up();
@@ -389,7 +398,7 @@ test.describe("Undo/Redo", () => {
     const moveStartY = initial1.y + initial1.height / 2;
     await page.mouse.move(moveStartX, moveStartY);
     await page.mouse.down();
-    await page.mouse.move(moveStartX + BEAT_WIDTH * 2, moveStartY);
+    await page.mouse.move(moveStartX + DEFAULT_PIXELS_PER_BEAT * 2, moveStartY);
     await page.mouse.up();
 
     // Verify both notes moved
@@ -434,11 +443,11 @@ test.describe("Undo/Redo", () => {
     }
 
     // Create a note
-    const startX = gridBox.x + BEAT_WIDTH * 0.5;
+    const startX = gridBox.x + DEFAULT_PIXELS_PER_BEAT * 0.5;
     const startY = gridBox.y + ROW_HEIGHT * 5.5;
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX + BEAT_WIDTH, startY);
+    await page.mouse.move(startX + DEFAULT_PIXELS_PER_BEAT, startY);
     await page.mouse.up();
 
     const note = page.locator("[data-testid^='note-']").first();
@@ -449,13 +458,16 @@ test.describe("Undo/Redo", () => {
     const initialX = initialBox.x;
 
     // Drag note through MANY intermediate steps (simulating a long drag)
-    const noteCenter = startX + BEAT_WIDTH * 0.5;
+    const noteCenter = startX + DEFAULT_PIXELS_PER_BEAT * 0.5;
     await page.mouse.move(noteCenter, startY);
     await page.mouse.down();
 
     // Move through 10 intermediate positions
     for (let i = 1; i <= 10; i++) {
-      await page.mouse.move(noteCenter + BEAT_WIDTH * 0.3 * i, startY);
+      await page.mouse.move(
+        noteCenter + DEFAULT_PIXELS_PER_BEAT * 0.3 * i,
+        startY,
+      );
     }
     await page.mouse.up();
 

--- a/src/lib/project-store.ts
+++ b/src/lib/project-store.ts
@@ -13,6 +13,7 @@ import { historyStore, type NoteChanges } from "./history-store";
 import { snapToGrid } from "./music";
 import type { KeySignature } from "./pitch-spelling";
 import { getFret, moveTabString, TAB_STRING_PRESETS } from "./tab-annotation";
+import { DEFAULT_PIXELS_PER_BEAT } from "./timeline";
 
 type NoteUpdate = {
   id: string;
@@ -209,10 +210,10 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   autoScrollEnabled: true,
   linkAudioOffsetsEnabled: true,
 
-  // Viewport state (defaults match piano-roll.tsx)
+  // Viewport state
   scrollX: 0,
   scrollY: 51, // MAX_PITCH (127) - DEFAULT_VIEW_MAX_PITCH (76)
-  pixelsPerBeat: 80, // DEFAULT_PIXELS_PER_BEAT
+  pixelsPerBeat: DEFAULT_PIXELS_PER_BEAT,
   pixelsPerKey: 20, // DEFAULT_PIXELS_PER_KEY
 
   addNote: (note) => {
@@ -736,7 +737,7 @@ const DEFAULTS = {
   // Viewport state defaults
   scrollX: 0,
   scrollY: 51, // MAX_PITCH (127) - DEFAULT_VIEW_MAX_PITCH (76)
-  pixelsPerBeat: 80,
+  pixelsPerBeat: DEFAULT_PIXELS_PER_BEAT,
   pixelsPerKey: 20,
 } satisfies Omit<SavedProject, "version">;
 


### PR DESCRIPTION
The default timeline scale was duplicated as BEAT_WIDTH, pixelsPerBeat, and raw pixel distances across E2E tests, while the project store also hardcoded it in two places.

This PR uses DEFAULT_PIXELS_PER_BEAT from src/lib/timeline.ts as the single source of truth for project defaults and default-scale E2E geometry. Beat-based distances are expressed as multiples of that constant. Explicit non-default zoom, historical migration fixtures, and unrelated pixel measurements stay unchanged. No behavior changes are intended.
