### PR TITLE
refactor: share multi-region track playback with capture

### DIFF
--- a/src/lib/recorder/README.md
+++ b/src/lib/recorder/README.md
@@ -9,26 +9,31 @@ flowchart LR
     captureWorklet --> analyser["captureInput.analyser.node"]
     analyser --> monitorGain["captureInput.monitorGain"]
     monitorGain --> captureInput
-    takeSource["recordingTrackPlaybacks[i].source"] --> takeBusInput
-    subgraph takePlaybackBus["takePlaybackBus: PlaybackBus"]
-        takeBusInput["input"] --> takePitchShifter["pitchShifter (optional)"]
-    end
-    takePitchShifter --> takePlaybackGain["takePlaybackGain"]
-    takePlaybackGain --> captureInput
 
-    subgraph captureChannel["captureChannel: AudioChannel"]
-        captureInput["input"] --> captureEqualizer["equalizer"]
-        captureEqualizer --> captureGain["gain"]
+    subgraph captureTrack["captureTrack: AudioTrackPlayback"]
+        takeSource["playbacks[i].source"] --> takeBusInput
+        subgraph takePlaybackBus["bus: PlaybackBus"]
+            takeBusInput["input"] --> takePitchShifter["pitchShifter (optional)"]
+        end
+        takePitchShifter --> takePlaybackGain["playbackGain"]
+        takePlaybackGain --> captureInput
+        subgraph captureChannel["channel: AudioChannel"]
+            captureInput["input"] --> captureEqualizer["equalizer"]
+            captureEqualizer --> captureGain["gain"]
+        end
     end
 
-    audioSource["audioTracks.get(id).playback.source"] --> audioBusInput
-    subgraph audioPlaybackBus["audioTracks.get(id).bus: PlaybackBus"]
-        audioBusInput["input"] --> audioPitchShifter["pitchShifter (optional)"]
-    end
-    audioPitchShifter --> trackInput
-    subgraph audioChannel["audioTracks.get(id).channel: AudioChannel"]
-        trackInput["input"] --> trackEqualizer["equalizer"]
-        trackEqualizer --> trackGain["gain"]
+    subgraph audioTrack["audioTracks.get(id): AudioTrackPlayback"]
+        audioSource["playbacks[i].source"] --> audioBusInput
+        subgraph audioPlaybackBus["bus: PlaybackBus"]
+            audioBusInput["input"] --> audioPitchShifter["pitchShifter (optional)"]
+        end
+        audioPitchShifter --> audioPlaybackGain["playbackGain"]
+        audioPlaybackGain --> trackInput
+        subgraph audioChannel["channel: AudioChannel"]
+            trackInput["input"] --> trackEqualizer["equalizer"]
+            trackEqualizer --> trackGain["gain"]
+        end
     end
 
     captureGain --> masterOutput["masterOutput"]

--- a/src/lib/recorder/audio-track-playback.ts
+++ b/src/lib/recorder/audio-track-playback.ts
@@ -4,11 +4,14 @@ import { AudioChannel } from "./audio-channel.ts";
 import { PlaybackBus } from "./playback-bus.ts";
 import type { AudioContextTransport } from "./transport.ts";
 
