### PR TITLE
fix: show a blocking notice when the recorder project fails to initialize

### DIFF
--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1,4 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
+import { Mic2Icon } from "lucide-react";
 import { useState, useSyncExternalStore } from "react";
 import { useWindowEvent } from "../../hooks/use-window-event";
 import { resolveAudioFiles } from "../../lib/audio-files";
@@ -9,6 +10,7 @@ import {
 } from "../../lib/keyboard";
 import { exportRecorderProjectArchive } from "../../lib/recorder/project-archive";
 import { RecorderRuntime } from "../../lib/recorder/runtime";
+import { routes } from "../../lib/routes";
 import { beatsToSeconds } from "../../lib/timeline";
 import { parseTimeSignature } from "../../types";
 import { Dialog } from "../ui/dialog";
@@ -154,6 +156,9 @@ export function Recorder({ projectId }: { projectId: string }) {
     isProcessing;
 
   useWindowEvent("keydown", (event) => {
+    if (project.loadError) {
+      return;
+    }
     if (isHelpOpen) {
       if (!event.repeat && matchKeyboardEvent(event, "Escape")) {
         event.preventDefault();
@@ -229,6 +234,10 @@ export function Recorder({ projectId }: { projectId: string }) {
       timeline.setAutoScrollEnabled(!timeline.autoScrollEnabled);
     }
   });
+
+  if (project.loadError) {
+    return <RecorderLoadError error={project.loadError} />;
+  }
 
   return (
     <main className="flex h-screen flex-col overflow-hidden bg-neutral-900 text-neutral-100">
@@ -683,6 +692,24 @@ export function Recorder({ projectId }: { projectId: string }) {
           />
         )}
       </div>
+    </main>
+  );
+}
+
+function RecorderLoadError({ error }: { error: Error }) {
+  return (
+    <main className="flex h-screen flex-col items-center justify-center gap-6 bg-neutral-900 px-6 text-neutral-100">
+      <div className="flex max-w-md flex-col items-center gap-2 text-center">
+        <Mic2Icon className="size-6 text-emerald-400" />
+        <h1 className="text-lg font-medium">Could not open this recording</h1>
+        <p className="text-sm text-neutral-400">{error.message}</p>
+      </div>
+      <a
+        href={routes.home.href()}
+        className="rounded-md border border-neutral-700 px-3 py-1.5 text-sm hover:bg-neutral-800"
+      >
+        Back to projects
+      </a>
     </main>
   );
 }

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -157,7 +157,7 @@ export function Recorder({ projectId }: { projectId: string }) {
     isProcessing;
 
   useWindowEvent("keydown", (event) => {
-    if (project.loadError) {
+    if (project.initError) {
       return;
     }
     if (isHelpOpen) {
@@ -238,7 +238,7 @@ export function Recorder({ projectId }: { projectId: string }) {
 
   return (
     <main
-      inert={project.loadError !== undefined}
+      inert={project.initError !== undefined}
       className="flex h-screen flex-col overflow-hidden bg-neutral-900 text-neutral-100"
     >
       <RecorderHeader
@@ -693,9 +693,9 @@ export function Recorder({ projectId }: { projectId: string }) {
           />
         )}
       </div>
-      {project.loadError &&
+      {project.initError &&
         createPortal(
-          <RecorderLoadError error={project.loadError} />,
+          <RecorderInitError error={project.initError} />,
           document.body,
         )}
     </main>
@@ -704,18 +704,18 @@ export function Recorder({ projectId }: { projectId: string }) {
 
 // Rendered outside the inert editor so the notice stays interactive while
 // everything beneath it is blocked from pointer and keyboard access.
-function RecorderLoadError({ error }: { error: Error }) {
+function RecorderInitError({ error }: { error: Error }) {
   return (
     <div
       role="alertdialog"
       aria-modal="true"
-      aria-labelledby="recorder-load-error-title"
+      aria-labelledby="recorder-init-error-title"
       className="fixed inset-0 z-50 flex items-center justify-center bg-neutral-900/80 p-4 text-neutral-100"
     >
       <div className="flex w-full max-w-md flex-col items-center gap-4 rounded-lg border border-neutral-700 bg-neutral-800 p-6 text-center shadow-2xl">
         <Mic2Icon className="size-6 text-emerald-400" />
         <div className="flex flex-col gap-1">
-          <h1 id="recorder-load-error-title" className="text-lg font-medium">
+          <h1 id="recorder-init-error-title" className="text-lg font-medium">
             Could not open this recording
           </h1>
           <p className="text-sm text-neutral-400">{error.message}</p>

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -716,7 +716,7 @@ function RecorderInitError({ error }: { error: Error }) {
         <Mic2Icon className="size-6 text-emerald-400" />
         <div className="flex flex-col gap-1">
           <h1 id="recorder-init-error-title" className="text-lg font-medium">
-            Could not open this recording
+            Could not open this project
           </h1>
           <p className="text-sm text-neutral-400">{error.message}</p>
         </div>

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -710,7 +710,7 @@ function RecorderInitError({ error }: { error: Error }) {
       role="alertdialog"
       aria-modal="true"
       aria-labelledby="recorder-init-error-title"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-neutral-900/80 p-4 text-neutral-100"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-neutral-900/50 p-4 text-neutral-100"
     >
       <div className="flex w-full max-w-md flex-col items-center gap-4 rounded-lg border border-neutral-700 bg-neutral-800 p-6 text-center shadow-2xl">
         <Mic2Icon className="size-6 text-emerald-400" />

--- a/src/components/recorder/use-recorder-project.ts
+++ b/src/components/recorder/use-recorder-project.ts
@@ -32,6 +32,10 @@ export function useRecorderProject({
 
   const saveMutation = useMutation({
     mutationFn: async () => {
+      // Never write default state over a project that did not initialize.
+      if (!projectQuery.isSuccess) {
+        throw new Error("Cannot save before the project has initialized.");
+      }
       const revision = revisionRef.current;
       await recorderProjectStorage.save({
         id: projectId,

--- a/src/components/recorder/use-recorder-project.ts
+++ b/src/components/recorder/use-recorder-project.ts
@@ -1,6 +1,5 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
-import { toast } from "sonner";
 import { useWindowEvent } from "../../hooks/use-window-event";
 import { recorderProjectStorage } from "../../lib/recorder/project-storage";
 import { RecorderRuntime } from "../../lib/recorder/runtime";
@@ -22,14 +21,9 @@ export function useRecorderProject({
     retry: false,
     staleTime: Infinity,
     queryFn: async () => {
-      try {
-        const project = await recorderProjectStorage.load(projectId);
-        runtime.deserializeProject(project);
-        return true;
-      } catch (error) {
-        toast.error(error instanceof Error ? error.message : "Unknown error");
-        throw error;
-      }
+      const project = await recorderProjectStorage.load(projectId);
+      runtime.deserializeProject(project);
+      return true;
     },
   });
 
@@ -72,8 +66,8 @@ export function useRecorderProject({
         : "saved";
   return {
     dirty,
-    error: projectQuery.error ?? saveMutation.error,
-    ready: projectQuery.isSuccess || projectQuery.isError,
+    loadError: projectQuery.error ?? undefined,
+    ready: projectQuery.isSuccess,
     save: saveMutation.mutate,
     saveStatus,
     saving: saveMutation.isPending,

--- a/src/components/recorder/use-recorder-project.ts
+++ b/src/components/recorder/use-recorder-project.ts
@@ -69,7 +69,7 @@ export function useRecorderProject({
         : "saved";
   return {
     dirty,
-    loadError: projectQuery.error ?? undefined,
+    initError: projectQuery.error ?? undefined,
     ready: projectQuery.isSuccess,
     save: saveMutation.mutate,
     saveStatus,


### PR DESCRIPTION
`useRecorderProject` reported `ready` as "the query settled" rather than "the query succeeded", so a stale deep link or a storage failure toasted the error and then kept running the editor as an empty default project under the real project id. Save stayed disabled only because the dirty subscription happens to be wired on success, which also meant the header showed "saved" while the user edited a project that would never persist. Export was enabled and would export the empty project under the real name. Any future cleanup that wires dirty tracking on `ready` would turn a failed load plus one edit into overwriting the stored project.

This PR makes `ready` mean the page initialized successfully, where initialization covers runtime worklet registration, the storage read, and deserialization. When any of that fails the hook exposes `initError` and the page shows a blocking notice over the editor with the failure message and a link back to the project home. The editor stays mounted, since the runtime and its hooks are alive either way, but it is marked `inert` so nothing beneath the notice can be reached by pointer or focus, and the window keyboard shortcuts bail out while the error is set. The notice is portaled to `document.body` so it stays interactive outside the inert subtree. The error toast goes away since the message is now on the page. As a precaution independent of the UI, the save mutation now throws before the project has initialized, so a stray save can never write default state over the stored project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXzHK7enKieoZ4sKFRhNm7

