### PR TITLE
docs: clarify E2E timeout guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 - File names: kebab-case
 - Prefer the smallest correct change, and avoid speculative abstractions or compatibility paths
 - When an existing test fails, first verify from first principles whether its expectation is correct. Do not compensate in the implementation merely to preserve an incorrect test.
-- Before adding or increasing an E2E timeout, instrument the focused test with `createCheckpoint()` from `e2e/helpers.ts` and run it repeatedly (for example, `pnpm test-e2e e2e/example.spec.ts --repeat-each=10`). Prefer Playwright's existing auto-waiting when measurements fit comfortably within its timeout; derive any custom timeout from the observed range with reasonable headroom.
+- Before adding or increasing an E2E timeout, measure the relevant wait with `createCheckpoint()` from `e2e/helpers.ts`. Prefer Playwright's default timeout when it comfortably covers the measured duration. If a custom timeout is needed, allow reasonable headroom and document the measured duration beside it.
 - Organize code into chunks with one primary reasoning domain, but do not equate a reasoning boundary with code or file extraction. Keep cohesive chunks together unless they form a clear module boundary
 - Order functions by reading flow, with primary entry points and callers before their implementation helpers
 - Prefer `undefined` over `null`


### PR DESCRIPTION
Custom E2E timeouts should retain the timing evidence that justifies them.

This PR updates AGENTS.md to measure the relevant wait, prefer Playwright's default timeout, and document the measured duration beside any custom timeout. It also removes the blanket requirement to run the test repeatedly.
