### PR TITLE
refactor: address recorder tracks and clips by id

### DIFF
--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -369,17 +369,15 @@ export function Recorder({ projectId }: { projectId: string }) {
                 soloed={track.soloed}
                 effectsOpen={effects.openEffects.has(track.id)}
                 onEffectsToggle={() => effects.toggleEffects(track.id)}
-                onGainChange={(gain) =>
-                  runtime.setAudioTrackMix(track.id, { gain })
-                }
+                onGainChange={(gain) => runtime.setTrackMix(track.id, { gain })}
                 onMutedChange={(muted) =>
-                  runtime.setAudioTrackMix(track.id, { muted })
+                  runtime.setTrackMix(track.id, { muted })
                 }
                 onSoloedChange={(soloed) =>
-                  runtime.setAudioTrackMix(track.id, { soloed })
+                  runtime.setTrackMix(track.id, { soloed })
                 }
                 onHeightChange={(height) =>
-                  runtime.setAudioTrackHeight(track.id, height)
+                  runtime.setTrackHeight(track.id, height)
                 }
                 action={
                   <AudioTrackActions
@@ -451,18 +449,22 @@ export function Recorder({ projectId }: { projectId: string }) {
               soloed={state.recordingTrack.soloed}
               effectsOpen={effects.openEffects.has("capture")}
               onEffectsToggle={() => effects.toggleEffects("capture")}
-              onGainChange={(gain) => runtime.setRecordingTrackMix({ gain })}
+              onGainChange={(gain) =>
+                runtime.setTrackMix(state.recordingTrack.id, { gain })
+              }
               onInputSetup={() => setIsInputSetupOpen(true)}
               onInputMonitoringChange={(monitoring) =>
                 runtime.setInputMonitoring(monitoring)
               }
               onInputToggle={input.toggle}
-              onMutedChange={(muted) => runtime.setRecordingTrackMix({ muted })}
+              onMutedChange={(muted) =>
+                runtime.setTrackMix(state.recordingTrack.id, { muted })
+              }
               onSoloedChange={(soloed) =>
-                runtime.setRecordingTrackMix({ soloed })
+                runtime.setTrackMix(state.recordingTrack.id, { soloed })
               }
               onHeightChange={(height) =>
-                runtime.setRecordingTrackHeight(height)
+                runtime.setTrackHeight(state.recordingTrack.id, height)
               }
             >
               <TakeTimelineLane
@@ -517,10 +519,10 @@ export function Recorder({ projectId }: { projectId: string }) {
                   muted={take.muted}
                   soloed={take.soloed}
                   onMutedChange={(muted) =>
-                    runtime.setTakeMuted(take.id, muted)
+                    runtime.setClipMuted({ id: take.id, muted })
                   }
                   onSoloedChange={(soloed) =>
-                    runtime.setTakeSoloed(take.id, soloed)
+                    runtime.setClipSoloed({ id: take.id, soloed })
                   }
                   onDelete={() =>
                     runtime.removeClips([{ type: "clip", id: take.id }])
@@ -633,9 +635,7 @@ export function Recorder({ projectId }: { projectId: string }) {
                     key={track.id}
                     label={`Audio ${index + 1}`}
                     eq={track.eq}
-                    onChange={(eq) =>
-                      runtime.setAudioTrackEq({ id: track.id, eq })
-                    }
+                    onChange={(eq) => runtime.setTrackEq({ id: track.id, eq })}
                     onClose={() => effects.closeEffects(track.id)}
                   />
                 ),
@@ -644,7 +644,9 @@ export function Recorder({ projectId }: { projectId: string }) {
               <RecorderEffects
                 label="Capture"
                 eq={state.recordingTrack.eq}
-                onChange={(update) => runtime.setRecordingTrackEq(update)}
+                onChange={(eq) =>
+                  runtime.setTrackEq({ id: state.recordingTrack.id, eq })
+                }
                 onClose={() => effects.closeEffects("capture")}
               />
             )}

--- a/src/components/recorder/recorder-mixer.tsx
+++ b/src/components/recorder/recorder-mixer.tsx
@@ -49,13 +49,9 @@ export function RecorderMixer({
           gain={track.gain}
           muted={track.muted}
           soloed={track.soloed}
-          onGainChange={(gain) => runtime.setAudioTrackMix(track.id, { gain })}
-          onMutedChange={(muted) =>
-            runtime.setAudioTrackMix(track.id, { muted })
-          }
-          onSoloedChange={(soloed) =>
-            runtime.setAudioTrackMix(track.id, { soloed })
-          }
+          onGainChange={(gain) => runtime.setTrackMix(track.id, { gain })}
+          onMutedChange={(muted) => runtime.setTrackMix(track.id, { muted })}
+          onSoloedChange={(soloed) => runtime.setTrackMix(track.id, { soloed })}
         />
       ))}
       <RecorderTrackChannel
@@ -66,9 +62,15 @@ export function RecorderMixer({
         muted={state.recordingTrack.muted}
         soloed={state.recordingTrack.soloed}
         icon={<Mic2Icon className="size-4 text-muted-foreground" />}
-        onGainChange={(gain) => runtime.setRecordingTrackMix({ gain })}
-        onMutedChange={(muted) => runtime.setRecordingTrackMix({ muted })}
-        onSoloedChange={(soloed) => runtime.setRecordingTrackMix({ soloed })}
+        onGainChange={(gain) =>
+          runtime.setTrackMix(state.recordingTrack.id, { gain })
+        }
+        onMutedChange={(muted) =>
+          runtime.setTrackMix(state.recordingTrack.id, { muted })
+        }
+        onSoloedChange={(soloed) =>
+          runtime.setTrackMix(state.recordingTrack.id, { soloed })
+        }
       />
       <MixerChannel
         icon={<MetronomeIcon className="size-4 text-muted-foreground" />}

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -323,7 +323,7 @@ export class RecorderRuntime {
     if (!this.store.get().audioTracks.some((track) => track.id === id)) {
       return;
     }
-    const track = this.updateAudioTrack(id, (track) => ({
+    const track = this.updateTrack(id, (track) => ({
       ...track,
       clips: [
         createAudioClip({
@@ -342,13 +342,11 @@ export class RecorderRuntime {
     }
   }
 
-  setAudioTrackMix(
+  setTrackMix(
     id: string,
     update: Partial<Pick<AudioTrackState, "gain" | "muted" | "soloed">>,
   ): void {
-    this.updateAudioTrack(id, (track) => {
-      return { ...track, ...update };
-    });
+    this.updateTrack(id, (track) => ({ ...track, ...update }));
     this.syncTrackMix();
   }
 
@@ -408,42 +406,43 @@ export class RecorderRuntime {
   }
 
   trimClip({ id, edge, value }: RecorderClipTrim): void {
+    this.updateClip(id, (clip) => ({
+      ...clip,
+      ...(edge === "start"
+        ? { trimStart: clamp(value, 0, clip.trimEnd - MIN_TAKE_DURATION) }
+        : {
+            trimEnd: clamp(
+              value,
+              clip.trimStart + MIN_TAKE_DURATION,
+              clip.duration,
+            ),
+          }),
+    }));
+  }
+
+  setClipMuted({ id, muted }: { id: string; muted: boolean }): void {
+    this.updateClip(id, (clip) => ({ ...clip, muted }));
+  }
+
+  setClipSoloed({ id, soloed }: { id: string; soloed: boolean }): void {
+    this.updateClip(id, (clip) => ({ ...clip, soloed }));
+  }
+
+  private updateClip(id: string, update: (clip: AudioClip) => AudioClip): void {
     const state = this.store.get();
     const wasPlaying = state.isPlaying;
     if (wasPlaying) {
       this.pause();
     }
-    const clipIds = new Set([id]);
-    function trimTrackClips(track: AudioTrackState): AudioTrackState {
+    function updateClips(track: AudioTrackState): AudioTrackState {
       return updateTrackClips({
         track,
         update: (clips) =>
-          clips.map((clip) =>
-            clipIds.has(clip.id)
-              ? {
-                  ...clip,
-                  ...(edge === "start"
-                    ? {
-                        trimStart: clamp(
-                          value,
-                          0,
-                          clip.trimEnd - MIN_TAKE_DURATION,
-                        ),
-                      }
-                    : {
-                        trimEnd: clamp(
-                          value,
-                          clip.trimStart + MIN_TAKE_DURATION,
-                          clip.duration,
-                        ),
-                      }),
-                }
-              : clip,
-          ),
+          clips.map((clip) => (clip.id === id ? update(clip) : clip)),
       });
     }
-    const audioTracks = state.audioTracks.map((track) => trimTrackClips(track));
-    const recordingTrack = trimTrackClips(state.recordingTrack);
+    const audioTracks = state.audioTracks.map((track) => updateClips(track));
+    const recordingTrack = updateClips(state.recordingTrack);
     this.store.update({ recordingTrack, audioTracks });
     if (recordingTrack !== state.recordingTrack) {
       this.syncTrackPlayback(recordingTrack);
@@ -499,10 +498,14 @@ export class RecorderRuntime {
     }
   }
 
-  setAudioTrackHeight(id: string, height: number): void {
-    this.updateAudioTrack(id, (track) => ({
+  setTrackHeight(id: string, height: number): void {
+    this.updateTrack(id, (track) => ({
       ...track,
-      height: clampTrackHeight(height),
+      // The Capture row carries input controls and needs more room.
+      height:
+        id === RECORDING_TRACK_ID
+          ? clampRecordingTrackHeight(height)
+          : clampTrackHeight(height),
     }));
   }
 
@@ -520,38 +523,32 @@ export class RecorderRuntime {
     this.syncTrackMix();
   }
 
-  setAudioTrackEq({ id, eq }: { id: string; eq: MultibandEqParameters }): void {
-    const track = this.updateAudioTrack(id, (track) => ({
-      ...track,
-      eq,
-    }));
-    this.trackPlaybacks.get(id)?.channel.setEq(track.eq);
+  setTrackEq({ id, eq }: { id: string; eq: MultibandEqParameters }): void {
+    this.updateTrack(id, (track) => ({ ...track, eq }));
+    this.trackPlaybacks.get(id)?.channel.setEq(eq);
   }
 
-  setRecordingTrackEq(eq: MultibandEqParameters): void {
-    const track = this.store.get().recordingTrack;
-    this.store.update({
-      recordingTrack: {
-        ...track,
-        eq,
-      },
-    });
-    this.trackPlaybacks.get(RECORDING_TRACK_ID)?.channel.setEq(eq);
-  }
-
-  private updateAudioTrack(
+  private updateTrack(
     id: string,
     update: (track: AudioTrackState) => AudioTrackState,
   ): AudioTrackState {
-    const audioTracks = this.store.get().audioTracks.slice();
+    const apply = (track: AudioTrackState): AudioTrackState => {
+      const next = update(track);
+      return next.clips === track.clips ? next : resolveTrackRegions(next);
+    };
+    const state = this.store.get();
+    if (id === RECORDING_TRACK_ID) {
+      const recordingTrack = apply(state.recordingTrack);
+      this.store.update({ recordingTrack });
+      return recordingTrack;
+    }
+    const audioTracks = state.audioTracks.slice();
     const index = audioTracks.findIndex((track) => track.id === id);
     const track = audioTracks[index];
     if (!track) {
       throw new Error("Audio track state is missing.");
     }
-    const next = update(track);
-    audioTracks[index] =
-      next.clips === track.clips ? next : resolveTrackRegions(next);
+    audioTracks[index] = apply(track);
     this.store.update({ audioTracks });
     return audioTracks[index]!;
   }
@@ -580,64 +577,6 @@ export class RecorderRuntime {
 
   private syncTrackPlayback(track: AudioTrackState): void {
     this.getTrackPlayback(track.id).setSources(getClipSources(track.regions));
-  }
-
-  setRecordingTrackMix(
-    update: Partial<Pick<AudioTrackState, "gain" | "muted" | "soloed">>,
-  ): void {
-    const recordingTrack = { ...this.store.get().recordingTrack, ...update };
-    this.store.update({ recordingTrack });
-    this.syncTrackMix();
-  }
-
-  setRecordingTrackHeight(height: number): void {
-    this.store.update({
-      recordingTrack: {
-        ...this.store.get().recordingTrack,
-        height: clampRecordingTrackHeight(height),
-      },
-    });
-  }
-
-  setTakeMuted(id: string, muted: boolean): void {
-    this.updateTake(id, (take) => ({ ...take, muted }));
-  }
-
-  setTakeSoloed(id: string, soloed: boolean): void {
-    this.updateTake(id, (take) => ({ ...take, soloed }));
-  }
-
-  private updateTake(
-    id: string,
-    updateFn: (take: AudioClip) => AudioClip,
-  ): void {
-    this.updateTakes((takes) => {
-      const index = takes.findIndex((take) => take.id === id);
-      const take = takes[index];
-      if (!take) {
-        throw new Error("Recording take state is missing.");
-      }
-      const nextTakes = takes.slice();
-      nextTakes[index] = updateFn(take);
-      return nextTakes;
-    });
-  }
-
-  private updateTakes(updateFn: (takes: AudioClip[]) => AudioClip[]): void {
-    const wasPlaying = this.store.get().isPlaying;
-    if (wasPlaying) {
-      this.pause();
-    }
-    const previousTrack = this.store.get().recordingTrack;
-    const recordingTrack = resolveTrackRegions({
-      ...previousTrack,
-      clips: updateFn(previousTrack.clips),
-    });
-    this.store.update({ recordingTrack });
-    this.syncTrackPlayback(recordingTrack);
-    if (wasPlaying) {
-      this.transport.play();
-    }
   }
 
   async play(): Promise<void> {


### PR DESCRIPTION
- related to https://github.com/hi-ogawa/toy-midi/issues/464
- stacked on https://github.com/hi-ogawa/toy-midi/pull/512

With the recording track sharing `AudioTrackState` and the playback map, the runtime still exposed paired setters for mix, height, and EQ, one per track kind, plus take-only mute and solo that walked a separate update path through `updateTake` and `updateTakes`.

This PR collapses each pair into one method keyed by track id: `setTrackMix`, `setTrackHeight`, and `setTrackEq`, backed by a private `updateTrack` that writes to whichever state field owns the id. Clip mute and solo become `setClipMuted` and `setClipSoloed` and share the same `updateClip` path as `trimClip`, so all three are a per-clip transform over the same publish and sync sequence. The UI passes `state.recordingTrack.id` where it used to call the recording-specific variants. The height clamp is the one place that still checks for the recording track, since the Capture row needs more room for its controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbHG7BkMV3VyQCDGy7i3bt
