### PR TITLE
test: wait for playback before measuring recorder rate

### DIFF
--- a/e2e/fake-audio/recorder-transport.test.ts
+++ b/e2e/fake-audio/recorder-transport.test.ts
@@ -88,13 +88,18 @@ for (const playbackRate of [0.5, 1.5]) {
       }));
 
     await page.getByTestId("recorder-play-button").click();
+    // Exclude the transport's scheduling lead from the playback-rate measurement.
+    await expect.poll(() => getRecorderPosition(page)).toBeGreaterThan(0.1);
+    checkpoint("playback advancing");
     const start = await sample();
     await page.waitForTimeout(1_000);
     const end = await sample();
 
     const observedRate =
       (end.position - start.position) / (end.wallTime - start.wallTime);
-    checkpoint("sample playback clocks");
+    checkpoint(
+      `sample playback clocks: expected ${playbackRate}, observed ${observedRate}`,
+    );
     expect(observedRate).toBeCloseTo(playbackRate, 1);
   });
 }


### PR DESCRIPTION
The recorder playback-rate E2E samples immediately after clicking Play, so its one-second window can include the transport's 30 ms scheduling lead. Combined with DOM update timing, this can undercount playback progress and fail the 1.5x assertion in CI.

This PR waits for position to advance past 0.1 seconds before measuring and logs the observed rate in the existing checkpoints. The measurement window and tolerance stay unchanged. Both rates passed 10 repetitions each with two workers, with observed rates of 0.492–0.502 and 1.495–1.511. `pnpm lint` also passed.
