### PR TITLE
refactor: consolidate test ID props to data-testid

### DIFF
--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -193,7 +193,7 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
           closeLabel="Close Mixer"
           onClose={() => setIsMixerOpen(false)}
           title="Mixer"
-          testId="mixer-panel"
+          data-testid="mixer-panel"
         >
           <Mixer />
         </FloatingPanel>
@@ -215,7 +215,7 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
               <ExternalLinkIcon className="size-3" />
             </a>
           }
-          testId="score-preview-panel"
+          data-testid="score-preview-panel"
           className="flex flex-col overflow-hidden"
           contentClassName="min-h-0 flex-1 p-0"
           style={scorePreviewSize}
@@ -238,7 +238,7 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
         <FloatingPanel
           closeLabel="Close Audio to MIDI"
           onClose={() => setAudioToMidiTrackId(undefined)}
-          testId="audio-to-midi-panel"
+          data-testid="audio-to-midi-panel"
           title={
             <span className="flex items-center gap-2">
               <SparklesIcon className="size-4" />
@@ -253,7 +253,7 @@ export function Editor({ projectId, initialProjectName }: EditorProps) {
         isOpen={isSettingsOpen}
         onClose={() => setIsSettingsOpen(false)}
         title="Project"
-        testId="settings-dialog"
+        data-testid="settings-dialog"
       >
         <Settings
           projectName={projectName}

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -601,7 +601,7 @@ export function Recorder({ projectId }: { projectId: string }) {
           isOpen={isInputSetupOpen}
           onClose={() => setIsInputSetupOpen(false)}
           title="Audio Input Setup"
-          testId="recorder-input-setup"
+          data-testid="recorder-input-setup"
         >
           <InputSetup
             devices={input.devices}
@@ -665,7 +665,7 @@ export function Recorder({ projectId }: { projectId: string }) {
             closeLabel="Close Mixer"
             onClose={() => setIsMixerOpen(false)}
             title="Mixer"
-            testId="recorder-mixer-panel"
+            data-testid="recorder-mixer-panel"
             className="pointer-events-auto min-w-80 flex-1"
           >
             <RecorderMixer

--- a/src/components/recorder/recorder-effects.tsx
+++ b/src/components/recorder/recorder-effects.tsx
@@ -61,7 +61,7 @@ export function RecorderEffects({
       title={`${label} Effects`}
       closeLabel={`Close ${label} Effects`}
       onClose={onClose}
-      testId="recorder-effects-panel"
+      data-testid="recorder-effects-panel"
       className="pointer-events-auto w-96 shrink-0"
     >
       <RecorderEffectsContent eq={eq} onChange={onChange} />

--- a/src/components/recorder/recorder-export-dialog.tsx
+++ b/src/components/recorder/recorder-export-dialog.tsx
@@ -37,7 +37,7 @@ export function RecorderExportDialog({
       isOpen={isOpen}
       onClose={onClose}
       title="Export Audio"
-      testId="recorder-audio-export"
+      data-testid="recorder-audio-export"
     >
       <div className="mb-6 space-y-4">
         <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm">

--- a/src/components/recorder/recorder-mixer.tsx
+++ b/src/components/recorder/recorder-mixer.tsx
@@ -38,7 +38,7 @@ export function RecorderMixer({
         gain={state.masterGain}
         onGainChange={(gain) => runtime.setMasterGain(gain)}
         inputProps={masterInput.props}
-        testId="recorder-mixer-master"
+        data-testid="recorder-mixer-master"
       />
       {state.audioTracks.map((track, index) => (
         <RecorderTrackChannel
@@ -77,7 +77,7 @@ export function RecorderMixer({
         gain={state.metronomeGain}
         onGainChange={(gain) => runtime.setMetronomeGain(gain)}
         inputProps={metronomeInput.props}
-        testId="recorder-mixer-metro"
+        data-testid="recorder-mixer-metro"
         action={
           <RecorderMixToggle
             active={!state.metronomeEnabled}
@@ -126,7 +126,7 @@ function RecorderTrackChannel({
       gain={gain}
       onGainChange={onGainChange}
       inputProps={input.props}
-      testId={`recorder-mixer-${label.toLowerCase().replace(" ", "-")}`}
+      data-testid={`recorder-mixer-${label.toLowerCase().replace(" ", "-")}`}
       action={
         <div className="flex flex-col gap-1">
           <RecorderMixToggle
@@ -176,7 +176,7 @@ function MixerChannel({
   gain,
   onGainChange,
   inputProps,
-  testId,
+  "data-testid": testId,
   action,
 }: {
   icon: ReactNode;
@@ -185,7 +185,7 @@ function MixerChannel({
   gain: number;
   onGainChange: (gain: number) => void;
   inputProps: ComponentProps<"input">;
-  testId: string;
+  "data-testid": string;
   action?: ReactNode;
 }) {
   return (

--- a/src/components/recorder/recorder-panel.tsx
+++ b/src/components/recorder/recorder-panel.tsx
@@ -7,7 +7,7 @@ export function RecorderPanel({
   closeLabel,
   onClose,
   children,
-  testId,
+  "data-testid": testId,
   className,
   contentClassName,
   style,
@@ -16,7 +16,7 @@ export function RecorderPanel({
   closeLabel: string;
   onClose: () => void;
   children: ReactNode;
-  testId?: string;
+  "data-testid"?: string;
   className?: string;
   contentClassName?: string;
   style?: CSSProperties;

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -202,7 +202,6 @@ function TimelineRuler({
           range={punch.range}
           enabled={punch.enabled}
           label="Punch"
-          testIdPrefix="recorder-punch"
           activeClassName="border-amber-300 bg-amber-400/20 text-amber-100"
           clearHoverClassName="hover:bg-amber-200/20"
           pixelsPerBeat={pixelsPerBeat}
@@ -250,7 +249,6 @@ function LoopRange({
       range={range}
       enabled={enabled}
       label="Loop"
-      testIdPrefix="recorder-loop"
       activeClassName="border-violet-300 bg-violet-400/20 text-violet-100"
       clearHoverClassName="hover:bg-violet-200/20"
       pixelsPerBeat={pixelsPerBeat}
@@ -266,7 +264,6 @@ function TimelineRange({
   range,
   enabled,
   label,
-  testIdPrefix,
   activeClassName,
   clearHoverClassName,
   pixelsPerBeat,
@@ -278,7 +275,6 @@ function TimelineRange({
   range: RecorderLoopRange | RecorderPunchRange;
   enabled: boolean;
   label: string;
-  testIdPrefix: "recorder-loop" | "recorder-punch";
   activeClassName: string;
   clearHoverClassName: string;
   pixelsPerBeat: number;
@@ -287,6 +283,7 @@ function TimelineRange({
   onChange: (range: RecorderLoopRange) => void;
   onClear: () => void;
 }) {
+  const testIdPrefix = `recorder-${label.toLowerCase()}`;
   const minimumLength = 1 / subdivisionsPerBeat;
   const dragRef = usePointerGesture({
     onStart: (event) => {

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -202,7 +202,7 @@ function TimelineRuler({
           range={punch.range}
           enabled={punch.enabled}
           label="Punch"
-          testId="recorder-punch"
+          testIdPrefix="recorder-punch"
           activeClassName="border-amber-300 bg-amber-400/20 text-amber-100"
           clearHoverClassName="hover:bg-amber-200/20"
           pixelsPerBeat={pixelsPerBeat}
@@ -250,7 +250,7 @@ function LoopRange({
       range={range}
       enabled={enabled}
       label="Loop"
-      testId="recorder-loop"
+      testIdPrefix="recorder-loop"
       activeClassName="border-violet-300 bg-violet-400/20 text-violet-100"
       clearHoverClassName="hover:bg-violet-200/20"
       pixelsPerBeat={pixelsPerBeat}
@@ -266,7 +266,7 @@ function TimelineRange({
   range,
   enabled,
   label,
-  testId,
+  testIdPrefix,
   activeClassName,
   clearHoverClassName,
   pixelsPerBeat,
@@ -278,7 +278,7 @@ function TimelineRange({
   range: RecorderLoopRange | RecorderPunchRange;
   enabled: boolean;
   label: string;
-  testId: "recorder-loop" | "recorder-punch";
+  testIdPrefix: "recorder-loop" | "recorder-punch";
   activeClassName: string;
   clearHoverClassName: string;
   pixelsPerBeat: number;
@@ -337,7 +337,7 @@ function TimelineRange({
   });
   return (
     <div
-      data-testid={`${testId}-range`}
+      data-testid={`${testIdPrefix}-range`}
       className={cn(
         "pointer-events-none absolute inset-y-0 z-10 border-x select-none",
         enabled
@@ -363,18 +363,18 @@ function TimelineRange({
       </span>
       <div
         ref={startRef}
-        data-testid={`${testId}-start`}
+        data-testid={`${testIdPrefix}-start`}
         className="pointer-events-auto absolute inset-y-0 -left-1 w-2 cursor-ew-resize"
       />
       <div
         ref={endRef}
-        data-testid={`${testId}-end`}
+        data-testid={`${testIdPrefix}-end`}
         className="pointer-events-auto absolute inset-y-0 -right-1 w-2 cursor-ew-resize"
       />
       <button
         type="button"
         title={`Clear ${label.toLowerCase()} range`}
-        data-testid={`${testId}-clear`}
+        data-testid={`${testIdPrefix}-clear`}
         className={cn(
           "pointer-events-auto absolute right-0.5 top-0.5 grid size-4 place-items-center rounded",
           enabled ? clearHoverClassName : "hover:bg-neutral-400/20",

--- a/src/components/recorder/reference-video.tsx
+++ b/src/components/recorder/reference-video.tsx
@@ -107,7 +107,7 @@ export function ReferenceVideoPanel({
       }
       closeLabel="Close Reference Video"
       onClose={onClose}
-      testId="recorder-youtube-reference"
+      data-testid="recorder-youtube-reference"
       className="pointer-events-auto relative flex shrink-0 flex-col overflow-hidden"
       contentClassName="min-h-0 flex-1 p-0"
       style={size}

--- a/src/components/score-viewer.tsx
+++ b/src/components/score-viewer.tsx
@@ -324,7 +324,7 @@ export function ScoreViewer({
           closeLabel="Close Score Settings"
           onClose={() => setIsSettingsOpen(false)}
           title="Score settings"
-          testId="score-settings-panel"
+          data-testid="score-settings-panel"
         >
           <ScoreSettings settings={settings} onChange={changeSettings} />
         </FloatingPanel>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -7,7 +7,7 @@ type DialogProps = {
   onClose: () => void;
   title: string;
   children: ReactNode;
-  testId?: string;
+  "data-testid"?: string;
   size?: "default" | "wide";
 };
 
@@ -16,7 +16,7 @@ export function Dialog({
   onClose,
   title,
   children,
-  testId,
+  "data-testid": testId,
   size = "default",
 }: DialogProps) {
   if (!isOpen) {

--- a/src/components/ui/floating-panel.tsx
+++ b/src/components/ui/floating-panel.tsx
@@ -8,7 +8,7 @@ type FloatingPanelProps = {
   closeLabel: string;
   onClose: () => void;
   children: ReactNode;
-  testId?: string;
+  "data-testid"?: string;
   className?: string;
   contentClassName?: string;
   style?: CSSProperties;
@@ -20,7 +20,7 @@ export function FloatingPanel({
   closeLabel,
   onClose,
   children,
-  testId,
+  "data-testid": testId,
   className,
   contentClassName,
   style,


### PR DESCRIPTION
Component props mix `testId` and `data-testid` for the same DOM attribute. This PR consolidates direct test ID props on `data-testid` and updates their call sites. The range component derives its test IDs from its label, removing the redundant prefix prop. Rendered test IDs stay unchanged.
