### PR TITLE
test: group common e2e helpers into boxed steps

### DIFF
--- a/e2e/fake-audio/recorder-helpers.ts
+++ b/e2e/fake-audio/recorder-helpers.ts
@@ -35,10 +35,16 @@ export async function addRecorderAudio(
 }
 
 export async function seekRecorderByPixels(page: Page, pixels: number) {
-  const ruler = page.getByTestId("recorder-timeline-ruler");
-  const box = await ruler.boundingBox();
-  expect(box).not.toBeNull();
-  await page.mouse.click(box!.x + pixels, box!.y + box!.height / 2);
+  await test.step(
+    `Seek recorder to ${pixels}px`,
+    async () => {
+      const ruler = page.getByTestId("recorder-timeline-ruler");
+      const box = await ruler.boundingBox();
+      expect(box).not.toBeNull();
+      await page.mouse.click(box!.x + pixels, box!.y + box!.height / 2);
+    },
+    { box: true },
+  );
 }
 
 export async function getRecorderPosition(page: Page): Promise<number> {
@@ -62,15 +68,25 @@ export async function dragBy(
     anchorXOffset,
   }: { deltaY?: number; anchorXOffset?: number } = {},
 ) {
-  const box = await locator.boundingBox();
-  expect(box).not.toBeNull();
-  const startX = box!.x + (anchorXOffset ?? box!.width / 2);
-  await page.mouse.move(startX, box!.y + box!.height / 2);
-  await page.mouse.down();
-  await page.mouse.move(startX + deltaX, box!.y + box!.height / 2 + deltaY, {
-    steps: 4,
-  });
-  await page.mouse.up();
+  await test.step(
+    `Drag by ${deltaX}px, ${deltaY}px`,
+    async () => {
+      const box = await locator.boundingBox();
+      expect(box).not.toBeNull();
+      const startX = box!.x + (anchorXOffset ?? box!.width / 2);
+      await page.mouse.move(startX, box!.y + box!.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(
+        startX + deltaX,
+        box!.y + box!.height / 2 + deltaY,
+        {
+          steps: 4,
+        },
+      );
+      await page.mouse.up();
+    },
+    { box: true },
+  );
 }
 
 export async function waitForRecordingSamples(recording: Locator) {

--- a/e2e/fake-audio/recorder-helpers.ts
+++ b/e2e/fake-audio/recorder-helpers.ts
@@ -2,28 +2,36 @@ import { expect, type Locator, type Page, test } from "@playwright/test";
 
 /** Create a recorder project from its index and wait for the recorder app. */
 export async function createRecorderProject(page: Page): Promise<void> {
-  await test.step("Create recorder project", async () => {
-    await page.goto("/");
-    await page.getByRole("tab", { name: "Recorder", exact: true }).click();
-    await page.getByTestId("new-recorder-project-button").click();
-    await expect(page).toHaveURL(/\/recorder\/[^/]+$/);
-    await expect(page.getByTestId("recorder-project-name")).toBeVisible();
-  });
+  await test.step(
+    "Create recorder project",
+    async () => {
+      await page.goto("/");
+      await page.getByRole("tab", { name: "Recorder", exact: true }).click();
+      await page.getByTestId("new-recorder-project-button").click();
+      await expect(page).toHaveURL(/\/recorder\/[^/]+$/);
+      await expect(page.getByTestId("recorder-project-name")).toBeVisible();
+    },
+    { box: true },
+  );
 }
 
 export async function addRecorderAudio(
   page: Page,
   filePath: string,
 ): Promise<void> {
-  await test.step("Add recorder audio", async () => {
-    const clips = page.getByTestId("recorder-clip-audio");
-    const count = await clips.count();
-    const fileChooser = page.waitForEvent("filechooser");
-    await page.getByTestId("recorder-add-audio-file").click();
-    await (await fileChooser).setFiles(filePath);
-    await expect(clips).toHaveCount(count + 1);
-    await expect(clips.nth(count).locator("svg")).toBeVisible();
-  });
+  await test.step(
+    "Add recorder audio",
+    async () => {
+      const clips = page.getByTestId("recorder-clip-audio");
+      const count = await clips.count();
+      const fileChooser = page.waitForEvent("filechooser");
+      await page.getByTestId("recorder-add-audio-file").click();
+      await (await fileChooser).setFiles(filePath);
+      await expect(clips).toHaveCount(count + 1);
+      await expect(clips.nth(count).locator("svg")).toBeVisible();
+    },
+    { box: true },
+  );
 }
 
 export async function seekRecorderByPixels(page: Page, pixels: number) {
@@ -77,35 +85,39 @@ export async function waitForRecordingSamples(recording: Locator) {
 }
 
 export async function enableInput(page: Page) {
-  await test.step("Enable audio input", async () => {
-    // Fake audio still exercises permission, device discovery, and channel setup.
-    const inputSetupButton = page.getByRole("button", {
-      name: "Configure audio input",
-    });
-    await expect(page.getByTestId("recorder-input-toggle")).toHaveAttribute(
-      "aria-pressed",
-      "false",
-    );
-    await inputSetupButton.click();
-    await expect(
-      page.getByRole("heading", { name: "Audio Input Setup" }),
-    ).toBeVisible();
-    const setup = page.getByTestId("recorder-input-setup");
-    await setup.getByRole("button", { name: "Enable input" }).click();
-    await expect(
-      setup.getByRole("button", { name: "Disable input" }),
-    ).toBeVisible();
-    await expect(page.getByLabel("Device")).toContainText(
-      "Fake Default Audio Input",
-    );
-    await expect(page.getByLabel("Channel")).toContainText("Channel 1");
-    await page.getByRole("button", { name: "Close" }).click();
-    await expect(
-      page.getByText("Fake Default Audio Input · Channel 1"),
-    ).toBeVisible();
-    await expect(page.getByTestId("recorder-input-toggle")).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
-  });
+  await test.step(
+    "Enable audio input",
+    async () => {
+      // Fake audio still exercises permission, device discovery, and channel setup.
+      const inputSetupButton = page.getByRole("button", {
+        name: "Configure audio input",
+      });
+      await expect(page.getByTestId("recorder-input-toggle")).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+      await inputSetupButton.click();
+      await expect(
+        page.getByRole("heading", { name: "Audio Input Setup" }),
+      ).toBeVisible();
+      const setup = page.getByTestId("recorder-input-setup");
+      await setup.getByRole("button", { name: "Enable input" }).click();
+      await expect(
+        setup.getByRole("button", { name: "Disable input" }),
+      ).toBeVisible();
+      await expect(page.getByLabel("Device")).toContainText(
+        "Fake Default Audio Input",
+      );
+      await expect(page.getByLabel("Channel")).toContainText("Channel 1");
+      await page.getByRole("button", { name: "Close" }).click();
+      await expect(
+        page.getByText("Fake Default Audio Input · Channel 1"),
+      ).toBeVisible();
+      await expect(page.getByTestId("recorder-input-toggle")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    },
+    { box: true },
+  );
 }

--- a/e2e/fake-audio/recorder-helpers.ts
+++ b/e2e/fake-audio/recorder-helpers.ts
@@ -1,25 +1,29 @@
-import { expect, type Locator, type Page } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 
 /** Create a recorder project from its index and wait for the recorder app. */
 export async function createRecorderProject(page: Page): Promise<void> {
-  await page.goto("/");
-  await page.getByRole("tab", { name: "Recorder", exact: true }).click();
-  await page.getByTestId("new-recorder-project-button").click();
-  await expect(page).toHaveURL(/\/recorder\/[^/]+$/);
-  await expect(page.getByTestId("recorder-project-name")).toBeVisible();
+  await test.step("Create recorder project", async () => {
+    await page.goto("/");
+    await page.getByRole("tab", { name: "Recorder", exact: true }).click();
+    await page.getByTestId("new-recorder-project-button").click();
+    await expect(page).toHaveURL(/\/recorder\/[^/]+$/);
+    await expect(page.getByTestId("recorder-project-name")).toBeVisible();
+  });
 }
 
 export async function addRecorderAudio(
   page: Page,
   filePath: string,
 ): Promise<void> {
-  const clips = page.getByTestId("recorder-clip-audio");
-  const count = await clips.count();
-  const fileChooser = page.waitForEvent("filechooser");
-  await page.getByTestId("recorder-add-audio-file").click();
-  await (await fileChooser).setFiles(filePath);
-  await expect(clips).toHaveCount(count + 1);
-  await expect(clips.nth(count).locator("svg")).toBeVisible();
+  await test.step("Add recorder audio", async () => {
+    const clips = page.getByTestId("recorder-clip-audio");
+    const count = await clips.count();
+    const fileChooser = page.waitForEvent("filechooser");
+    await page.getByTestId("recorder-add-audio-file").click();
+    await (await fileChooser).setFiles(filePath);
+    await expect(clips).toHaveCount(count + 1);
+    await expect(clips.nth(count).locator("svg")).toBeVisible();
+  });
 }
 
 export async function seekRecorderByPixels(page: Page, pixels: number) {
@@ -73,33 +77,35 @@ export async function waitForRecordingSamples(recording: Locator) {
 }
 
 export async function enableInput(page: Page) {
-  // Fake audio still exercises permission, device discovery, and channel setup.
-  const inputSetupButton = page.getByRole("button", {
-    name: "Configure audio input",
+  await test.step("Enable audio input", async () => {
+    // Fake audio still exercises permission, device discovery, and channel setup.
+    const inputSetupButton = page.getByRole("button", {
+      name: "Configure audio input",
+    });
+    await expect(page.getByTestId("recorder-input-toggle")).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    await inputSetupButton.click();
+    await expect(
+      page.getByRole("heading", { name: "Audio Input Setup" }),
+    ).toBeVisible();
+    const setup = page.getByTestId("recorder-input-setup");
+    await setup.getByRole("button", { name: "Enable input" }).click();
+    await expect(
+      setup.getByRole("button", { name: "Disable input" }),
+    ).toBeVisible();
+    await expect(page.getByLabel("Device")).toContainText(
+      "Fake Default Audio Input",
+    );
+    await expect(page.getByLabel("Channel")).toContainText("Channel 1");
+    await page.getByRole("button", { name: "Close" }).click();
+    await expect(
+      page.getByText("Fake Default Audio Input · Channel 1"),
+    ).toBeVisible();
+    await expect(page.getByTestId("recorder-input-toggle")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
   });
-  await expect(page.getByTestId("recorder-input-toggle")).toHaveAttribute(
-    "aria-pressed",
-    "false",
-  );
-  await inputSetupButton.click();
-  await expect(
-    page.getByRole("heading", { name: "Audio Input Setup" }),
-  ).toBeVisible();
-  const setup = page.getByTestId("recorder-input-setup");
-  await setup.getByRole("button", { name: "Enable input" }).click();
-  await expect(
-    setup.getByRole("button", { name: "Disable input" }),
-  ).toBeVisible();
-  await expect(page.getByLabel("Device")).toContainText(
-    "Fake Default Audio Input",
-  );
-  await expect(page.getByLabel("Channel")).toContainText("Channel 1");
-  await page.getByRole("button", { name: "Close" }).click();
-  await expect(
-    page.getByText("Fake Default Audio Input · Channel 1"),
-  ).toBeVisible();
-  await expect(page.getByTestId("recorder-input-toggle")).toHaveAttribute(
-    "aria-pressed",
-    "true",
-  );
 }

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import type { useProjectStore } from "../src/lib/project-store";
 
 /** Log elapsed checkpoints while investigating E2E timing. */
@@ -44,26 +44,32 @@ export async function loadAudioFile(
   fileName = "test-audio.wav",
   fixtureName = "test-audio.wav",
 ): Promise<void> {
-  // Open settings dialog
-  await page.getByTestId("settings-button").click();
+  await test.step(`Load audio: ${fileName}`, async () => {
+    // Open settings dialog
+    await page.getByTestId("settings-button").click();
 
-  // Find audio file input within settings dialog
-  const fileInput = page.getByTestId("audio-file-input");
-  const fs = await import("fs/promises");
-  const path = await import("path");
-  const testAudioPath = path.join(import.meta.dirname, "fixtures", fixtureName);
-  await fileInput.setInputFiles({
-    name: fileName,
-    mimeType: "audio/wav",
-    buffer: await fs.readFile(testAudioPath),
+    // Find audio file input within settings dialog
+    const fileInput = page.getByTestId("audio-file-input");
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    const testAudioPath = path.join(
+      import.meta.dirname,
+      "fixtures",
+      fixtureName,
+    );
+    await fileInput.setInputFiles({
+      name: fileName,
+      mimeType: "audio/wav",
+      buffer: await fs.readFile(testAudioPath),
+    });
+    await expect(
+      page.getByTestId("settings-dialog").getByText(fileName, { exact: true }),
+    ).toBeVisible();
+
+    // Close settings dialog
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("settings-dialog")).toBeHidden();
   });
-  await expect(
-    page.getByTestId("settings-dialog").getByText(fileName, { exact: true }),
-  ).toBeVisible();
-
-  // Close settings dialog
-  await page.keyboard.press("Escape");
-  await expect(page.getByTestId("settings-dialog")).toBeHidden();
 }
 
 /**

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -44,32 +44,38 @@ export async function loadAudioFile(
   fileName = "test-audio.wav",
   fixtureName = "test-audio.wav",
 ): Promise<void> {
-  await test.step(`Load audio: ${fileName}`, async () => {
-    // Open settings dialog
-    await page.getByTestId("settings-button").click();
+  await test.step(
+    `Load audio: ${fileName}`,
+    async () => {
+      // Open settings dialog
+      await page.getByTestId("settings-button").click();
 
-    // Find audio file input within settings dialog
-    const fileInput = page.getByTestId("audio-file-input");
-    const fs = await import("fs/promises");
-    const path = await import("path");
-    const testAudioPath = path.join(
-      import.meta.dirname,
-      "fixtures",
-      fixtureName,
-    );
-    await fileInput.setInputFiles({
-      name: fileName,
-      mimeType: "audio/wav",
-      buffer: await fs.readFile(testAudioPath),
-    });
-    await expect(
-      page.getByTestId("settings-dialog").getByText(fileName, { exact: true }),
-    ).toBeVisible();
+      // Find audio file input within settings dialog
+      const fileInput = page.getByTestId("audio-file-input");
+      const fs = await import("fs/promises");
+      const path = await import("path");
+      const testAudioPath = path.join(
+        import.meta.dirname,
+        "fixtures",
+        fixtureName,
+      );
+      await fileInput.setInputFiles({
+        name: fileName,
+        mimeType: "audio/wav",
+        buffer: await fs.readFile(testAudioPath),
+      });
+      await expect(
+        page
+          .getByTestId("settings-dialog")
+          .getByText(fileName, { exact: true }),
+      ).toBeVisible();
 
-    // Close settings dialog
-    await page.keyboard.press("Escape");
-    await expect(page.getByTestId("settings-dialog")).toBeHidden();
-  });
+      // Close settings dialog
+      await page.keyboard.press("Escape");
+      await expect(page.getByTestId("settings-dialog")).toBeHidden();
+    },
+    { box: true },
+  );
 }
 
 /**


### PR DESCRIPTION
Frequently used E2E helpers expand into several low-level actions, which makes traces harder to scan.

This PR wraps audio loading, recorder project creation, recorder audio upload, input setup, seeking, and dragging in named, boxed `test.step()` calls. Their actions appear together in the trace, and selecting a helper step shows its call in the test. Failures also point to the helper call site, while child actions remain available for inspection.