-/** Owns an audio track's source, playback processing, and mixer channel. */
+/** Owns region playback and a channel that also accepts independently routed input. */
 export class AudioTrackPlayback {
-  private readonly playback: AudioBufferPlayback;
+  readonly channel: AudioChannel;
+  private readonly transport: AudioContextTransport;
+  private readonly playbacks: AudioBufferPlayback[] = [];
   private readonly bus: PlaybackBus;
-  private readonly channel: AudioChannel;
+  /** Mutes region playback without muting other sources connected to channel.input. */
+  private readonly playbackGain: GainNode;
 
   constructor({
     transport,
@@ -21,43 +24,56 @@ export class AudioTrackPlayback {
     eq: EqParameters;
     gain: number;
   }) {
+    this.transport = transport;
     this.channel = new AudioChannel({
       context: transport.context,
       output,
       eq,
       gain,
     });
-    this.bus = new PlaybackBus({ transport, output: this.channel.input });
-    this.playback = new AudioBufferPlayback({
-      transport,
-      output: this.bus.input,
-    });
+    this.playbackGain = transport.context.createGain();
+    this.playbackGain.connect(this.channel.input);
+    this.bus = new PlaybackBus({ transport, output: this.playbackGain });
   }
 
-  setBuffer(buffer?: AudioBuffer): void {
-    this.playback.stop();
-    this.playback.setBuffer(buffer);
+  setRegions(
+    regions: readonly {
+      buffer: AudioBuffer;
+      timelineOffset: number;
+      timelineStart: number;
+      timelineEnd: number;
+    }[],
+  ): void {
+    for (const playback of this.playbacks) {
+      playback.dispose();
+    }
+    this.playbacks.length = 0;
+    for (const region of regions) {
+      const playback = new AudioBufferPlayback({
+        transport: this.transport,
+        output: this.bus.input,
+      });
+      playback.setBuffer(region.buffer);
+      playback.setBufferTimelineOffset(region.timelineOffset);
+      playback.setTimelineRange({
+        start: region.timelineStart,
+        end: region.timelineEnd,
+      });
+      this.playbacks.push(playback);
+    }
   }
 
-  setBufferTimelineOffset(offset: number): void {
-    this.playback.setBufferTimelineOffset(offset);
-  }
-
-  setTimelineRange(range: { start: number; end: number }): void {
-    this.playback.setTimelineRange(range);
-  }
-
-  setEq(eq: EqParameters): void {
-    this.channel.setEq(eq);
-  }
-
-  setGain(gain: number): void {
-    this.channel.setGain(gain);
+  setPlaybackMuted(muted: boolean): void {
+    this.playbackGain.gain.setValueAtTime(
+      muted ? 0 : 1,
+      this.transport.context.currentTime,
+    );
   }
 
   dispose(): void {
-    this.playback.dispose();
+    this.setRegions([]);
     this.bus.dispose();
+    this.playbackGain.disconnect();
     this.channel.dispose();
   }
 }

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -10,8 +10,6 @@ import { ensurePitchShifterWorklet } from "../dsp/pitch-shifter-node.ts";
 import { clamp } from "../music.ts";
 import { beatsToSeconds } from "../timeline.ts";
 import type { YouTubePlayerApi } from "../youtube.ts";
-import { AudioBufferPlayback } from "./audio-buffer-playback.ts";
-import { AudioChannel } from "./audio-channel.ts";
 import { AudioTrackPlayback } from "./audio-track-playback.ts";
 import { CaptureInput } from "./capture-input.ts";
 import { RecorderMetronome } from "./metronome.ts";
@@ -25,7 +23,6 @@ import {
   type SerializedRecorderRuntimeState,
   serializeRecorderRuntimeState,
 } from "./persistence.ts";
-import { PlaybackBus } from "./playback-bus.ts";
 import { ActiveRecording } from "./recording.ts";
 import { deriveTakeRegions } from "./take-regions.ts";
 import type { TakeRegion, TakeState } from "./take.ts";
@@ -209,11 +206,7 @@ export class RecorderRuntime {
   private readonly transport: AudioContextTransport;
   captureInput?: CaptureInput;
   private audioTracks = new Map<string, AudioTrackPlayback>();
-  private captureChannel?: AudioChannel;
-  /** Silences existing takes during recording while live monitoring stays audible. */
-  private readonly takePlaybackGain: GainNode;
-  private readonly takePlaybackBus: PlaybackBus;
-  private recordingTrackPlaybacks: AudioBufferPlayback[] = [];
+  private captureTrack?: AudioTrackPlayback;
   private attachedYouTubePlayer?: {
     videoId: string;
     player: YouTubePlayerApi;
@@ -224,12 +217,7 @@ export class RecorderRuntime {
   constructor() {
     this.masterOutput = this.context.createGain();
     this.masterOutput.connect(this.context.destination);
-    this.takePlaybackGain = this.context.createGain();
     this.transport = new AudioContextTransport(this.context);
-    this.takePlaybackBus = new PlaybackBus({
-      transport: this.transport,
-      output: this.takePlaybackGain,
-    });
     this.metronome = new RecorderMetronome(this.transport, this.masterOutput);
     this.masterOutput.gain.value = this.store.get().masterGain;
     this.syncMetronomeGain();
@@ -247,14 +235,13 @@ export class RecorderRuntime {
       ensurePitchShifterWorklet(this.context),
       ensureBiquadEqWorklet(this.context),
     ]);
-    if (!this.captureChannel) {
-      this.captureChannel = new AudioChannel({
-        context: this.context,
+    if (!this.captureTrack) {
+      this.captureTrack = new AudioTrackPlayback({
+        transport: this.transport,
         output: this.masterOutput,
         eq: this.store.get().recordingTrack.eq,
         gain: deriveTrackMix(this.store.get()).recordingGain,
       });
-      this.takePlaybackGain.connect(this.captureChannel.input);
     }
   }
 
@@ -269,7 +256,7 @@ export class RecorderRuntime {
     const { input, channelCount } = await CaptureInput.open({
       context,
       deviceId,
-      output: this.captureChannel!.input,
+      output: this.captureTrack!.channel.input,
       onNotification: (message) => {
         switch (message.type) {
           case "samples": {
@@ -346,8 +333,6 @@ export class RecorderRuntime {
     if (!this.store.get().audioTracks.some((track) => track.id === id)) {
       return;
     }
-    const playback = this.getAudioTrackPlayback(id);
-    playback.setBuffer(buffer);
     const track = this.updateAudioTrack(id, (track) => ({
       ...track,
       trimStart: 0,
@@ -521,7 +506,7 @@ export class RecorderRuntime {
       this.pause();
     }
     for (const id of audioIds) {
-      this.audioTracks.get(id)?.setBuffer(undefined);
+      this.audioTracks.get(id)?.setRegions([]);
     }
     const audioTracks = state.audioTracks.map((track) =>
       audioIds.has(track.id)
@@ -580,7 +565,7 @@ export class RecorderRuntime {
       ...track,
       eq: { ...track.eq, ...update },
     }));
-    this.audioTracks.get(id)?.setEq(track.eq);
+    this.audioTracks.get(id)?.channel.setEq(track.eq);
   }
 
   setRecordingTrackEq(update: Partial<EqParameters>): void {
@@ -591,7 +576,7 @@ export class RecorderRuntime {
         eq: { ...track.eq, ...update },
       },
     });
-    this.captureChannel?.setEq(this.store.get().recordingTrack.eq);
+    this.captureTrack?.channel.setEq(this.store.get().recordingTrack.eq);
   }
 
   private updateAudioTrack(
@@ -624,7 +609,6 @@ export class RecorderRuntime {
         eq: track.eq,
         gain: 0,
       });
-      playback.setBufferTimelineOffset(track.timelineOffset);
       this.audioTracks.set(id, playback);
       this.syncTrackMix();
     }
@@ -637,11 +621,7 @@ export class RecorderRuntime {
       this.pause();
     }
     const playback = this.getAudioTrackPlayback(track.id);
-    playback.setBufferTimelineOffset(track.timelineOffset);
-    playback.setTimelineRange({
-      start: track.timelineOffset + track.trimStart,
-      end: track.timelineOffset + track.trimEnd,
-    });
+    playback.setRegions(getAudioTrackRegions(track));
     if (wasPlaying) {
       this.transport.play();
     }
@@ -746,7 +726,7 @@ export class RecorderRuntime {
     if (!this.store.get().isPlaying) {
       await this.play();
     }
-    this.takePlaybackGain.gain.setValueAtTime(0, context.currentTime);
+    this.captureTrack!.setPlaybackMuted(true);
     // Trim samples captured during playback lead time.
     const playbackStartFrame =
       this.transport.playbackAnchor!.contextTime * context.sampleRate;
@@ -1028,12 +1008,7 @@ export class RecorderRuntime {
         eq: track.eq,
         gain: 0,
       });
-      playback.setBuffer(buffer);
-      playback.setBufferTimelineOffset(track.timelineOffset);
-      playback.setTimelineRange({
-        start: track.timelineOffset + track.trimStart,
-        end: track.timelineOffset + track.trimEnd,
-      });
+      playback.setRegions(getAudioTrackRegions(track));
       this.audioTracks.set(track.id, playback);
     }
     // Clamp loaded external state at the runtime boundary so older projects
@@ -1046,7 +1021,7 @@ export class RecorderRuntime {
         height: clampRecordingTrackHeight(project.recordingTrack.height),
       },
     });
-    this.captureChannel!.setEq(project.recordingTrack.eq);
+    this.captureTrack!.channel.setEq(project.recordingTrack.eq);
     this.syncYouTubePlayer();
     this.transport.seek(0);
     this.metronome.setTempo(project.tempo);
@@ -1086,14 +1061,13 @@ export class RecorderRuntime {
       recordingTrack,
     });
     for (const [index, track] of audioTracks.entries()) {
-      this.audioTracks.get(track.id)?.setGain(audioTrackGains[index]!);
+      this.audioTracks.get(track.id)?.channel.setGain(audioTrackGains[index]!);
     }
-    this.captureChannel?.setGain(recordingGain);
+    this.captureTrack?.channel.setGain(recordingGain);
     // Suppress take playback independently so channel mix edits cannot unmute it.
     const { captureStatus } = this.store.get();
-    this.takePlaybackGain.gain.setValueAtTime(
-      captureStatus === "recording" || captureStatus === "processing" ? 0 : 1,
-      this.context.currentTime,
+    this.captureTrack?.setPlaybackMuted(
+      captureStatus === "recording" || captureStatus === "processing",
     );
   }
 
@@ -1211,29 +1185,35 @@ export class RecorderRuntime {
   }
 
   private syncTakePlayback(takeRegions: TakeRegion[]): void {
-    for (const playback of this.recordingTrackPlaybacks) {
-      playback.dispose();
-    }
-    this.recordingTrackPlaybacks = [];
-    for (const region of takeRegions) {
-      const { take } = region;
-      if (!take.buffer) {
-        continue;
-      }
-      const playback = new AudioBufferPlayback({
-        transport: this.transport,
-        output: this.takePlaybackBus.input,
-      });
-      playback.setBuffer(take.buffer);
-      playback.setBufferTimelineOffset(take.timelineOffset);
-      playback.setTimelineRange({
-        start: region.timelineStart,
-        end: region.timelineEnd,
-      });
-      this.recordingTrackPlaybacks.push(playback);
-    }
+    this.captureTrack!.setRegions(
+      takeRegions.flatMap(({ take, timelineStart, timelineEnd }) =>
+        take.buffer
+          ? [
+              {
+                buffer: take.buffer,
+                timelineOffset: take.timelineOffset,
+                timelineStart,
+                timelineEnd,
+              },
+            ]
+          : [],
+      ),
+    );
     this.syncTrackMix();
   }
+}
+
+function getAudioTrackRegions(track: AudioTrackState) {
+  return track.clip
+    ? [
+        {
+          buffer: track.clip.buffer,
+          timelineOffset: track.timelineOffset,
+          timelineStart: track.timelineOffset + track.trimStart,
+          timelineEnd: track.timelineOffset + track.trimEnd,
+        },
+      ]
+    : [];
 }
 
 function deriveActiveTakes(takes: readonly TakeState[]): TakeState[] {


### PR DESCRIPTION
- stacked on https://github.com/hi-ogawa/toy-midi/pull/492

AudioTrackPlayback owned one buffer player, while Capture separately managed its take players, playback bus, playback gain, and channel. This PR uses the same track wrapper for both, with multiple region players feeding one bus and channel.

The wrapper exposes `readonly channel`, so runtime routes live monitoring directly to `captureTrack.channel.input` and updates EQ and mixer gain through the channel. Region playback can be muted independently, and replacing regions preserves the channel and its external connections. The single-buffer setters and EQ/gain forwarding methods are removed.

Recording destinations and project data models remain as they are today. This establishes a shared audio composition for routing other sources into tracks, and the diagram reflects that ownership. Audio comparisons verified multiple regions and direct channel input at 0.75x, 1x, and 1.5x, including clearing regions and muting playback independently of monitoring.
