### PR TITLE
fix: keep recorder playhead below floating panels

### DIFF
--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -276,7 +276,7 @@ export function Recorder({ projectId }: { projectId: string }) {
         />
         <section
           data-testid="recorder-track-scroll"
-          className="relative min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto"
+          className="relative isolate min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto"
         >
           <div
             ref={timeline.viewportRef}


### PR DESCRIPTION
The recorder playhead's z-50 layer could draw over the floating mixer and reference video panels at z-40 because the timeline had no stacking context of its own.

This PR isolates the track-scroll section so the playhead stays above timeline content but below floating panels, without raising panel z-index values.