### PR TITLE
fix: hide the default recorder title until the project initializes

### DIFF
--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -242,7 +242,7 @@ export function Recorder({ projectId }: { projectId: string }) {
       className="flex h-screen flex-col overflow-hidden bg-neutral-900 text-neutral-100"
     >
       <RecorderHeader
-        title={state.title}
+        title={project.ready ? state.title : undefined}
         saveStatus={project.saveStatus}
         referenceVideoOpen={isReferenceVideoOpen}
         isPlaying={state.isPlaying}

--- a/src/components/recorder/recorder-header.tsx
+++ b/src/components/recorder/recorder-header.tsx
@@ -90,7 +90,8 @@ export function RecorderHeader({
   onHelpOpen,
   mixerOpen,
 }: {
-  title: string;
+  /** Undefined until the project has initialized, so the default title never shows. */
+  title?: string;
   saveStatus: SaveStatus;
   referenceVideoOpen: boolean;
   isPlaying: boolean;
@@ -344,6 +345,7 @@ export function RecorderHeader({
         type="button"
         data-testid="recorder-project-name"
         title="Rename project"
+        disabled={title === undefined}
         onClick={() => {
           const nextTitle = window.prompt("Project name", title)?.trim();
           if (nextTitle && nextTitle !== title) {
@@ -352,7 +354,12 @@ export function RecorderHeader({
         }}
         className="max-w-[220px] truncate text-sm text-neutral-300 hover:text-neutral-100"
       >
-        {title}
+        {title ?? (
+          <span
+            aria-label="Loading project name"
+            className="inline-block h-3 w-24 rounded bg-neutral-700 align-middle"
+          />
+        )}
       </button>
       <div className="h-5 w-px bg-neutral-600" />
       <Button


### PR DESCRIPTION
- follow-up to https://github.com/hi-ogawa/toy-midi/pull/488

The recorder header renders whatever title the runtime store holds, and the store starts from the default state until the project query deserializes the real one. Every open therefore flashed "Untitled recording" before the actual name appeared. Tracks and clips appearing a moment later read as loading, but a wrong name replaced by the right one reads as a glitch. Storage is async, so the real name cannot be known synchronously on a deep link or reload, and the default title is also what a genuinely new project is named at creation, so changing the default would change new project naming.

This PR passes the title to the header only once the project is ready and renders a skeleton bar in its place until then, with the rename button disabled. That also closes a small gap where a rename during load would have been overwritten by deserialization a moment later. The same placeholder shows behind the init error notice, since `ready` is false there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXzHK7enKieoZ4sKFRhNm7
