### PR TITLE
fix: clarify recorder input status labels

### DIFF
--- a/e2e/fake-audio/recorder-helpers.ts
+++ b/e2e/fake-audio/recorder-helpers.ts
@@ -96,7 +96,7 @@ export async function enableInput(page: Page) {
   await expect(page.getByLabel("Channel")).toContainText("Channel 1");
   await page.getByRole("button", { name: "Close" }).click();
   await expect(
-    page.getByText("Fake Default Audio Input · Input 1"),
+    page.getByText("Fake Default Audio Input · Channel 1"),
   ).toBeVisible();
   await expect(page.getByTestId("recorder-input-toggle")).toHaveAttribute(
     "aria-pressed",

--- a/src/components/recorder/use-recorder-input.ts
+++ b/src/components/recorder/use-recorder-input.ts
@@ -110,7 +110,7 @@ export function useRecorderInput({
             label: `${selectedDevice.label || "Audio input"} · Input ${state.selectedChannel + 1}`,
             needsSetup: false,
           }
-        : { label: "No input configured · Set up", needsSetup: true };
+        : { label: "No input configured", needsSetup: true };
 
   return {
     active,

--- a/src/components/recorder/use-recorder-input.ts
+++ b/src/components/recorder/use-recorder-input.ts
@@ -104,7 +104,7 @@ export function useRecorderInput({
   const route = !initialized
     ? { label: "Loading audio inputs…", needsSetup: false }
     : !hasAccess
-      ? { label: "Microphone access required · Set up", needsSetup: true }
+      ? { label: "Microphone access required", needsSetup: true }
       : selectedDevice
         ? {
             label: `${selectedDevice.label || "Audio input"} · Input ${state.selectedChannel + 1}`,

--- a/src/components/recorder/use-recorder-input.ts
+++ b/src/components/recorder/use-recorder-input.ts
@@ -107,7 +107,7 @@ export function useRecorderInput({
       ? { label: "Microphone access required", needsSetup: true }
       : selectedDevice
         ? {
-            label: `${selectedDevice.label || "Audio input"} · Input ${state.selectedChannel + 1}`,
+            label: `${selectedDevice.label || "Unnamed input"} · Channel ${state.selectedChannel + 1}`,
             needsSetup: false,
           }
         : { label: "No input configured", needsSetup: true };


### PR DESCRIPTION
The input status labels include a redundant “· Set up” suffix that can get cut off. This PR removes it from “Microphone access required” and “No input configured”, since the adjacent settings button already opens input setup.

The selected device label now uses “Channel N” to match the setup dialog and falls back to “Unnamed input” when the device has no name.
