### PR TITLE
feat: wire multiband EQ into recorder runtime

### DIFF
--- a/e2e/fake-audio/recorder-effects.test.ts
+++ b/e2e/fake-audio/recorder-effects.test.ts
@@ -31,7 +31,7 @@ test("edits and persists independent Audio and Capture EQ settings", async ({
     audio.getByRole("textbox", { name: "Q", exact: true }),
   ).toHaveValue("1");
   await expect(
-    audio.getByRole("checkbox", { name: "Bypass" }),
+    audio.getByRole("checkbox", { name: "Bypass" }).first(),
   ).not.toBeChecked();
 
   // Set different EQ values for Audio and Capture.
@@ -43,7 +43,10 @@ test("edits and persists independent Audio and Capture EQ settings", async ({
     .press("Enter");
   await audio.getByRole("textbox", { name: "Q", exact: true }).fill("2");
   await audio.getByRole("textbox", { name: "Q", exact: true }).press("Enter");
-  await audio.getByRole("checkbox", { name: "Bypass" }).check();
+  await audio.getByRole("button", { name: "Add band" }).click();
+  await audio.getByRole("textbox", { name: "Frequency" }).fill("3000");
+  await audio.getByRole("textbox", { name: "Frequency" }).press("Enter");
+  await audio.getByRole("checkbox", { name: "Bypass" }).first().check();
   await capture.getByRole("textbox", { name: "Gain", exact: true }).fill("-4");
   await capture
     .getByRole("textbox", { name: "Gain", exact: true })
@@ -58,6 +61,8 @@ test("edits and persists independent Audio and Capture EQ settings", async ({
   await page
     .getByRole("button", { name: "Audio 1 effects", exact: true })
     .click();
+  await expect(audio.getByTestId("multiband-eq-response-point")).toHaveCount(2);
+  await audio.getByRole("button", { name: "Select band 1" }).click();
   await page
     .getByRole("button", { name: "Capture effects", exact: true })
     .click();
@@ -70,14 +75,20 @@ test("edits and persists independent Audio and Capture EQ settings", async ({
   await expect(
     audio.getByRole("textbox", { name: "Q", exact: true }),
   ).toHaveValue("2");
-  await expect(audio.getByRole("checkbox", { name: "Bypass" })).toBeChecked();
+  await expect(
+    audio.getByRole("checkbox", { name: "Bypass" }).first(),
+  ).toBeChecked();
+  await audio.getByRole("button", { name: "Select band 2" }).click();
+  await expect(audio.getByRole("textbox", { name: "Frequency" })).toHaveValue(
+    "3000",
+  );
   await expect(
     capture.getByRole("textbox", { name: "Gain", exact: true }),
   ).toHaveValue("-4");
   await expect(save).toHaveAttribute("data-status", "saved");
 
   // Resetting Audio leaves Capture unchanged and dirties the project.
-  await audio.getByRole("button", { name: "Reset" }).click();
+  await audio.getByRole("button", { name: "Reset EQ" }).click();
   await expect(audio.getByRole("textbox", { name: "Frequency" })).toHaveValue(
     "1000",
   );
@@ -88,7 +99,7 @@ test("edits and persists independent Audio and Capture EQ settings", async ({
     audio.getByRole("textbox", { name: "Q", exact: true }),
   ).toHaveValue("1");
   await expect(
-    audio.getByRole("checkbox", { name: "Bypass" }),
+    audio.getByRole("checkbox", { name: "Bypass" }).first(),
   ).not.toBeChecked();
   await expect(
     capture.getByRole("textbox", { name: "Gain", exact: true }),
@@ -104,12 +115,21 @@ test("edits EQ with graph clicks and wheel gestures", async ({ page }) => {
     .getByRole("button", { name: "Capture effects", exact: true })
     .click();
   const panel = page.getByTestId("recorder-effects-panel");
-  await expect(panel.getByTestId("eq-response-graph")).toBeVisible();
+  await expect(panel.getByTestId("multiband-eq-response-graph")).toBeVisible();
 
   // Click above and to the right of the point to increase frequency and gain.
-  const point = await panel.getByTestId("eq-response-point").boundingBox();
+  const point = await panel
+    .getByTestId("multiband-eq-response-point")
+    .boundingBox();
   expect(point).toBeTruthy();
-  await page.mouse.click(point!.x + point!.width / 2 + 30, point!.y - 20);
+  const pointCenter = {
+    x: point!.x + point!.width / 2,
+    y: point!.y + point!.height / 2,
+  };
+  await page.mouse.move(pointCenter.x, pointCenter.y);
+  await page.mouse.down();
+  await page.mouse.move(pointCenter.x + 30, pointCenter.y - 20);
+  await page.mouse.up();
   const frequencyInput = panel.getByRole("textbox", { name: "Frequency" });
   const gainInput = panel.getByRole("textbox", { name: "Gain", exact: true });
   await expect
@@ -133,11 +153,11 @@ test("edits EQ with graph clicks and wheel gestures", async ({ page }) => {
   await expect(gainInput).toHaveValue(gain);
 
   // Bypass dims the configured response curve.
-  await panel.getByRole("checkbox", { name: "Bypass" }).check();
-  await expect(panel.getByTestId("eq-response-curve")).toHaveClass(
-    /stroke-blue-400\/35/,
-  );
-  await panel.getByRole("checkbox", { name: "Bypass" }).uncheck();
+  await panel.getByRole("checkbox", { name: "Bypass" }).first().check();
+  await expect(
+    panel.getByTestId("multiband-eq-combined-curve"),
+  ).toHaveAttribute("stroke-opacity", "0.25");
+  await panel.getByRole("checkbox", { name: "Bypass" }).first().uncheck();
 
   // Optional sliders can be shown and hidden beside the graph controls.
   await expect(panel.getByRole("slider")).toHaveCount(0);

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -16,13 +16,14 @@ import { beatsToSeconds } from "../../lib/timeline";
 import { parseTimeSignature } from "../../types";
 import { Dialog } from "../ui/dialog";
 import { RecorderHelp } from "./help";
-import { RecorderEffects, useRecorderEffectsUi } from "./recorder-effects";
+import { useRecorderEffectsUi } from "./recorder-effects";
 import { RecorderExportDialog } from "./recorder-export-dialog";
 import { deriveRecorderFlags } from "./recorder-flags";
 import { RecorderHeader } from "./recorder-header";
 import { InputSetup } from "./recorder-input";
 import { RecorderLocatorRow, useRecorderLocators } from "./recorder-locators";
 import { RecorderMixer } from "./recorder-mixer";
+import { RecorderMultibandEffectsPanel } from "./recorder-multiband-effects";
 import { RecorderPanel } from "./recorder-panel";
 import {
   TakeTimelineLane,
@@ -639,19 +640,19 @@ export function Recorder({ projectId }: { projectId: string }) {
             {state.audioTracks.map(
               (track, index) =>
                 effects.openEffects.has(track.id) && (
-                  <RecorderEffects
+                  <RecorderMultibandEffectsPanel
                     key={track.id}
                     label={`Audio ${index + 1}`}
                     eq={track.eq}
-                    onChange={(update) =>
-                      runtime.setAudioTrackEq({ id: track.id, update })
+                    onChange={(eq) =>
+                      runtime.setAudioTrackEq({ id: track.id, eq })
                     }
                     onClose={() => effects.closeEffects(track.id)}
                   />
                 ),
             )}
             {effects.openEffects.has("capture") && (
-              <RecorderEffects
+              <RecorderMultibandEffectsPanel
                 label="Capture"
                 eq={state.recordingTrack.eq}
                 onChange={(update) => runtime.setRecordingTrackEq(update)}

--- a/src/components/recorder/multiband-eq-response-graph.tsx
+++ b/src/components/recorder/multiband-eq-response-graph.tsx
@@ -7,10 +7,10 @@ import {
 import {
   calculateBiquadEqCoefficients,
   calculateBiquadEqResponse,
+  type MultibandEqBand,
 } from "../../lib/dsp/biquad-eq";
 import { clamp, dbToGain, gainToDb } from "../../lib/music";
 import { EQ_CONTROL_LIMITS } from "./eq-control-limits";
-import type { MultibandEqBand } from "./recorder-multiband-effects";
 
 const GRAPH_SAMPLE_RATE = 48000;
 const FREQUENCY_TICKS = [20, 100, 1000, 10000, 20000];

--- a/src/components/recorder/recorder-effects.tsx
+++ b/src/components/recorder/recorder-effects.tsx
@@ -7,7 +7,6 @@ import { dbToGain, gainToDb } from "../../lib/music";
 import { Slider } from "../ui/slider";
 import { EQ_CONTROL_LIMITS } from "./eq-control-limits";
 import { EqResponseGraph } from "./eq-response-graph";
-import { RecorderPanel } from "./recorder-panel";
 
 export function useRecorderEffectsUi() {
   // Audio track UUIDs and the singleton Capture channel identify panels.
@@ -39,30 +38,6 @@ export function useRecorderEffectsUi() {
   }
 
   return { openEffects, toggleEffects, closeEffects };
-}
-
-export function RecorderEffects({
-  label,
-  eq,
-  onChange,
-  onClose,
-}: {
-  label: string;
-  eq: EqParameters;
-  onChange: (update: Partial<EqParameters>) => void;
-  onClose: () => void;
-}) {
-  return (
-    <RecorderPanel
-      title={`${label} Effects`}
-      closeLabel={`Close ${label} Effects`}
-      onClose={onClose}
-      testId="recorder-effects-panel"
-      className="pointer-events-auto w-96 shrink-0"
-    >
-      <RecorderEffectsContent eq={eq} onChange={onChange} />
-    </RecorderPanel>
-  );
 }
 
 export function RecorderEffectsContent({

--- a/src/components/recorder/recorder-multiband-effects-preview.tsx
+++ b/src/components/recorder/recorder-multiband-effects-preview.tsx
@@ -1,11 +1,9 @@
 import { useState } from "react";
+import type { MultibandEqParameters } from "../../lib/dsp/biquad-eq";
 import { dbToGain } from "../../lib/music";
-import {
-  type MultibandEqState,
-  RecorderMultibandEffects,
-} from "./recorder-multiband-effects";
+import { RecorderMultibandEffects } from "./recorder-multiband-effects";
 
-const INITIAL_EQ: MultibandEqState = {
+const INITIAL_EQ: MultibandEqParameters = {
   bypass: false,
   bands: [
     {

--- a/src/components/recorder/recorder-multiband-effects.tsx
+++ b/src/components/recorder/recorder-multiband-effects.tsx
@@ -1,8 +1,15 @@
 import { Plus, RotateCcw, SlidersHorizontal, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useDraftInput } from "../../hooks/use-draft-input";
-import type { EqParameters } from "../../lib/dsp/biquad-eq";
-import { createDefaultEq } from "../../lib/dsp/biquad-eq-node";
+import {
+  MAX_EQ_BANDS,
+  type MultibandEqBand,
+  type MultibandEqParameters,
+} from "../../lib/dsp/biquad-eq";
+import {
+  createDefaultEq,
+  createDefaultEqBand,
+} from "../../lib/dsp/biquad-eq-node";
 import { dbToGain, gainToDb } from "../../lib/music";
 import { Slider } from "../ui/slider";
 import { EQ_CONTROL_LIMITS } from "./eq-control-limits";
@@ -10,22 +17,38 @@ import {
   EQ_BAND_COLORS,
   MultibandEqResponseGraph,
 } from "./multiband-eq-response-graph";
+import { RecorderPanel } from "./recorder-panel";
 
-const MAX_EQ_BANDS = 8;
-
-export type MultibandEqBand = EqParameters & { id: string };
-
-export interface MultibandEqState {
-  bypass: boolean;
-  bands: MultibandEqBand[];
+export function RecorderMultibandEffectsPanel({
+  label,
+  eq,
+  onChange,
+  onClose,
+}: {
+  label: string;
+  eq: MultibandEqParameters;
+  onChange: (eq: MultibandEqParameters) => void;
+  onClose: () => void;
+}) {
+  return (
+    <RecorderPanel
+      title={`${label} Effects`}
+      closeLabel={`Close ${label} Effects`}
+      onClose={onClose}
+      testId="recorder-effects-panel"
+      className="pointer-events-auto w-96 shrink-0"
+    >
+      <RecorderMultibandEffects eq={eq} onChange={onChange} />
+    </RecorderPanel>
+  );
 }
 
 export function RecorderMultibandEffects({
   eq,
   onChange,
 }: {
-  eq: MultibandEqState;
-  onChange: (eq: MultibandEqState) => void;
+  eq: MultibandEqParameters;
+  onChange: (eq: MultibandEqParameters) => void;
 }) {
   const [selectedBandId, setSelectedBandId] = useState(eq.bands[0]?.id);
   const [slidersOpen, setSlidersOpen] = useState(false);
@@ -49,13 +72,13 @@ export function RecorderMultibandEffects({
     if (eq.bands.length >= MAX_EQ_BANDS) {
       return;
     }
-    const band = createEqBand();
+    const band = createDefaultEqBand();
     onChange({ ...eq, bands: [...eq.bands, band] });
     setSelectedBandId(band.id);
   };
 
   const resetEq = () => {
-    const band = createEqBand();
+    const band = createDefaultEqBand();
     onChange({ bypass: false, bands: [band] });
     setSelectedBandId(band.id);
   };
@@ -244,10 +267,6 @@ export function RecorderMultibandEffects({
       )}
     </div>
   );
-}
-
-function createEqBand(): MultibandEqBand {
-  return { id: crypto.randomUUID(), ...createDefaultEq() };
 }
 
 function IconButton({

--- a/src/lib/dsp/biquad-eq-node.ts
+++ b/src/lib/dsp/biquad-eq-node.ts
@@ -1,11 +1,23 @@
 import biquadEqWorkletUrl from "./biquad-eq-worklet.ts?worker&url";
-import type { EqParameters } from "./biquad-eq.ts";
+import type {
+  EqParameters,
+  MultibandEqBand,
+  MultibandEqParameters,
+} from "./biquad-eq.ts";
 
 const PROCESSOR_NAME = "biquad-eq";
 const registrations = new WeakMap<BaseAudioContext, Promise<void>>();
 
 export function createDefaultEq(): EqParameters {
   return { frequency: 1000, gain: 1, q: 1, bypass: false };
+}
+
+export function createDefaultEqBand(): MultibandEqBand {
+  return { id: crypto.randomUUID(), ...createDefaultEq() };
+}
+
+export function createDefaultMultibandEq(): MultibandEqParameters {
+  return { bypass: false, bands: [createDefaultEqBand()] };
 }
 
 export class BiquadEqNode extends AudioWorkletNode {
@@ -16,7 +28,7 @@ export class BiquadEqNode extends AudioWorkletNode {
   }: {
     context: BaseAudioContext;
     channelCount: number;
-    parameters: EqParameters;
+    parameters: MultibandEqParameters;
   }) {
     super(context, PROCESSOR_NAME, {
       numberOfInputs: 1,
@@ -28,7 +40,7 @@ export class BiquadEqNode extends AudioWorkletNode {
     });
   }
 
-  setParameters(parameters: Partial<EqParameters>): void {
+  setParameters(parameters: MultibandEqParameters): void {
     this.port.postMessage(parameters);
   }
 }

--- a/src/lib/dsp/biquad-eq-worklet.ts
+++ b/src/lib/dsp/biquad-eq-worklet.ts
@@ -1,10 +1,10 @@
-import { type EqParameters, BiquadEq } from "./biquad-eq.ts";
+import { type MultibandEqParameters, MultibandEq } from "./biquad-eq.ts";
 
 const PROCESSOR_NAME = "biquad-eq";
 
 type ProcessorOptions = {
   channelCount: number;
-  parameters: EqParameters;
+  parameters: MultibandEqParameters;
 };
 
 declare const AudioWorkletProcessor: new (
@@ -19,14 +19,14 @@ declare function registerProcessor(
 ): void;
 
 class BiquadEqProcessor extends AudioWorkletProcessor {
-  private readonly eq: BiquadEq;
+  private readonly eq: MultibandEq;
 
   constructor(options?: AudioWorkletNodeOptions) {
     super(options);
     const { channelCount, parameters } = options!
       .processorOptions as ProcessorOptions;
-    this.eq = new BiquadEq({ sampleRate, channelCount, ...parameters });
-    this.port.onmessage = (event: MessageEvent<Partial<EqParameters>>) => {
+    this.eq = new MultibandEq({ sampleRate, channelCount, parameters });
+    this.port.onmessage = (event: MessageEvent<MultibandEqParameters>) => {
       this.eq.setParameters(event.data);
     };
   }

--- a/src/lib/dsp/biquad-eq.test.ts
+++ b/src/lib/dsp/biquad-eq.test.ts
@@ -5,6 +5,8 @@ import {
   calculateBiquadEqResponse,
   type EqParameters,
   BiquadEq,
+  MAX_EQ_BANDS,
+  MultibandEq,
 } from "./biquad-eq";
 
 const SAMPLE_RATE = 48000;
@@ -116,6 +118,80 @@ describe(BiquadEq, () => {
   });
 });
 
+describe(MultibandEq, () => {
+  it("cascades bands in one fixed-capacity processor", () => {
+    const eq = new MultibandEq({
+      sampleRate: SAMPLE_RATE,
+      channelCount: 1,
+      parameters: {
+        bypass: false,
+        bands: ["a", "b"].map((id) => ({
+          id,
+          ...DEFAULT_PARAMETERS,
+          gain: dbToGain(6),
+        })),
+      },
+    });
+    const input = createSignal({ frames: SAMPLE_RATE, frequency: 1000 });
+    const output = process(eq, input);
+    expect(
+      10 *
+        Math.log10(
+          measureEnergy(output.subarray(SAMPLE_RATE / 2)) /
+            measureEnergy(input.subarray(SAMPLE_RATE / 2)),
+        ),
+    ).toBeCloseTo(12, 3);
+  });
+
+  it("reconciles updates by band ID without resetting its ramp", () => {
+    const eq = new MultibandEq({
+      sampleRate: SAMPLE_RATE,
+      channelCount: 1,
+      parameters: {
+        bypass: false,
+        bands: [{ id: "band", ...DEFAULT_PARAMETERS }],
+      },
+    });
+    eq.setParameters({
+      bypass: false,
+      bands: [{ id: "band", ...DEFAULT_PARAMETERS, gain: dbToGain(18) }],
+    });
+    const input = createSignal({ frames: 100, frequency: 1000 });
+    const ramped = process(eq, input);
+    const replaced = process(
+      new MultibandEq({
+        sampleRate: SAMPLE_RATE,
+        channelCount: 1,
+        parameters: {
+          bypass: false,
+          bands: [
+            { id: "replacement", ...DEFAULT_PARAMETERS, gain: dbToGain(18) },
+          ],
+        },
+      }),
+      input,
+    );
+    expect(measureEnergy(ramped) / measureEnergy(replaced)).toBeLessThan(0.5);
+  });
+
+  it("rejects state beyond its fixed capacity", () => {
+    expect(
+      () =>
+        new MultibandEq({
+          sampleRate: SAMPLE_RATE,
+          channelCount: 1,
+          parameters: {
+            bypass: false,
+            bands: Array.from({ length: MAX_EQ_BANDS + 1 }, (_, index) => ({
+              id: String(index),
+              ...DEFAULT_PARAMETERS,
+            })),
+          },
+        }),
+    ).toThrow(`EQ supports at most ${MAX_EQ_BANDS} bands`);
+  });
+});
+
 describe(calculateBiquadEqResponse, () => {
   it.each([-18, -6, 0, 6, 18])(
     "returns %s dB at the center frequency",
@@ -204,7 +280,10 @@ function createSignal({
   );
 }
 
-function process(eq: BiquadEq, input: Float32Array): Float32Array {
+function process(
+  eq: Pick<BiquadEq, "process">,
+  input: Float32Array,
+): Float32Array {
   const output = new Float32Array(input.length);
   eq.process({ input: [input], output: [output] });
   return output;

--- a/src/lib/dsp/biquad-eq.ts
+++ b/src/lib/dsp/biquad-eq.ts
@@ -21,6 +21,15 @@ export type EqParameters = {
   bypass: boolean;
 };
 
+export const MAX_EQ_BANDS = 8;
+
+export type MultibandEqBand = EqParameters & { id: string };
+
+export interface MultibandEqParameters {
+  bypass: boolean;
+  bands: MultibandEqBand[];
+}
+
 export type BiquadEqCoefficients = {
   b0: number;
   b1: number;
@@ -182,6 +191,85 @@ export class BiquadEq {
       q: Math.exp(this.current[2]),
       output: this.coefficients,
     });
+  }
+}
+
+/** Fixed-capacity ordered cascade that preserves each band's state by ID. */
+export class MultibandEq {
+  private readonly slots: { id?: string; eq: BiquadEq }[];
+  private active: { id?: string; eq: BiquadEq }[] = [];
+
+  constructor({
+    sampleRate,
+    channelCount,
+    parameters,
+  }: {
+    sampleRate: number;
+    channelCount: number;
+    parameters: MultibandEqParameters;
+  }) {
+    this.slots = Array.from({ length: MAX_EQ_BANDS }, () => ({
+      eq: new BiquadEq({
+        sampleRate,
+        channelCount,
+        frequency: 1000,
+        gain: 1,
+        q: 1,
+        bypass: true,
+      }),
+    }));
+    this.setParameters(parameters);
+  }
+
+  setParameters(parameters: MultibandEqParameters): void {
+    if (parameters.bands.length > MAX_EQ_BANDS) {
+      throw new RangeError(`EQ supports at most ${MAX_EQ_BANDS} bands`);
+    }
+    if (
+      new Set(parameters.bands.map((band) => band.id)).size !==
+      parameters.bands.length
+    ) {
+      throw new RangeError("EQ band IDs must be unique");
+    }
+    const previous = new Map(this.active.map((slot) => [slot.id, slot]));
+    const retained = new Set(
+      parameters.bands.flatMap((band) => {
+        const slot = previous.get(band.id);
+        return slot ? [slot] : [];
+      }),
+    );
+    const used = new Set<{ id?: string; eq: BiquadEq }>();
+    this.active = parameters.bands.map((band) => {
+      const existing = previous.get(band.id);
+      const slot =
+        existing ??
+        this.slots.find((entry) => !retained.has(entry) && !used.has(entry))!;
+      used.add(slot);
+      slot.eq.setParameters({
+        ...band,
+        bypass: parameters.bypass || band.bypass,
+      });
+      if (!existing) {
+        slot.id = band.id;
+        slot.eq.reset();
+      }
+      return slot;
+    });
+  }
+
+  process({
+    input,
+    output,
+  }: {
+    input: readonly Float32Array[];
+    output: readonly Float32Array[];
+  }): void {
+    for (let channel = 0; channel < input.length; channel++) {
+      output[channel].set(input[channel]);
+    }
+    for (const slot of this.active) {
+      slot.eq.process({ input: output, output });
+    }
   }
 }
 

--- a/src/lib/recorder/audio-channel.ts
+++ b/src/lib/recorder/audio-channel.ts
@@ -1,5 +1,5 @@
 import { BiquadEqNode } from "../dsp/biquad-eq-node.ts";
-import type { EqParameters } from "../dsp/biquad-eq.ts";
+import type { MultibandEqParameters } from "../dsp/biquad-eq.ts";
 
 /** Persistent stereo processing shared by all sources in a mixer channel. */
 export class AudioChannel {
@@ -15,7 +15,7 @@ export class AudioChannel {
   }: {
     context: BaseAudioContext;
     output: AudioNode;
-    eq: EqParameters;
+    eq: MultibandEqParameters;
     gain: number;
   }) {
     this.input = context.createGain();
@@ -29,7 +29,7 @@ export class AudioChannel {
     this.input.connect(this.equalizer).connect(this.gain).connect(output);
   }
 
-  setEq(eq: EqParameters): void {
+  setEq(eq: MultibandEqParameters): void {
     this.equalizer.setParameters(eq);
   }
 

--- a/src/lib/recorder/audio-track-playback.ts
+++ b/src/lib/recorder/audio-track-playback.ts
@@ -1,4 +1,4 @@
-import type { EqParameters } from "../dsp/biquad-eq.ts";
+import type { MultibandEqParameters } from "../dsp/biquad-eq.ts";
 import { createPitchShifterNode } from "../dsp/pitch-shifter-node.ts";
 import { AudioBufferPlayback } from "./audio-buffer-playback.ts";
 import { AudioChannel } from "./audio-channel.ts";
@@ -25,7 +25,7 @@ export class AudioTrackPlayback {
   }: {
     transport: AudioContextTransport;
     output: AudioNode;
-    eq: EqParameters;
+    eq: MultibandEqParameters;
     gain: number;
   }) {
     this.transport = transport;

--- a/src/lib/recorder/mix.ts
+++ b/src/lib/recorder/mix.ts
@@ -1,12 +1,16 @@
 import { ensureBiquadEqWorklet } from "../dsp/biquad-eq-node.ts";
-import type { EqParameters } from "../dsp/biquad-eq.ts";
+import type { MultibandEqParameters } from "../dsp/biquad-eq.ts";
 import { AudioChannel } from "./audio-channel.ts";
 import type { AudioPlaybackSource } from "./audio-sources.ts";
 import { getAudioTrackSources, getTakeSources } from "./audio-sources.ts";
 import type { RecorderRuntimeState } from "./runtime.ts";
 
 interface RecorderMix {
-  tracks: { eq: EqParameters; gain: number; regions: AudioPlaybackSource[] }[];
+  tracks: {
+    eq: MultibandEqParameters;
+    gain: number;
+    regions: AudioPlaybackSource[];
+  }[];
   masterGain: number;
   duration: number;
 }

--- a/src/lib/recorder/persistence.ts
+++ b/src/lib/recorder/persistence.ts
@@ -1,6 +1,9 @@
 import { createAudioView } from "../audio-view.ts";
-import { createDefaultEq } from "../dsp/biquad-eq-node.ts";
-import type { EqParameters } from "../dsp/biquad-eq.ts";
+import {
+  createDefaultEqBand,
+  createDefaultMultibandEq,
+} from "../dsp/biquad-eq-node.ts";
+import type { EqParameters, MultibandEqParameters } from "../dsp/biquad-eq.ts";
 import {
   WAVEFORM_POINTS_PER_SECOND,
   type PersistableRecorderRuntimeState,
@@ -15,7 +18,7 @@ export interface SerializedRecorderRuntimeState {
   audioTracks: SerializedAudioTrackState[];
   recordingTrack: {
     // Optional for projects saved before track EQ support.
-    eq?: EqParameters;
+    eq?: MultibandEqParameters | EqParameters;
     height: number;
     gain: number;
     muted: boolean;
@@ -58,7 +61,7 @@ export interface SerializedRecorderRuntimeState {
 
 interface SerializedAudioTrackState {
   // Optional for projects saved before track EQ support.
-  eq?: EqParameters;
+  eq?: MultibandEqParameters | EqParameters;
   id: string;
   height: number;
   clip?: {
@@ -177,7 +180,7 @@ export function deserializeRecorderRuntimeState({
                 ),
               }
             : undefined,
-        eq: track.eq ?? createDefaultEq(),
+        eq: deserializeEq(track.eq),
         gain: track.gain,
         muted: track.muted,
         soloed: track.soloed,
@@ -188,7 +191,7 @@ export function deserializeRecorderRuntimeState({
     }),
     recordingTrack: {
       height: project.recordingTrack.height,
-      eq: project.recordingTrack.eq ?? createDefaultEq(),
+      eq: deserializeEq(project.recordingTrack.eq),
       gain: project.recordingTrack.gain,
       muted: project.recordingTrack.muted,
       soloed: project.recordingTrack.soloed,
@@ -223,6 +226,21 @@ export function deserializeRecorderRuntimeState({
     tempo: project.tempo,
     timeSignature: project.timeSignature,
     referenceVideo: project.referenceVideo,
+  };
+}
+
+function deserializeEq(
+  eq?: MultibandEqParameters | EqParameters,
+): MultibandEqParameters {
+  if (!eq) {
+    return createDefaultMultibandEq();
+  }
+  if ("bands" in eq) {
+    return eq;
+  }
+  return {
+    bypass: false,
+    bands: [{ ...createDefaultEqBand(), ...eq }],
   };
 }
 

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -2,10 +2,10 @@ import { DEFAULT_TIME_SIGNATURE, type TimeSignature } from "../../types.ts";
 import { createStore, shallowEqual } from "../../utils/store.ts";
 import { type AudioView, createAudioView } from "../audio-view.ts";
 import {
-  createDefaultEq,
+  createDefaultMultibandEq,
   ensureBiquadEqWorklet,
 } from "../dsp/biquad-eq-node.ts";
-import type { EqParameters } from "../dsp/biquad-eq.ts";
+import type { MultibandEqParameters } from "../dsp/biquad-eq.ts";
 import { ensurePitchShifterWorklet } from "../dsp/pitch-shifter-node.ts";
 import { clamp } from "../music.ts";
 import { beatsToSeconds } from "../timeline.ts";
@@ -41,7 +41,7 @@ const MAX_TRACK_HEIGHT = 300;
 type CaptureStatus = "disabled" | "ready" | "recording" | "processing";
 
 export interface AudioTrackState {
-  eq: EqParameters;
+  eq: MultibandEqParameters;
   id: string;
   height: number;
   clip?: {
@@ -59,7 +59,7 @@ export interface AudioTrackState {
 }
 
 interface RecordingTrackState {
-  eq: EqParameters;
+  eq: MultibandEqParameters;
   height: number;
   gain: number;
   muted: boolean;
@@ -555,26 +555,20 @@ export class RecorderRuntime {
     this.syncTrackMix();
   }
 
-  setAudioTrackEq({
-    id,
-    update,
-  }: {
-    id: string;
-    update: Partial<EqParameters>;
-  }): void {
+  setAudioTrackEq({ id, eq }: { id: string; eq: MultibandEqParameters }): void {
     const track = this.updateAudioTrack(id, (track) => ({
       ...track,
-      eq: { ...track.eq, ...update },
+      eq,
     }));
     this.audioTracks.get(id)?.channel.setEq(track.eq);
   }
 
-  setRecordingTrackEq(update: Partial<EqParameters>): void {
+  setRecordingTrackEq(eq: MultibandEqParameters): void {
     const track = this.store.get().recordingTrack;
     this.store.update({
       recordingTrack: {
         ...track,
-        eq: { ...track.eq, ...update },
+        eq,
       },
     });
     this.captureTrack?.channel.setEq(this.store.get().recordingTrack.eq);
@@ -1253,7 +1247,7 @@ function sliceRecordingSamples({
 
 function createAudioTrackState(): AudioTrackState {
   return {
-    eq: createDefaultEq(),
+    eq: createDefaultMultibandEq(),
     id: crypto.randomUUID(),
     height: DEFAULT_TRACK_HEIGHT,
     gain: 1,
@@ -1267,7 +1261,7 @@ function createAudioTrackState(): AudioTrackState {
 
 function createRecordingTrackState(): RecordingTrackState {
   return {
-    eq: createDefaultEq(),
+    eq: createDefaultMultibandEq(),
     height: MIN_RECORDING_TRACK_HEIGHT,
     gain: 1,
     muted: false,


### PR DESCRIPTION
- follow-up to https://github.com/hi-ogawa/toy-midi/pull/484
- related to https://github.com/hi-ogawa/toy-midi/issues/475

PR #484 establishes the multiband controls, but recorder tracks still store and process one peaking band per channel.

This PR moves the ordered multiband state into recorder tracks and persistence, migrates saved single-band EQ settings, and runs up to eight stable-ID bands as a cascade inside the existing persistent channel worklet. Live playback, capture monitoring, and offline export continue to share the same `AudioChannel` path.