### PR TITLE
refactor: derive committed take regions outside runtime state

### DIFF
--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { Mic2Icon } from "lucide-react";
-import { useState, useSyncExternalStore } from "react";
+import { useMemo, useState, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 import { useWindowEvent } from "../../hooks/use-window-event";
 import { resolveAudioFiles } from "../../lib/audio-files";
@@ -11,6 +11,10 @@ import {
 } from "../../lib/keyboard";
 import { exportRecorderProjectArchive } from "../../lib/recorder/project-archive";
 import { RecorderRuntime } from "../../lib/recorder/runtime";
+import {
+  deriveTakeRegions,
+  deriveActiveTakes,
+} from "../../lib/recorder/take-regions";
 import { routes } from "../../lib/routes";
 import { beatsToSeconds } from "../../lib/timeline";
 import { parseTimeSignature } from "../../types";
@@ -127,6 +131,10 @@ export function Recorder({ projectId }: { projectId: string }) {
   });
 
   const takes = state.recordingTrack.takes;
+  const takeRegions = useMemo(
+    () => deriveTakeRegions(deriveActiveTakes(takes)),
+    [takes],
+  );
   const flags = deriveRecorderFlags({
     captureStatus: state.captureStatus,
     project,
@@ -479,7 +487,7 @@ export function Recorder({ projectId }: { projectId: string }) {
             >
               <TakeTimelineLane
                 takes={takes}
-                regions={state.previewTakeRegions ?? state.takeRegions}
+                regions={state.previewTakeRegions ?? takeRegions}
                 pendingRecording={state.pendingRecording}
                 captureStatus={state.captureStatus}
                 isTakeSelected={(id) =>

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -19,6 +19,7 @@ import type {
   RecorderPunchState,
   ReferenceVideoState,
 } from "../../lib/recorder/runtime";
+import type { TakeRegion } from "../../lib/recorder/take";
 import { formatTimeMinutes } from "../../lib/time-format";
 import {
   beatsToSeconds,
@@ -423,7 +424,7 @@ export function TakeTimelineLane({
   onTakeTrimMove,
 }: {
   takes: RecorderRuntimeState["recordingTrack"]["takes"];
-  regions: RecorderRuntimeState["takeRegions"];
+  regions: TakeRegion[];
   pendingRecording: RecorderRuntimeState["pendingRecording"];
   captureStatus: RecorderRuntimeState["captureStatus"];
   isTakeSelected: (id: string) => boolean;

--- a/src/lib/recorder/mix.ts
+++ b/src/lib/recorder/mix.ts
@@ -4,6 +4,7 @@ import { AudioChannel } from "./audio-channel.ts";
 import type { AudioPlaybackSource } from "./audio-sources.ts";
 import { getAudioTrackSources, getTakeSources } from "./audio-sources.ts";
 import type { RecorderRuntimeState } from "./runtime.ts";
+import { deriveTakeRegions, deriveActiveTakes } from "./take-regions.ts";
 
 interface RecorderMix {
   tracks: {
@@ -28,7 +29,9 @@ export function resolveRecorderMix(state: RecorderRuntimeState): RecorderMix {
   tracks.push({
     eq: state.recordingTrack.eq,
     gain: recordingGain,
-    regions: getTakeSources(state.takeRegions),
+    regions: getTakeSources(
+      deriveTakeRegions(deriveActiveTakes(state.recordingTrack.takes)),
+    ),
   });
   // Mixer toggles change sound, not the committed arrangement's extent.
   let duration = 0;

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -25,7 +25,7 @@ import {
   serializeRecorderRuntimeState,
 } from "./persistence.ts";
 import { ActiveRecording } from "./recording.ts";
-import { deriveTakeRegions } from "./take-regions.ts";
+import { deriveTakeRegions, deriveActiveTakes } from "./take-regions.ts";
 import type { TakeRegion, TakeState } from "./take.ts";
 import { AudioContextTransport } from "./transport.ts";
 import { YouTubePlayerPlayback } from "./youtube-player-playback.ts";
@@ -134,7 +134,6 @@ export interface RecorderRuntimeState {
   // Tracks
   audioTracks: AudioTrackState[];
   recordingTrack: RecordingTrackState;
-  takeRegions: TakeRegion[];
   previewTakeRegions?: TakeRegion[];
   pendingRecording?: PendingRecordingState;
   // Capture
@@ -190,7 +189,6 @@ export function createDefaultRecorderRuntimeState(): RecorderRuntimeState {
     metronomeGain: 0.5,
     audioTracks: [],
     recordingTrack: createRecordingTrackState(),
-    takeRegions: [],
     captureStatus: "disabled",
     inputChannelCount: 0,
     selectedChannel: 0,
@@ -1165,7 +1163,7 @@ export class RecorderRuntime {
     const takeRegions = deriveTakeRegions(
       deriveActiveTakes(recordingTrack.takes),
     );
-    this.store.update({ ...update, takeRegions });
+    this.store.update(update);
     this.syncTakePlayback(takeRegions);
   }
 
@@ -1183,11 +1181,6 @@ export class RecorderRuntime {
     this.captureTrack!.setSources(getTakeSources(takeRegions));
     this.syncTrackMix();
   }
-}
-
-function deriveActiveTakes(takes: readonly TakeState[]): TakeState[] {
-  const anyTakeSoloed = takes.some((take) => take.soloed);
-  return takes.filter((take) => !take.muted && (!anyTakeSoloed || take.soloed));
 }
 
 function pendingRecordingToTake(

--- a/src/lib/recorder/take-regions.test.ts
+++ b/src/lib/recorder/take-regions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { deriveTakeRegions } from "./take-regions.ts";
+import { deriveTakeRegions, deriveActiveTakes } from "./take-regions.ts";
 import type { TakeState } from "./take.ts";
 
 describe(deriveTakeRegions, () => {
@@ -63,6 +63,19 @@ describe(deriveTakeRegions, () => {
       { take: trimmed, timelineStart: 4, timelineEnd: 8 },
     ]);
   });
+});
+
+it("filters mute and solo before resolving the committed comp", () => {
+  const older = take("older", 0, 10);
+  const newer = { ...take("newer", 3, 4), muted: true };
+  expect(deriveTakeRegions(deriveActiveTakes([older, newer]))).toEqual([
+    { take: older, timelineStart: 0, timelineEnd: 10 },
+  ]);
+  const soloed = { ...newer, muted: false, soloed: true };
+  expect(deriveTakeRegions(deriveActiveTakes([older, soloed]))).toEqual([
+    { take: soloed, timelineStart: 3, timelineEnd: 7 },
+  ]);
+  expect(deriveActiveTakes([older, { ...soloed, muted: true }])).toEqual([]);
 });
 
 function take(id: string, timelineOffset: number, duration: number): TakeState {

--- a/src/lib/recorder/take-regions.ts
+++ b/src/lib/recorder/take-regions.ts
@@ -61,3 +61,8 @@ export function deriveTakeRegions(takes: readonly TakeState[]): TakeRegion[] {
 
   return regions.sort((a, b) => a.timelineStart - b.timelineStart);
 }
+
+export function deriveActiveTakes(takes: readonly TakeState[]): TakeState[] {
+  const anyTakeSoloed = takes.some((take) => take.soloed);
+  return takes.filter((take) => !take.muted && (!anyTakeSoloed || take.soloed));
+}


### PR DESCRIPTION
- related to https://github.com/hi-ogawa/toy-midi/issues/464

This PR removes committed `takeRegions` from recorder runtime state. The timeline memoizes regions from the takes array, playback derives them when takes change, and export derives them from its current snapshot. All consumers share the existing mute/solo filtering and overlap resolver.

Recording preview regions remain in state. This isolates the derived-state change from track unification and keeps the existing track model and project format.
