### PR TITLE
refactor: share recorder playback map and address tracks by id

### DIFF
--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -369,17 +369,15 @@ export function Recorder({ projectId }: { projectId: string }) {
                 soloed={track.soloed}
                 effectsOpen={effects.openEffects.has(track.id)}
                 onEffectsToggle={() => effects.toggleEffects(track.id)}
-                onGainChange={(gain) =>
-                  runtime.setAudioTrackMix(track.id, { gain })
-                }
+                onGainChange={(gain) => runtime.setTrackMix(track.id, { gain })}
                 onMutedChange={(muted) =>
-                  runtime.setAudioTrackMix(track.id, { muted })
+                  runtime.setTrackMix(track.id, { muted })
                 }
                 onSoloedChange={(soloed) =>
-                  runtime.setAudioTrackMix(track.id, { soloed })
+                  runtime.setTrackMix(track.id, { soloed })
                 }
                 onHeightChange={(height) =>
-                  runtime.setAudioTrackHeight(track.id, height)
+                  runtime.setTrackHeight(track.id, height)
                 }
                 action={
                   <AudioTrackActions
@@ -451,18 +449,22 @@ export function Recorder({ projectId }: { projectId: string }) {
               soloed={state.recordingTrack.soloed}
               effectsOpen={effects.openEffects.has("capture")}
               onEffectsToggle={() => effects.toggleEffects("capture")}
-              onGainChange={(gain) => runtime.setRecordingTrackMix({ gain })}
+              onGainChange={(gain) =>
+                runtime.setTrackMix(state.recordingTrack.id, { gain })
+              }
               onInputSetup={() => setIsInputSetupOpen(true)}
               onInputMonitoringChange={(monitoring) =>
                 runtime.setInputMonitoring(monitoring)
               }
               onInputToggle={input.toggle}
-              onMutedChange={(muted) => runtime.setRecordingTrackMix({ muted })}
+              onMutedChange={(muted) =>
+                runtime.setTrackMix(state.recordingTrack.id, { muted })
+              }
               onSoloedChange={(soloed) =>
-                runtime.setRecordingTrackMix({ soloed })
+                runtime.setTrackMix(state.recordingTrack.id, { soloed })
               }
               onHeightChange={(height) =>
-                runtime.setRecordingTrackHeight(height)
+                runtime.setTrackHeight(state.recordingTrack.id, height)
               }
             >
               <TakeTimelineLane
@@ -517,10 +519,10 @@ export function Recorder({ projectId }: { projectId: string }) {
                   muted={take.muted}
                   soloed={take.soloed}
                   onMutedChange={(muted) =>
-                    runtime.setTakeMuted(take.id, muted)
+                    runtime.setClipMuted({ id: take.id, muted })
                   }
                   onSoloedChange={(soloed) =>
-                    runtime.setTakeSoloed(take.id, soloed)
+                    runtime.setClipSoloed({ id: take.id, soloed })
                   }
                   onDelete={() =>
                     runtime.removeClips([{ type: "clip", id: take.id }])
@@ -633,9 +635,7 @@ export function Recorder({ projectId }: { projectId: string }) {
                     key={track.id}
                     label={`Audio ${index + 1}`}
                     eq={track.eq}
-                    onChange={(eq) =>
-                      runtime.setAudioTrackEq({ id: track.id, eq })
-                    }
+                    onChange={(eq) => runtime.setTrackEq({ id: track.id, eq })}
                     onClose={() => effects.closeEffects(track.id)}
                   />
                 ),
@@ -644,7 +644,9 @@ export function Recorder({ projectId }: { projectId: string }) {
               <RecorderEffects
                 label="Capture"
                 eq={state.recordingTrack.eq}
-                onChange={(update) => runtime.setRecordingTrackEq(update)}
+                onChange={(eq) =>
+                  runtime.setTrackEq({ id: state.recordingTrack.id, eq })
+                }
                 onClose={() => effects.closeEffects("capture")}
               />
             )}

--- a/src/components/recorder/recorder-mixer.tsx
+++ b/src/components/recorder/recorder-mixer.tsx
@@ -49,13 +49,9 @@ export function RecorderMixer({
           gain={track.gain}
           muted={track.muted}
           soloed={track.soloed}
-          onGainChange={(gain) => runtime.setAudioTrackMix(track.id, { gain })}
-          onMutedChange={(muted) =>
-            runtime.setAudioTrackMix(track.id, { muted })
-          }
-          onSoloedChange={(soloed) =>
-            runtime.setAudioTrackMix(track.id, { soloed })
-          }
+          onGainChange={(gain) => runtime.setTrackMix(track.id, { gain })}
+          onMutedChange={(muted) => runtime.setTrackMix(track.id, { muted })}
+          onSoloedChange={(soloed) => runtime.setTrackMix(track.id, { soloed })}
         />
       ))}
       <RecorderTrackChannel
@@ -66,9 +62,15 @@ export function RecorderMixer({
         muted={state.recordingTrack.muted}
         soloed={state.recordingTrack.soloed}
         icon={<Mic2Icon className="size-4 text-muted-foreground" />}
-        onGainChange={(gain) => runtime.setRecordingTrackMix({ gain })}
-        onMutedChange={(muted) => runtime.setRecordingTrackMix({ muted })}
-        onSoloedChange={(soloed) => runtime.setRecordingTrackMix({ soloed })}
+        onGainChange={(gain) =>
+          runtime.setTrackMix(state.recordingTrack.id, { gain })
+        }
+        onMutedChange={(muted) =>
+          runtime.setTrackMix(state.recordingTrack.id, { muted })
+        }
+        onSoloedChange={(soloed) =>
+          runtime.setTrackMix(state.recordingTrack.id, { soloed })
+        }
       />
       <MixerChannel
         icon={<MetronomeIcon className="size-4 text-muted-foreground" />}

--- a/src/lib/recorder/README.md
+++ b/src/lib/recorder/README.md
@@ -10,7 +10,7 @@ flowchart LR
     analyser --> monitorGain["captureInput.monitorGain"]
     monitorGain --> captureInput
 
-    subgraph captureTrack["captureTrack: AudioTrackPlayback"]
+    subgraph captureTrack["trackPlaybacks.get(RECORDING_TRACK_ID): AudioTrackPlayback"]
         takeSource["playbacks[i].source"] --> takeBusInput
         subgraph takePitchShiftBus["bus: PitchShiftBus"]
             takeBusInput["input"] --> takePitchShifter["pitchShifter (optional)"]
@@ -24,7 +24,7 @@ flowchart LR
     end
 
     captureGain --> masterOutput["masterOutput"]
-    audioTrack["audioTracks.get(id): AudioTrackPlayback"] --> masterOutput
+    audioTrack["trackPlaybacks.get(id): AudioTrackPlayback"] --> masterOutput
     oscillator["oscillator"] --> envelope["envelope"]
     envelope --> metronomeOutput["metronome.output"]
     metronomeOutput --> masterOutput

--- a/src/lib/recorder/capture-input.ts
+++ b/src/lib/recorder/capture-input.ts
@@ -105,6 +105,12 @@ export class CaptureInput {
     this.worklet.setChannel(channel);
   }
 
+  /** Re-points monitoring at another channel without reopening the device. */
+  setMonitorOutput(output: AudioNode): void {
+    this.monitorGain.disconnect();
+    this.monitorGain.connect(output);
+  }
+
   setMonitoring(enabled: boolean): void {
     this.monitorGain.gain.setTargetAtTime(
       enabled ? 1 : 0,

--- a/src/lib/recorder/mix.ts
+++ b/src/lib/recorder/mix.ts
@@ -17,19 +17,15 @@ interface RecorderMix {
 
 /** Snapshot committed audio at 1x, independent of transport and reference audio. */
 export function resolveRecorderMix(state: RecorderRuntimeState): RecorderMix {
-  const { audioTrackGains, recordingGain } = deriveTrackMix(state);
-  const tracks: RecorderMix["tracks"] = state.audioTracks.map(
-    (track, index) => ({
-      eq: track.eq,
-      gain: audioTrackGains[index]!,
-      regions: getClipSources(track.regions),
-    }),
-  );
-  tracks.push({
-    eq: state.recordingTrack.eq,
-    gain: recordingGain,
-    regions: getClipSources(state.recordingTrack.regions),
-  });
+  const gains = deriveTrackMix(state);
+  const tracks: RecorderMix["tracks"] = [
+    ...state.audioTracks,
+    state.recordingTrack,
+  ].map((track) => ({
+    eq: track.eq,
+    gain: gains.get(track.id)!,
+    regions: getClipSources(track.regions),
+  }));
   // Mixer toggles change sound, not the committed arrangement's extent.
   let duration = 0;
   for (const track of tracks) {
@@ -86,14 +82,20 @@ export async function renderRecorderMix({
   return context.startRendering();
 }
 
+/** Effective channel gain per track id after mute and solo. */
 export function deriveTrackMix({
   audioTracks,
   recordingTrack,
-}: Pick<RecorderRuntimeState, "audioTracks" | "recordingTrack">) {
+}: Pick<RecorderRuntimeState, "audioTracks" | "recordingTrack">): Map<
+  string,
+  number
+> {
   const tracks = [...audioTracks, recordingTrack];
   const anyTrackSoloed = tracks.some((track) => track.soloed);
-  const gains = tracks.map((track) =>
-    track.muted || (anyTrackSoloed && !track.soloed) ? 0 : track.gain,
+  return new Map(
+    tracks.map((track) => [
+      track.id,
+      track.muted || (anyTrackSoloed && !track.soloed) ? 0 : track.gain,
+    ]),
   );
-  return { audioTrackGains: gains.slice(0, -1), recordingGain: gains.at(-1)! };
 }

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -40,14 +40,18 @@ const DEFAULT_TRACK_HEIGHT = 72;
 const MIN_TRACK_HEIGHT = DEFAULT_TRACK_HEIGHT;
 const MIN_RECORDING_TRACK_HEIGHT = 116;
 const MAX_TRACK_HEIGHT = 300;
+// The recording track keeps a fixed id so its playback can live in the shared
+// track playback map while its state still lives outside audioTracks.
+const RECORDING_TRACK_ID = "__capture__";
 
 type CaptureStatus = "disabled" | "ready" | "recording" | "processing";
 
 // The ordinary-track UI currently keeps zero or one imported clip and has
 // no clip-level mute/solo controls. Imported clips initialize both flags to false.
 // Ordinary tracks leave nextTakeNumber at 1 because only the recording track
-// creates takes. The recording track has an id, but is still addressed directly
-// through recordingTrack rather than looked up by id.
+// creates takes. The recording track uses RECORDING_TRACK_ID. Its state is still
+// stored in recordingTrack rather than audioTracks, but its playback shares
+// trackPlaybacks with ordinary tracks.
 export interface AudioTrackState {
   id: string;
   eq: MultibandEqParameters;
@@ -197,8 +201,7 @@ export class RecorderRuntime {
   private readonly masterOutput: GainNode;
   private readonly transport: AudioContextTransport;
   captureInput?: CaptureInput;
-  private audioTracks = new Map<string, AudioTrackPlayback>();
-  private captureTrack?: AudioTrackPlayback;
+  private trackPlaybacks = new Map<string, AudioTrackPlayback>();
   private attachedYouTubePlayer?: {
     videoId: string;
     player: YouTubePlayerApi;
@@ -227,14 +230,9 @@ export class RecorderRuntime {
       ensurePitchShifterWorklet(this.context),
       ensureBiquadEqWorklet(this.context),
     ]);
-    if (!this.captureTrack) {
-      this.captureTrack = new AudioTrackPlayback({
-        transport: this.transport,
-        output: this.masterOutput,
-        eq: this.store.get().recordingTrack.eq,
-        gain: deriveTrackMix(this.store.get()).recordingGain,
-      });
-    }
+    // Create the recording playback eagerly because startInput routes the
+    // capture input into its channel.
+    this.getTrackPlayback(RECORDING_TRACK_ID);
   }
 
   async startInput({
@@ -248,7 +246,7 @@ export class RecorderRuntime {
     const { input, channelCount } = await CaptureInput.open({
       context,
       deviceId,
-      output: this.captureTrack!.channel.input,
+      output: this.getTrackPlayback(RECORDING_TRACK_ID).channel.input,
       onNotification: (message) => {
         switch (message.type) {
           case "samples": {
@@ -334,7 +332,14 @@ export class RecorderRuntime {
         }),
       ],
     }));
-    this.syncAudioTrackPlayback(track);
+    const wasPlaying = this.store.get().isPlaying;
+    if (wasPlaying) {
+      this.pause();
+    }
+    this.syncTrackPlayback(track);
+    if (wasPlaying) {
+      this.transport.play();
+    }
   }
 
   setAudioTrackMix(
@@ -387,14 +392,14 @@ export class RecorderRuntime {
     }
     this.store.update({ recordingTrack, audioTracks, referenceVideo });
     if (recordingTrack !== state.recordingTrack) {
-      this.syncTakePlayback(recordingTrack.regions);
+      this.syncTrackPlayback(recordingTrack);
     }
     if (referenceOffset !== undefined) {
       this.syncYouTubePlayer();
     }
     for (const [index, track] of audioTracks.entries()) {
       if (track !== state.audioTracks[index]) {
-        this.syncAudioTrackPlayback(track);
+        this.syncTrackPlayback(track);
       }
     }
     if (wasPlaying) {
@@ -441,11 +446,11 @@ export class RecorderRuntime {
     const recordingTrack = trimTrackClips(state.recordingTrack);
     this.store.update({ recordingTrack, audioTracks });
     if (recordingTrack !== state.recordingTrack) {
-      this.syncTakePlayback(recordingTrack.regions);
+      this.syncTrackPlayback(recordingTrack);
     }
     for (const [index, track] of audioTracks.entries()) {
       if (track !== state.audioTracks[index]) {
-        this.syncAudioTrackPlayback(track);
+        this.syncTrackPlayback(track);
       }
     }
     if (wasPlaying) {
@@ -479,11 +484,11 @@ export class RecorderRuntime {
       ...(removeReference ? { referenceVideo: undefined } : {}),
     });
     if (recordingTrack !== state.recordingTrack) {
-      this.syncTakePlayback(recordingTrack.regions);
+      this.syncTrackPlayback(recordingTrack);
     }
     for (const [index, track] of audioTracks.entries()) {
       if (track !== state.audioTracks[index]) {
-        this.syncAudioTrackPlayback(track);
+        this.syncTrackPlayback(track);
       }
     }
     if (removeReference) {
@@ -502,8 +507,11 @@ export class RecorderRuntime {
   }
 
   removeAudioTrack(id: string): void {
-    this.audioTracks.get(id)?.dispose();
-    this.audioTracks.delete(id);
+    if (id === RECORDING_TRACK_ID) {
+      throw new Error("The recording track cannot be removed.");
+    }
+    this.trackPlaybacks.get(id)?.dispose();
+    this.trackPlaybacks.delete(id);
     this.store.update({
       audioTracks: this.store
         .get()
@@ -517,7 +525,7 @@ export class RecorderRuntime {
       ...track,
       eq,
     }));
-    this.audioTracks.get(id)?.channel.setEq(track.eq);
+    this.trackPlaybacks.get(id)?.channel.setEq(track.eq);
   }
 
   setRecordingTrackEq(eq: MultibandEqParameters): void {
@@ -528,7 +536,7 @@ export class RecorderRuntime {
         eq,
       },
     });
-    this.captureTrack?.channel.setEq(this.store.get().recordingTrack.eq);
+    this.trackPlaybacks.get(RECORDING_TRACK_ID)?.channel.setEq(eq);
   }
 
   private updateAudioTrack(
@@ -548,12 +556,13 @@ export class RecorderRuntime {
     return audioTracks[index]!;
   }
 
-  private getAudioTrackPlayback(id: string): AudioTrackPlayback {
-    let playback = this.audioTracks.get(id);
+  private getTrackPlayback(id: string): AudioTrackPlayback {
+    let playback = this.trackPlaybacks.get(id);
     if (!playback) {
-      const track = this.store
-        .get()
-        .audioTracks.find((entry) => entry.id === id);
+      const { audioTracks, recordingTrack } = this.store.get();
+      const track = [...audioTracks, recordingTrack].find(
+        (entry) => entry.id === id,
+      );
       if (!track) {
         throw new Error("Audio track state is missing.");
       }
@@ -563,22 +572,14 @@ export class RecorderRuntime {
         eq: track.eq,
         gain: 0,
       });
-      this.audioTracks.set(id, playback);
+      this.trackPlaybacks.set(id, playback);
       this.syncTrackMix();
     }
     return playback;
   }
 
-  private syncAudioTrackPlayback(track: AudioTrackState): void {
-    const wasPlaying = this.store.get().isPlaying;
-    if (wasPlaying) {
-      this.pause();
-    }
-    const playback = this.getAudioTrackPlayback(track.id);
-    playback.setSources(getClipSources(track.regions));
-    if (wasPlaying) {
-      this.transport.play();
-    }
+  private syncTrackPlayback(track: AudioTrackState): void {
+    this.getTrackPlayback(track.id).setSources(getClipSources(track.regions));
   }
 
   setRecordingTrackMix(
@@ -633,7 +634,7 @@ export class RecorderRuntime {
       clips: updateFn(previousTrack.clips),
     });
     this.store.update({ recordingTrack });
-    this.syncTakePlayback(recordingTrack.regions);
+    this.syncTrackPlayback(recordingTrack);
     if (wasPlaying) {
       this.transport.play();
     }
@@ -662,7 +663,7 @@ export class RecorderRuntime {
     if (!this.store.get().isPlaying) {
       await this.play();
     }
-    this.captureTrack!.setPlaybackGain(0);
+    this.getTrackPlayback(RECORDING_TRACK_ID).setPlaybackGain(0);
     // Trim samples captured during playback lead time.
     const playbackStartFrame =
       this.transport.playbackAnchor!.contextTime * context.sampleRate;
@@ -929,10 +930,14 @@ export class RecorderRuntime {
       throw new Error("Cannot load a project while recording.");
     }
     this.pause();
-    for (const playback of this.audioTracks.values()) {
-      playback.dispose();
+    // Keep the recording playback because the open capture input is routed
+    // into its channel.
+    for (const [id, playback] of this.trackPlaybacks) {
+      if (id !== RECORDING_TRACK_ID) {
+        playback.dispose();
+        this.trackPlaybacks.delete(id);
+      }
     }
-    this.audioTracks.clear();
     const audioTracks = project.audioTracks.map((track) =>
       resolveTrackRegions(track),
     );
@@ -947,12 +952,14 @@ export class RecorderRuntime {
         gain: 0,
       });
       playback.setSources(getClipSources(track.regions));
-      this.audioTracks.set(track.id, playback);
+      this.trackPlaybacks.set(track.id, playback);
     }
     // Clamp loaded external state at the runtime boundary so older projects
-    // cannot restore a Capture row too short for its current controls.
+    // cannot restore a Capture row too short for its current controls, and pin
+    // the recording track id that persistence does not preserve.
     const recordingTrack = resolveTrackRegions({
       ...project.recordingTrack,
+      id: RECORDING_TRACK_ID,
       height: clampRecordingTrackHeight(project.recordingTrack.height),
     });
     this.store.update({
@@ -961,8 +968,8 @@ export class RecorderRuntime {
       position: 0,
       recordingTrack,
     });
-    this.syncTakePlayback(recordingTrack.regions);
-    this.captureTrack!.channel.setEq(project.recordingTrack.eq);
+    this.syncTrackPlayback(recordingTrack);
+    this.getTrackPlayback(RECORDING_TRACK_ID).channel.setEq(recordingTrack.eq);
     this.syncYouTubePlayer();
     this.transport.seek(0);
     this.metronome.setTempo(project.tempo);
@@ -996,20 +1003,17 @@ export class RecorderRuntime {
   }
 
   private syncTrackMix(): void {
-    const { audioTracks, recordingTrack } = this.store.get();
-    const { audioTrackGains, recordingGain } = deriveTrackMix({
-      audioTracks,
-      recordingTrack,
-    });
-    for (const [index, track] of audioTracks.entries()) {
-      this.audioTracks.get(track.id)?.channel.setGain(audioTrackGains[index]!);
+    const state = this.store.get();
+    for (const [id, gain] of deriveTrackMix(state)) {
+      this.trackPlaybacks.get(id)?.channel.setGain(gain);
     }
-    this.captureTrack?.channel.setGain(recordingGain);
     // Suppress take playback independently so channel mix edits cannot unmute it.
-    const { captureStatus } = this.store.get();
-    this.captureTrack?.setPlaybackGain(
-      captureStatus === "recording" || captureStatus === "processing" ? 0 : 1,
-    );
+    const { captureStatus } = state;
+    this.trackPlaybacks
+      .get(RECORDING_TRACK_ID)
+      ?.setPlaybackGain(
+        captureStatus === "recording" || captureStatus === "processing" ? 0 : 1,
+      );
   }
 
   private syncMetronomeGain(): void {
@@ -1089,7 +1093,8 @@ export class RecorderRuntime {
       previewClipRegions: undefined,
       recordingTrack,
     });
-    this.syncTakePlayback(recordingTrack.regions);
+    this.syncTrackPlayback(recordingTrack);
+    this.syncTrackMix();
   }
 
   private closeInput(): void {
@@ -1105,11 +1110,6 @@ export class RecorderRuntime {
       pendingRecordingToTake(pendingRecording),
     ]);
     this.store.update({ pendingRecording, previewClipRegions });
-  }
-
-  private syncTakePlayback(takeRegions: ClipRegion[]): void {
-    this.captureTrack!.setSources(getClipSources(takeRegions));
-    this.syncTrackMix();
   }
 }
 
@@ -1219,7 +1219,7 @@ function createAudioTrackState(): AudioTrackState {
 
 function createRecordingTrackState(): AudioTrackState {
   return {
-    id: crypto.randomUUID(),
+    id: RECORDING_TRACK_ID,
     eq: createDefaultMultibandEq(),
     height: MIN_RECORDING_TRACK_HEIGHT,
     gain: 1,

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -323,7 +323,7 @@ export class RecorderRuntime {
     if (!this.store.get().audioTracks.some((track) => track.id === id)) {
       return;
     }
-    const track = this.updateAudioTrack(id, (track) => ({
+    const track = this.updateTrack(id, (track) => ({
       ...track,
       clips: [
         createAudioClip({
@@ -342,13 +342,11 @@ export class RecorderRuntime {
     }
   }
 
-  setAudioTrackMix(
+  setTrackMix(
     id: string,
     update: Partial<Pick<AudioTrackState, "gain" | "muted" | "soloed">>,
   ): void {
-    this.updateAudioTrack(id, (track) => {
-      return { ...track, ...update };
-    });
+    this.updateTrack(id, (track) => ({ ...track, ...update }));
     this.syncTrackMix();
   }
 
@@ -408,42 +406,43 @@ export class RecorderRuntime {
   }
 
   trimClip({ id, edge, value }: RecorderClipTrim): void {
+    this.updateClip(id, (clip) => ({
+      ...clip,
+      ...(edge === "start"
+        ? { trimStart: clamp(value, 0, clip.trimEnd - MIN_TAKE_DURATION) }
+        : {
+            trimEnd: clamp(
+              value,
+              clip.trimStart + MIN_TAKE_DURATION,
+              clip.duration,
+            ),
+          }),
+    }));
+  }
+
+  setClipMuted({ id, muted }: { id: string; muted: boolean }): void {
+    this.updateClip(id, (clip) => ({ ...clip, muted }));
+  }
+
+  setClipSoloed({ id, soloed }: { id: string; soloed: boolean }): void {
+    this.updateClip(id, (clip) => ({ ...clip, soloed }));
+  }
+
+  private updateClip(id: string, update: (clip: AudioClip) => AudioClip): void {
     const state = this.store.get();
     const wasPlaying = state.isPlaying;
     if (wasPlaying) {
       this.pause();
     }
-    const clipIds = new Set([id]);
-    function trimTrackClips(track: AudioTrackState): AudioTrackState {
+    function updateClips(track: AudioTrackState): AudioTrackState {
       return updateTrackClips({
         track,
         update: (clips) =>
-          clips.map((clip) =>
-            clipIds.has(clip.id)
-              ? {
-                  ...clip,
-                  ...(edge === "start"
-                    ? {
-                        trimStart: clamp(
-                          value,
-                          0,
-                          clip.trimEnd - MIN_TAKE_DURATION,
-                        ),
-                      }
-                    : {
-                        trimEnd: clamp(
-                          value,
-                          clip.trimStart + MIN_TAKE_DURATION,
-                          clip.duration,
-                        ),
-                      }),
-                }
-              : clip,
-          ),
+          clips.map((clip) => (clip.id === id ? update(clip) : clip)),
       });
     }
-    const audioTracks = state.audioTracks.map((track) => trimTrackClips(track));
-    const recordingTrack = trimTrackClips(state.recordingTrack);
+    const audioTracks = state.audioTracks.map((track) => updateClips(track));
+    const recordingTrack = updateClips(state.recordingTrack);
     this.store.update({ recordingTrack, audioTracks });
     if (recordingTrack !== state.recordingTrack) {
       this.syncTrackPlayback(recordingTrack);
@@ -499,10 +498,14 @@ export class RecorderRuntime {
     }
   }
 
-  setAudioTrackHeight(id: string, height: number): void {
-    this.updateAudioTrack(id, (track) => ({
+  setTrackHeight(id: string, height: number): void {
+    this.updateTrack(id, (track) => ({
       ...track,
-      height: clampTrackHeight(height),
+      // The Capture row carries input controls and needs more room.
+      height:
+        id === RECORDING_TRACK_ID
+          ? clampRecordingTrackHeight(height)
+          : clampTrackHeight(height),
     }));
   }
 
@@ -520,38 +523,32 @@ export class RecorderRuntime {
     this.syncTrackMix();
   }
 
-  setAudioTrackEq({ id, eq }: { id: string; eq: MultibandEqParameters }): void {
-    const track = this.updateAudioTrack(id, (track) => ({
-      ...track,
-      eq,
-    }));
-    this.trackPlaybacks.get(id)?.channel.setEq(track.eq);
+  setTrackEq({ id, eq }: { id: string; eq: MultibandEqParameters }): void {
+    this.updateTrack(id, (track) => ({ ...track, eq }));
+    this.trackPlaybacks.get(id)?.channel.setEq(eq);
   }
 
-  setRecordingTrackEq(eq: MultibandEqParameters): void {
-    const track = this.store.get().recordingTrack;
-    this.store.update({
-      recordingTrack: {
-        ...track,
-        eq,
-      },
-    });
-    this.trackPlaybacks.get(RECORDING_TRACK_ID)?.channel.setEq(eq);
-  }
-
-  private updateAudioTrack(
+  private updateTrack(
     id: string,
     update: (track: AudioTrackState) => AudioTrackState,
   ): AudioTrackState {
-    const audioTracks = this.store.get().audioTracks.slice();
+    const apply = (track: AudioTrackState): AudioTrackState => {
+      const next = update(track);
+      return next.clips === track.clips ? next : resolveTrackRegions(next);
+    };
+    const state = this.store.get();
+    if (id === RECORDING_TRACK_ID) {
+      const recordingTrack = apply(state.recordingTrack);
+      this.store.update({ recordingTrack });
+      return recordingTrack;
+    }
+    const audioTracks = state.audioTracks.slice();
     const index = audioTracks.findIndex((track) => track.id === id);
     const track = audioTracks[index];
     if (!track) {
       throw new Error("Audio track state is missing.");
     }
-    const next = update(track);
-    audioTracks[index] =
-      next.clips === track.clips ? next : resolveTrackRegions(next);
+    audioTracks[index] = apply(track);
     this.store.update({ audioTracks });
     return audioTracks[index]!;
   }
@@ -580,64 +577,6 @@ export class RecorderRuntime {
 
   private syncTrackPlayback(track: AudioTrackState): void {
     this.getTrackPlayback(track.id).setSources(getClipSources(track.regions));
-  }
-
-  setRecordingTrackMix(
-    update: Partial<Pick<AudioTrackState, "gain" | "muted" | "soloed">>,
-  ): void {
-    const recordingTrack = { ...this.store.get().recordingTrack, ...update };
-    this.store.update({ recordingTrack });
-    this.syncTrackMix();
-  }
-
-  setRecordingTrackHeight(height: number): void {
-    this.store.update({
-      recordingTrack: {
-        ...this.store.get().recordingTrack,
-        height: clampRecordingTrackHeight(height),
-      },
-    });
-  }
-
-  setTakeMuted(id: string, muted: boolean): void {
-    this.updateTake(id, (take) => ({ ...take, muted }));
-  }
-
-  setTakeSoloed(id: string, soloed: boolean): void {
-    this.updateTake(id, (take) => ({ ...take, soloed }));
-  }
-
-  private updateTake(
-    id: string,
-    updateFn: (take: AudioClip) => AudioClip,
-  ): void {
-    this.updateTakes((takes) => {
-      const index = takes.findIndex((take) => take.id === id);
-      const take = takes[index];
-      if (!take) {
-        throw new Error("Recording take state is missing.");
-      }
-      const nextTakes = takes.slice();
-      nextTakes[index] = updateFn(take);
-      return nextTakes;
-    });
-  }
-
-  private updateTakes(updateFn: (takes: AudioClip[]) => AudioClip[]): void {
-    const wasPlaying = this.store.get().isPlaying;
-    if (wasPlaying) {
-      this.pause();
-    }
-    const previousTrack = this.store.get().recordingTrack;
-    const recordingTrack = resolveTrackRegions({
-      ...previousTrack,
-      clips: updateFn(previousTrack.clips),
-    });
-    this.store.update({ recordingTrack });
-    this.syncTrackPlayback(recordingTrack);
-    if (wasPlaying) {
-      this.transport.play();
-    }
   }
 
   async play(): Promise<void> {

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -627,13 +627,13 @@ export class RecorderRuntime {
     if (wasPlaying) {
       this.pause();
     }
-    const recordingTrack = this.store.get().recordingTrack;
-    this.updateRecordingTrack({
-      recordingTrack: resolveTrackRegions({
-        ...recordingTrack,
-        clips: updateFn(recordingTrack.clips),
-      }),
+    const previousTrack = this.store.get().recordingTrack;
+    const recordingTrack = resolveTrackRegions({
+      ...previousTrack,
+      clips: updateFn(previousTrack.clips),
     });
+    this.store.update({ recordingTrack });
+    this.syncTakePlayback(recordingTrack.regions);
     if (wasPlaying) {
       this.transport.play();
     }
@@ -951,15 +951,17 @@ export class RecorderRuntime {
     }
     // Clamp loaded external state at the runtime boundary so older projects
     // cannot restore a Capture row too short for its current controls.
-    this.updateRecordingTrack({
+    const recordingTrack = resolveTrackRegions({
+      ...project.recordingTrack,
+      height: clampRecordingTrackHeight(project.recordingTrack.height),
+    });
+    this.store.update({
       ...project,
       audioTracks,
       position: 0,
-      recordingTrack: resolveTrackRegions({
-        ...project.recordingTrack,
-        height: clampRecordingTrackHeight(project.recordingTrack.height),
-      }),
+      recordingTrack,
     });
+    this.syncTakePlayback(recordingTrack.regions);
     this.captureTrack!.channel.setEq(project.recordingTrack.eq);
     this.syncYouTubePlayer();
     this.transport.seek(0);
@@ -1065,40 +1067,34 @@ export class RecorderRuntime {
     );
     takeBuffer.getChannelData(0).set(slice.samples);
     const timelineOffset = pendingRecording.timelineOffset + slice.startOffset;
-    const recordingTrack = this.store.get().recordingTrack;
-    this.updateRecordingTrack({
+    const previousTrack = this.store.get().recordingTrack;
+    const recordingTrack = resolveTrackRegions({
+      ...previousTrack,
+      nextTakeNumber: previousTrack.nextTakeNumber + 1,
+      clips: [
+        ...previousTrack.clips,
+        {
+          ...createAudioClip({
+            id: pendingRecording.id,
+            name: pendingRecording.name,
+            buffer: takeBuffer,
+          }),
+          timelineOffset,
+        },
+      ],
+    });
+    this.store.update({
       captureStatus: "ready",
       pendingRecording: undefined,
       previewClipRegions: undefined,
-      recordingTrack: resolveTrackRegions({
-        ...recordingTrack,
-        nextTakeNumber: recordingTrack.nextTakeNumber + 1,
-        clips: [
-          ...recordingTrack.clips,
-          {
-            ...createAudioClip({
-              id: pendingRecording.id,
-              name: pendingRecording.name,
-              buffer: takeBuffer,
-            }),
-            timelineOffset,
-          },
-        ],
-      }),
+      recordingTrack,
     });
+    this.syncTakePlayback(recordingTrack.regions);
   }
 
   private closeInput(): void {
     this.captureInput?.dispose();
     this.captureInput = undefined;
-  }
-
-  private updateRecordingTrack(
-    update: Partial<RecorderRuntimeState> &
-      Pick<RecorderRuntimeState, "recordingTrack">,
-  ): void {
-    this.store.update(update);
-    this.syncTakePlayback(update.recordingTrack.regions);
   }
 
   private updatePendingRecording(

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -230,9 +230,6 @@ export class RecorderRuntime {
       ensurePitchShifterWorklet(this.context),
       ensureBiquadEqWorklet(this.context),
     ]);
-    // Create the recording playback eagerly because startInput routes the
-    // capture input into its channel.
-    this.getTrackPlayback(RECORDING_TRACK_ID);
   }
 
   async startInput({
@@ -930,14 +927,10 @@ export class RecorderRuntime {
       throw new Error("Cannot load a project while recording.");
     }
     this.pause();
-    // Keep the recording playback because the open capture input is routed
-    // into its channel.
-    for (const [id, playback] of this.trackPlaybacks) {
-      if (id !== RECORDING_TRACK_ID) {
-        playback.dispose();
-        this.trackPlaybacks.delete(id);
-      }
+    for (const playback of this.trackPlaybacks.values()) {
+      playback.dispose();
     }
+    this.trackPlaybacks.clear();
     const audioTracks = project.audioTracks.map((track) =>
       resolveTrackRegions(track),
     );
@@ -969,7 +962,11 @@ export class RecorderRuntime {
       recordingTrack,
     });
     this.syncTrackPlayback(recordingTrack);
-    this.getTrackPlayback(RECORDING_TRACK_ID).channel.setEq(recordingTrack.eq);
+    // The recording playback was recreated above, so point the open input at
+    // its new channel.
+    this.captureInput?.setMonitorOutput(
+      this.getTrackPlayback(RECORDING_TRACK_ID).channel.input,
+    );
     this.syncYouTubePlayer();
     this.transport.seek(0);
     this.metronome.setTempo(project.tempo);


### PR DESCRIPTION
- related to https://github.com/hi-ogawa/toy-midi/issues/464

The runtime kept the recording track's playback in a separate `captureTrack` field next to the `audioTracks` map, and exposed paired setters for mix, height, and EQ, one per track kind, plus take-only mute and solo on a separate update path. The recording track already shares `AudioTrackState`, so the only thing preventing one map and one API was a stable id to key them by.

This PR gives the recording track a fixed id and moves its playback into a single `trackPlaybacks` map. One `getTrackPlayback` lazily creates entries for any track, one `syncTrackPlayback` replaces the take and audio track variants, and `deriveTrackMix` returns gains keyed by track id so mix sync and export no longer split by position. Playback sync helpers no longer pause and resume on their own, so the one caller that relied on that, audio import, does it explicitly.

On top of that, `setTrackMix`, `setTrackHeight`, and `setTrackEq` replace the per-kind pairs, backed by a private `updateTrack` that writes to whichever state field owns the id. Clip mute and solo become `setClipMuted` and `setClipSoloed` and share the same `updateClip` path as `trimClip`. The UI passes `state.recordingTrack.id` where it used to call the recording-specific variants. The height clamp is the one place that still checks for the recording track, since the Capture row needs more room for its controls.

The one thing that made the recording playback non-ephemeral was `CaptureInput` wiring its monitor gain into a channel at device-open time with no way to change it. `CaptureInput` gains `setMonitorOutput` so the runtime can re-point monitoring without reopening the device. Project load then disposes every playback uniformly and points the open input at the recreated recording channel, and the same call is what arming a different track will need later.

The recording track's state still lives in `recordingTrack`. Moving it into `audioTracks` with an armed track id stays in https://github.com/hi-ogawa/toy-midi/pull/503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbHG7BkMV3VyQCDGy7i3bt
