### PR TITLE
fix: drain pitch shifter when input is missing

### DIFF
--- a/src/lib/dsp/pitch-shifter-worklet.ts
+++ b/src/lib/dsp/pitch-shifter-worklet.ts
@@ -23,11 +23,16 @@ declare function registerProcessor(
 
 class PitchShifterProcessor extends AudioWorkletProcessor {
   private readonly shifter: StreamingPitchShifter;
+  private readonly silence: Float32Array[];
 
   constructor(options?: AudioWorkletNodeOptions) {
     super(options);
     const { channelCount, pitchRatio } = options!
       .processorOptions as ProcessorOptions;
+    this.silence = Array.from(
+      { length: channelCount },
+      () => new Float32Array(BLOCK_FRAMES),
+    );
     this.shifter = new StreamingPitchShifter({
       channelCount,
       sampleRate,
@@ -41,10 +46,11 @@ class PitchShifterProcessor extends AudioWorkletProcessor {
   process(inputs: Float32Array[][], outputs: Float32Array[][]): boolean {
     const input = inputs[0] ?? [];
     const output = outputs[0] ?? [];
-    if (input.length === 0 || output.length === 0) {
+    if (output.length === 0) {
       return true;
     }
-    this.shifter.push(input);
+    // Keep the stream clock advancing and drain buffered audio between sources.
+    this.shifter.push(input.length > 0 ? input : this.silence);
     const written = this.shifter.pull(output);
     for (const channel of output) {
       channel.fill(0, written);


### PR DESCRIPTION
- extracted from https://github.com/hi-ogawa/toy-midi/pull/492

The pitch-shifter worklet returned early when its input had no channels, freezing buffered processing state. This cut off the audio tail when a source ended and could replay stale buffered audio when input resumed.

Feed preallocated silent blocks through the shifter while input is missing so buffered audio drains and the stream clock continues advancing. This fix is based directly on main and is independent of the playback-bus and runtime-control changes.

A focused DSP check reproduced the mismatch before the fix and verified identical output to explicit silent input afterward at pitch ratios 0.75 and 1.5, including input resumption. Lint and all 168 unit tests pass.
