### PR TITLE
fix: allocate a free port for Playwright

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,18 +1,25 @@
+import net from "node:net";
 import type { TracePackReporterOptions } from "@hiogawa/playwright-trace-pack/reporter";
 import { defineConfig, devices } from "@playwright/test";
+
+// Resolve the port once and share it with Playwright workers.
+const port = process.env.E2E_PORT
+  ? Number(process.env.E2E_PORT)
+  : await getFreePort(5183);
+process.env.E2E_PORT = String(port);
 
 export default defineConfig({
   testDir: "./e2e",
   webServer: {
-    command: "pnpm dev --port 5183",
-    url: "http://localhost:5183",
+    command: `pnpm dev --port ${port} --strictPort`,
+    url: `http://localhost:${port}`,
     reuseExistingServer: false,
     env: {
       VITE_AUTO_SAVE_DEBOUNCE_MS: "50",
     },
   },
   use: {
-    baseURL: "http://localhost:5183",
+    baseURL: `http://localhost:${port}`,
     trace:
       process.env.E2E_TRACE === "1"
         ? { mode: "on", screenshots: false }
@@ -61,3 +68,26 @@ export default defineConfig({
     },
   ],
 });
+
+function getFreePort(preferred: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", (error: NodeJS.ErrnoException) => {
+      if (error.code === "EADDRINUSE" && preferred !== 0) {
+        resolve(getFreePort(0));
+      } else {
+        reject(error);
+      }
+    });
+    server.listen(preferred, () => {
+      const port = (server.address() as net.AddressInfo).port;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(port);
+        }
+      });
+    });
+  });
+}


### PR DESCRIPTION
Playwright currently uses a fixed port, so E2E runs in separate worktrees can collide.

This PR keeps 5183 as the preferred port and falls back to an OS-assigned free port when it is occupied. The selected port is shared with workers through `E2E_PORT`, which also supports an explicit override. Vite uses `--strictPort` so it fails clearly if the selected port is taken before startup.
