### PR TITLE
refactor: unify recorder track ownership behind an armed track id

### DIFF
--- a/e2e/fake-audio/recorder-archive.test.ts
+++ b/e2e/fake-audio/recorder-archive.test.ts
@@ -1,4 +1,7 @@
+import { readFile } from "node:fs/promises";
 import { expect, type Page, test } from "@playwright/test";
+import type { SerializedRecorderRuntimeState } from "../../src/lib/recorder/persistence";
+import { exportRecorderProjectArchive } from "../../src/lib/recorder/project-archive";
 import { DEFAULT_PIXELS_PER_BEAT } from "../../src/lib/timeline";
 import {
   addRecorderAudio,
@@ -79,3 +82,73 @@ async function getRecorderClipGeometry(page: Page) {
   );
   return geometry;
 }
+
+test("imports a legacy recorder archive", async ({ page }) => {
+  // Export a typed legacy project using the archive writer.
+  const bytes = await readFile("e2e/fixtures/test-tones.pcm");
+  const pcm = new Float32Array(Uint8Array.from(bytes).buffer);
+  const project: SerializedRecorderRuntimeState = {
+    title: "Legacy archive",
+    tempo: 120,
+    timeSignature: { numerator: 4, denominator: 4 },
+    latencyCompensation: 0,
+    audioTracks: [
+      {
+        id: "backing",
+        height: 72,
+        gain: 0.5,
+        muted: false,
+        soloed: false,
+        timelineOffset: 2,
+        trimStart: 0.5,
+        trimEnd: 3,
+        clip: {
+          name: "stereo.wav",
+          pcm: { sampleRate: 22050, channels: [pcm, pcm] },
+        },
+      },
+    ],
+    recordingTrack: {
+      height: 116,
+      gain: 0.8,
+      muted: false,
+      soloed: false,
+      nextTakeNumber: 9,
+      takes: [
+        {
+          id: "retained",
+          number: 8,
+          timelineOffset: 3,
+          trimStart: 0.25,
+          trimEnd: 2,
+          pcm: { sampleRate: 22050, channels: [pcm] },
+        },
+      ],
+    },
+  };
+  const archive = await exportRecorderProjectArchive(project);
+
+  // Import through the Recorder project list and open the migrated recorder.
+  await page.goto("/");
+  await page.getByRole("tab", { name: "Recorder", exact: true }).click();
+  const chooserPromise = page.waitForEvent("filechooser");
+  await page.getByTestId("import-recorder-project").click();
+  await (
+    await chooserPromise
+  ).setFiles({
+    name: "legacy.toymidi.zip",
+    mimeType: "application/zip",
+    buffer: Buffer.from(await archive.arrayBuffer()),
+  });
+  await expect(page.getByTestId("recorder-project-name")).toHaveText(
+    "Legacy archive",
+  );
+
+  // Verify legacy backing audio and the retained take appear with decoded waveforms.
+  const audio = page.getByTestId("recorder-clip-audio");
+  const take = page.getByTestId("recorder-clip-comp");
+  await expect(audio).toContainText("stereo.wav");
+  await expect(take).toContainText("Take 8");
+  await expect(audio.locator("svg")).toBeVisible();
+  await expect(take.locator("svg")).toBeVisible();
+});

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -127,7 +127,13 @@ export function Recorder({ projectId }: { projectId: string }) {
     },
   });
 
-  const takes = state.recordingTrack.clips;
+  const recordingTrack = state.audioTracks.find(
+    (track) => track.id === state.armedTrackId,
+  )!;
+  const audioTracks = state.audioTracks.filter(
+    (track) => track.id !== state.armedTrackId,
+  );
+  const takes = recordingTrack.clips;
   const flags = deriveRecorderFlags({
     captureStatus: state.captureStatus,
     project,
@@ -359,7 +365,7 @@ export function Recorder({ projectId }: { projectId: string }) {
                 onRemove={() => runtime.removeReferenceVideo()}
               />
             )}
-            {state.audioTracks.map((track, index) => (
+            {audioTracks.map((track, index) => (
               <TrackRow
                 key={track.id}
                 title={`Audio ${index + 1}`}
@@ -434,8 +440,8 @@ export function Recorder({ projectId }: { projectId: string }) {
             <CaptureTrackRow
               route={input.route.label}
               routeNeedsSetup={input.route.needsSetup}
-              gain={state.recordingTrack.gain}
-              height={state.recordingTrack.height}
+              gain={recordingTrack.gain}
+              height={recordingTrack.height}
               inputActive={input.active}
               inputAnalyser={runtime.captureInput?.analyser}
               inputMonitoring={state.inputMonitoring}
@@ -445,12 +451,12 @@ export function Recorder({ projectId }: { projectId: string }) {
                 flags.isRecording ||
                 (!input.active && input.route.needsSetup)
               }
-              muted={state.recordingTrack.muted}
-              soloed={state.recordingTrack.soloed}
+              muted={recordingTrack.muted}
+              soloed={recordingTrack.soloed}
               effectsOpen={effects.openEffects.has("capture")}
               onEffectsToggle={() => effects.toggleEffects("capture")}
               onGainChange={(gain) =>
-                runtime.setTrackMix(state.recordingTrack.id, { gain })
+                runtime.setTrackMix(recordingTrack.id, { gain })
               }
               onInputSetup={() => setIsInputSetupOpen(true)}
               onInputMonitoringChange={(monitoring) =>
@@ -458,20 +464,18 @@ export function Recorder({ projectId }: { projectId: string }) {
               }
               onInputToggle={input.toggle}
               onMutedChange={(muted) =>
-                runtime.setTrackMix(state.recordingTrack.id, { muted })
+                runtime.setTrackMix(recordingTrack.id, { muted })
               }
               onSoloedChange={(soloed) =>
-                runtime.setTrackMix(state.recordingTrack.id, { soloed })
+                runtime.setTrackMix(recordingTrack.id, { soloed })
               }
               onHeightChange={(height) =>
-                runtime.setTrackHeight(state.recordingTrack.id, height)
+                runtime.setTrackHeight(recordingTrack.id, height)
               }
             >
               <TakeTimelineLane
                 takes={takes}
-                regions={
-                  state.previewClipRegions ?? state.recordingTrack.regions
-                }
+                regions={state.previewClipRegions ?? recordingTrack.regions}
                 pendingRecording={state.pendingRecording}
                 captureStatus={state.captureStatus}
                 isTakeSelected={(id) =>
@@ -628,7 +632,7 @@ export function Recorder({ projectId }: { projectId: string }) {
       <div className="pointer-events-none fixed right-4 bottom-4 z-40 flex max-w-[calc(100vw-2rem)] items-end gap-4">
         {effects.openEffects.size > 0 && (
           <div className="pointer-events-auto flex min-w-0 items-end gap-4 overflow-x-auto">
-            {state.audioTracks.map(
+            {audioTracks.map(
               (track, index) =>
                 effects.openEffects.has(track.id) && (
                   <RecorderEffects
@@ -643,9 +647,9 @@ export function Recorder({ projectId }: { projectId: string }) {
             {effects.openEffects.has("capture") && (
               <RecorderEffects
                 label="Capture"
-                eq={state.recordingTrack.eq}
+                eq={recordingTrack.eq}
                 onChange={(eq) =>
-                  runtime.setTrackEq({ id: state.recordingTrack.id, eq })
+                  runtime.setTrackEq({ id: recordingTrack.id, eq })
                 }
                 onClose={() => effects.closeEffects("capture")}
               />

--- a/src/components/recorder/recorder-mixer.tsx
+++ b/src/components/recorder/recorder-mixer.tsx
@@ -22,6 +22,12 @@ export function RecorderMixer({
   openEffects: ReadonlySet<string>;
   onEffectsToggle: (id: string) => void;
 }) {
+  const recordingTrack = state.audioTracks.find(
+    (track) => track.id === state.armedTrackId,
+  )!;
+  const audioTracks = state.audioTracks.filter(
+    (track) => track.id !== state.armedTrackId,
+  );
   const masterInput = useGainInput(
     state.masterGain,
     runtime.setMasterGain.bind(runtime),
@@ -40,7 +46,7 @@ export function RecorderMixer({
         inputProps={masterInput.props}
         data-testid="recorder-mixer-master"
       />
-      {state.audioTracks.map((track, index) => (
+      {audioTracks.map((track, index) => (
         <RecorderTrackChannel
           key={track.id}
           effectsOpen={openEffects.has(track.id)}
@@ -58,18 +64,18 @@ export function RecorderMixer({
         label="Capture"
         effectsOpen={openEffects.has("capture")}
         onEffectsToggle={() => onEffectsToggle("capture")}
-        gain={state.recordingTrack.gain}
-        muted={state.recordingTrack.muted}
-        soloed={state.recordingTrack.soloed}
+        gain={recordingTrack.gain}
+        muted={recordingTrack.muted}
+        soloed={recordingTrack.soloed}
         icon={<Mic2Icon className="size-4 text-muted-foreground" />}
         onGainChange={(gain) =>
-          runtime.setTrackMix(state.recordingTrack.id, { gain })
+          runtime.setTrackMix(recordingTrack.id, { gain })
         }
         onMutedChange={(muted) =>
-          runtime.setTrackMix(state.recordingTrack.id, { muted })
+          runtime.setTrackMix(recordingTrack.id, { muted })
         }
         onSoloedChange={(soloed) =>
-          runtime.setTrackMix(state.recordingTrack.id, { soloed })
+          runtime.setTrackMix(recordingTrack.id, { soloed })
         }
       />
       <MixerChannel

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -423,8 +423,8 @@ export function TakeTimelineLane({
   onTakeTrimStart,
   onTakeTrimMove,
 }: {
-  takes: RecorderRuntimeState["recordingTrack"]["clips"];
-  regions: RecorderRuntimeState["recordingTrack"]["regions"];
+  takes: RecorderRuntimeState["audioTracks"][number]["clips"];
+  regions: RecorderRuntimeState["audioTracks"][number]["regions"];
   pendingRecording: RecorderRuntimeState["pendingRecording"];
   captureStatus: RecorderRuntimeState["captureStatus"];
   isTakeSelected: (id: string) => boolean;

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -196,13 +196,21 @@ export function CaptureTrackRow({
   onHeightChange: (height: number) => void;
   children: React.ReactNode;
 }) {
+  // The current Capture controls need more space than an ordinary track row.
+  const minimumHeight = 116;
+  height = Math.max(minimumHeight, height);
   const resizeRef = usePointerDrag({
     onStart: (event) => {
       event.preventDefault();
       return { startClientY: event.clientY, startHeight: height };
     },
     onMove: (event, drag) => {
-      onHeightChange(drag.startHeight + event.clientY - drag.startClientY);
+      onHeightChange(
+        Math.max(
+          minimumHeight,
+          drag.startHeight + event.clientY - drag.startClientY,
+        ),
+      );
     },
   });
   return (

--- a/src/components/recorder/use-recorder-clip-interaction.ts
+++ b/src/components/recorder/use-recorder-clip-interaction.ts
@@ -35,7 +35,7 @@ export function useRecorderClipInteraction({
 
   function getSelectedClips(selectedKeys: ReadonlySet<string>) {
     return {
-      clips: [...state.audioTracks, state.recordingTrack].flatMap((track) =>
+      clips: state.audioTracks.flatMap((track) =>
         track.clips.filter((clip) =>
           selectedKeys.has(getKey({ type: "clip", id: clip.id })),
         ),
@@ -48,7 +48,7 @@ export function useRecorderClipInteraction({
 
   useEffect(() => {
     const available = new Set([
-      ...[...state.audioTracks, state.recordingTrack].flatMap((track) =>
+      ...state.audioTracks.flatMap((track) =>
         track.clips.map((clip) => getKey({ type: "clip", id: clip.id })),
       ),
       ...(state.referenceVideo ? [getKey({ type: "reference" })] : []),
@@ -57,7 +57,7 @@ export function useRecorderClipInteraction({
       const next = new Set([...current].filter((key) => available.has(key)));
       return next.size === current.size ? current : next;
     });
-  }, [state.audioTracks, state.recordingTrack.clips, state.referenceVideo]);
+  }, [state.audioTracks, state.referenceVideo]);
 
   function select(clip: RecorderClipId, additive: boolean): void {
     onSelect();
@@ -147,7 +147,7 @@ export function useRecorderClipInteraction({
   }): RecorderClipTrimSnapshot {
     const selected =
       clip.type === "clip"
-        ? [...state.audioTracks, state.recordingTrack]
+        ? state.audioTracks
             .flatMap((track) => track.clips)
             .find((entry) => entry.id === clip.id)
         : undefined;

--- a/src/lib/recorder/README.md
+++ b/src/lib/recorder/README.md
@@ -1,6 +1,6 @@
 # Recorder signal flow
 
-The diagram shows how audio flows from sources through processing to recording and output.
+The diagram shows how audio flows from sources through processing to recording and output. Every audio track uses the same playback and channel structure. The shared capture input monitors through the armed track's channel, and the armed track stays fixed from the moment a recording starts until it finishes processing.
 
 ```mermaid
 flowchart LR
@@ -10,7 +10,7 @@ flowchart LR
     analyser --> monitorGain["captureInput.monitorGain"]
     monitorGain --> captureInput
 
-    subgraph captureTrack["trackPlaybacks.get(RECORDING_TRACK_ID): AudioTrackPlayback"]
+    subgraph captureTrack["trackPlaybacks.get(armedTrackId): AudioTrackPlayback"]
         takeSource["playbacks[i].source"] --> takeBusInput
         subgraph takePitchShiftBus["bus: PitchShiftBus"]
             takeBusInput["input"] --> takePitchShifter["pitchShifter (optional)"]

--- a/src/lib/recorder/mix.ts
+++ b/src/lib/recorder/mix.ts
@@ -18,10 +18,7 @@ interface RecorderMix {
 /** Snapshot committed audio at 1x, independent of transport and reference audio. */
 export function resolveRecorderMix(state: RecorderRuntimeState): RecorderMix {
   const gains = deriveTrackMix(state);
-  const tracks: RecorderMix["tracks"] = [
-    ...state.audioTracks,
-    state.recordingTrack,
-  ].map((track) => ({
+  const tracks: RecorderMix["tracks"] = state.audioTracks.map((track) => ({
     eq: track.eq,
     gain: gains.get(track.id)!,
     regions: getClipSources(track.regions),
@@ -85,15 +82,10 @@ export async function renderRecorderMix({
 /** Effective channel gain per track id after mute and solo. */
 export function deriveTrackMix({
   audioTracks,
-  recordingTrack,
-}: Pick<RecorderRuntimeState, "audioTracks" | "recordingTrack">): Map<
-  string,
-  number
-> {
-  const tracks = [...audioTracks, recordingTrack];
-  const anyTrackSoloed = tracks.some((track) => track.soloed);
+}: Pick<RecorderRuntimeState, "audioTracks">): Map<string, number> {
+  const anyTrackSoloed = audioTracks.some((track) => track.soloed);
   return new Map(
-    tracks.map((track) => [
+    audioTracks.map((track) => [
       track.id,
       track.muted || (anyTrackSoloed && !track.soloed) ? 0 : track.gain,
     ]),

--- a/src/lib/recorder/persistence.ts
+++ b/src/lib/recorder/persistence.ts
@@ -7,7 +7,6 @@ import type { EqParameters } from "../dsp/biquad-eq.ts";
 import { createAudioClip } from "./audio-clip.ts";
 import {
   type PersistableRecorderRuntimeState,
-  type RecorderRuntimeState,
   type RecorderLocator,
 } from "./runtime.ts";
 
@@ -17,19 +16,16 @@ import {
  */
 export interface SerializedRecorderRuntimeState<ChannelData = Float32Array> {
   title: string;
-  // Optional for recorder projects saved before locator support.
   locators?: RecorderLocator[];
+  // Optional for projects saved before track unification.
+  armedTrackId?: string;
   audioTracks: SerializedAudioTrackState<ChannelData>[];
-  recordingTrack: {
-    // Optional for projects saved before track EQ support.
-    eq?: MultibandEqParameters | EqParameters;
-    height: number;
-    gain: number;
-    muted: boolean;
-    soloed: boolean;
+  // Retained for projects saved with a separate recording track.
+  recordingTrack?: Pick<
+    SerializedAudioTrackState<ChannelData>,
+    "eq" | "height" | "gain" | "muted" | "soloed" | "nextTakeNumber"
+  > & {
     takes: SerializedAudioClip<ChannelData>[];
-    // Optional for recorder projects saved before multi-take support.
-    nextTakeNumber?: number;
   };
   latencyCompensation: number;
   // Optional for recorder projects saved before mixer support.
@@ -64,28 +60,25 @@ export interface SerializedRecorderRuntimeState<ChannelData = Float32Array> {
 }
 
 interface SerializedAudioTrackState<ChannelData> {
-  // Optional for projects saved before track EQ support.
-  eq?: MultibandEqParameters | EqParameters;
   id: string;
+  eq?: MultibandEqParameters | EqParameters;
   height: number;
-  clip?: {
-    name: string;
-    pcm: RecorderPcm<ChannelData>;
-  };
   gain: number;
   muted: boolean;
   soloed: boolean;
-  timelineOffset: number;
-  // optional for back compat
+  nextTakeNumber?: number;
+  clips?: SerializedAudioClip<ChannelData>[];
+  // Retained for ordinary tracks saved with a single imported clip.
+  clip?: { name: string; pcm: RecorderPcm<ChannelData> };
+  timelineOffset?: number;
   trimStart?: number;
   trimEnd?: number;
 }
 
 interface SerializedAudioClip<ChannelData> {
-  // Optional for recorder projects saved before multi-take support.
   id?: string;
-  number?: number;
   name?: string;
+  number?: number;
   muted?: boolean;
   soloed?: boolean;
   timelineOffset: number;
@@ -100,54 +93,36 @@ export interface RecorderPcm<ChannelData> {
 }
 
 export function serializeRecorderRuntimeState(
-  state: RecorderRuntimeState,
+  state: PersistableRecorderRuntimeState,
 ): SerializedRecorderRuntimeState {
   return {
     title: state.title,
     locators: state.locators,
-    audioTracks: state.audioTracks.map((track) => {
-      const clip = track.clips[0];
-      return {
-        id: track.id,
-        height: track.height,
-        clip: clip?.buffer
-          ? {
-              name: clip.name,
-              pcm: serializeAudioBuffer(clip.buffer),
-            }
-          : undefined,
-        eq: track.eq,
-        gain: track.gain,
-        muted: track.muted,
-        soloed: track.soloed,
-        timelineOffset: clip?.timelineOffset ?? 0,
-        trimStart: clip?.trimStart ?? 0,
-        trimEnd: clip?.trimEnd ?? 0,
-      };
-    }),
-    recordingTrack: {
-      height: state.recordingTrack.height,
-      eq: state.recordingTrack.eq,
-      gain: state.recordingTrack.gain,
-      muted: state.recordingTrack.muted,
-      soloed: state.recordingTrack.soloed,
-      nextTakeNumber: state.recordingTrack.nextTakeNumber,
-      takes: state.recordingTrack.clips.map((take) => {
-        if (!take.buffer) {
-          throw new Error("Recording take has no loaded buffer.");
+    armedTrackId: state.armedTrackId,
+    audioTracks: state.audioTracks.map((track) => ({
+      id: track.id,
+      height: track.height,
+      eq: track.eq,
+      gain: track.gain,
+      muted: track.muted,
+      soloed: track.soloed,
+      nextTakeNumber: track.nextTakeNumber,
+      clips: track.clips.map((clip) => {
+        if (!clip.buffer) {
+          throw new Error("Audio clip has no loaded buffer.");
         }
         return {
-          id: take.id,
-          name: take.name,
-          muted: take.muted,
-          soloed: take.soloed,
-          timelineOffset: take.timelineOffset,
-          trimStart: take.trimStart,
-          trimEnd: take.trimEnd,
-          pcm: serializeAudioBuffer(take.buffer),
+          id: clip.id,
+          name: clip.name,
+          muted: clip.muted,
+          soloed: clip.soloed,
+          timelineOffset: clip.timelineOffset,
+          trimStart: clip.trimStart,
+          trimEnd: clip.trimEnd,
+          pcm: serializeAudioBuffer(clip.buffer),
         };
       }),
-    },
+    })),
     latencyCompensation: state.latencyCompensation,
     masterGain: state.masterGain,
     metronomeGain: state.metronomeGain,
@@ -163,66 +138,70 @@ export function deserializeRecorderRuntimeState({
   context,
   project,
 }: {
-  context: AudioContext;
+  context: Pick<AudioContext, "createBuffer">;
   project: SerializedRecorderRuntimeState;
 }): PersistableRecorderRuntimeState {
+  // Fold the old singleton recording track into the track list before decoding.
+  const armedTrackId = project.armedTrackId ?? crypto.randomUUID();
+  const tracks: SerializedAudioTrackState<Float32Array>[] =
+    project.recordingTrack
+      ? [
+          ...project.audioTracks,
+          {
+            ...project.recordingTrack,
+            id: armedTrackId,
+            clips: project.recordingTrack.takes,
+            nextTakeNumber:
+              project.recordingTrack.nextTakeNumber ??
+              project.recordingTrack.takes.length + 1,
+          },
+        ]
+      : project.audioTracks;
+  if (!tracks.some((track) => track.id === armedTrackId)) {
+    throw new Error("Recorder project has no recording destination.");
+  }
   return {
     title: project.title,
     locators: project.locators ?? [],
-    audioTracks: project.audioTracks.map((track) => {
-      const buffer = track.clip
-        ? deserializeAudioBuffer(context, track.clip.pcm)
-        : undefined;
+    armedTrackId,
+    audioTracks: tracks.map((track) => {
+      const clips: SerializedAudioClip<Float32Array>[] =
+        track.clips ??
+        (track.clip
+          ? [
+              {
+                ...track.clip,
+                timelineOffset: track.timelineOffset ?? 0,
+                trimStart: track.trimStart,
+                trimEnd: track.trimEnd,
+              },
+            ]
+          : []);
       return {
         id: track.id,
-        nextTakeNumber: 1,
         height: track.height,
-        clips:
-          track.clip && buffer
-            ? [
-                {
-                  ...createAudioClip({
-                    buffer,
-                    name: track.clip.name,
-                  }),
-                  timelineOffset: track.timelineOffset,
-                  trimStart: track.trimStart ?? 0,
-                  trimEnd: track.trimEnd ?? buffer.duration,
-                },
-              ]
-            : [],
-        eq: deserializeEq(track.eq),
         gain: track.gain,
         muted: track.muted,
         soloed: track.soloed,
+        eq: deserializeEq(track.eq),
+        nextTakeNumber: track.nextTakeNumber ?? 1,
+        clips: clips.map((clip, index) => {
+          const buffer = deserializeAudioBuffer(context, clip.pcm);
+          return {
+            ...createAudioClip({
+              id: clip.id,
+              name: clip.name ?? `Take ${clip.number ?? index + 1}`,
+              buffer,
+            }),
+            timelineOffset: clip.timelineOffset,
+            muted: clip.muted ?? false,
+            soloed: clip.soloed ?? false,
+            trimStart: clip.trimStart ?? 0,
+            trimEnd: clip.trimEnd ?? buffer.duration,
+          };
+        }),
       };
     }),
-    recordingTrack: {
-      id: crypto.randomUUID(),
-      height: project.recordingTrack.height,
-      eq: deserializeEq(project.recordingTrack.eq),
-      gain: project.recordingTrack.gain,
-      muted: project.recordingTrack.muted,
-      soloed: project.recordingTrack.soloed,
-      nextTakeNumber:
-        project.recordingTrack.nextTakeNumber ??
-        project.recordingTrack.takes.length + 1,
-      clips: project.recordingTrack.takes.map((take, index) => {
-        const buffer = deserializeAudioBuffer(context, take.pcm);
-        return {
-          ...createAudioClip({
-            id: take.id,
-            buffer,
-            name: take.name ?? `Take ${take.number ?? index + 1}`,
-          }),
-          timelineOffset: take.timelineOffset,
-          muted: take.muted ?? false,
-          soloed: take.soloed ?? false,
-          trimStart: take.trimStart ?? 0,
-          trimEnd: take.trimEnd ?? buffer.duration,
-        };
-      }),
-    },
     latencyCompensation: project.latencyCompensation,
     masterGain: project.masterGain ?? 1,
     metronomeGain: project.metronomeGain ?? 0.5,
@@ -259,7 +238,7 @@ function serializeAudioBuffer(buffer: AudioBuffer): RecorderPcm<Float32Array> {
 }
 
 function deserializeAudioBuffer(
-  context: AudioContext,
+  context: Pick<AudioContext, "createBuffer">,
   pcm: RecorderPcm<Float32Array>,
 ): AudioBuffer {
   if (!Number.isFinite(pcm.sampleRate) || pcm.sampleRate <= 0) {

--- a/src/lib/recorder/project-archive.ts
+++ b/src/lib/recorder/project-archive.ts
@@ -3,25 +3,24 @@ import type {
   RecorderPcm,
   SerializedRecorderRuntimeState,
 } from "./persistence.ts";
-
 // .toymidi.zip
 // ├── manifest.json  { formatVersion: 1, projectType: "recorder", ... }
-// ├── project.json   { audioTracks: [{ clip: { pcm: { channels:
-// │                    ["audio/tracks/0/channel-0.f32"] } } }], ... }
-// └── audio/
-//     ├── tracks/0/channel-0.f32
-//     └── takes/0/channel-0.f32
+// ├── project.json   { audioTracks: [{ clips: [{ pcm: { channels:
+// │                    ["audio/tracks/0/clips/0/channel-0.f32"] } }] }], ... }
+// └── audio/tracks/
+//     ├── 0/clips/0/channel-0.f32
+//     └── 1/clips/0/channel-0.f32
 //
 // project.json serializes SerializedRecorderRuntimeState<string>, replacing
 // each PCM channel's Float32Array with its ZIP entry path. The samples are
 // stored separately in the referenced .f32 files.
 
-const CURRENT_FORMAT_VERSION: RecorderProjectManifest["formatVersion"] = 1;
+const CURRENT_FORMAT_VERSION = 1;
 const MANIFEST_PATH = "manifest.json";
 const PROJECT_PATH = "project.json";
 
 interface RecorderProjectManifest {
-  formatVersion: 1;
+  formatVersion: number;
   projectType: "recorder";
   exportedAt: string;
 }
@@ -90,14 +89,24 @@ function writeProjectContent(
             ),
           }
         : undefined,
-    })),
-    recordingTrack: {
-      ...content.recordingTrack,
-      takes: content.recordingTrack.takes.map((take, takeIndex) => ({
-        ...take,
-        pcm: writeProjectPcm(zip, take.pcm, `audio/takes/${takeIndex}`),
+      clips: track.clips?.map((clip, clipIndex) => ({
+        ...clip,
+        pcm: writeProjectPcm(
+          zip,
+          clip.pcm,
+          `audio/tracks/${trackIndex}/clips/${clipIndex}`,
+        ),
       })),
-    },
+    })),
+    recordingTrack: content.recordingTrack
+      ? {
+          ...content.recordingTrack,
+          takes: content.recordingTrack.takes.map((take, index) => ({
+            ...take,
+            pcm: writeProjectPcm(zip, take.pcm, `audio/takes/${index}`),
+          })),
+        }
+      : undefined,
   };
 }
 
@@ -111,22 +120,29 @@ async function readProjectContent(
       content.audioTracks.map(async (track) => ({
         ...track,
         clip: track.clip
-          ? {
-              ...track.clip,
-              pcm: await readProjectPcm(zip, track.clip.pcm),
-            }
+          ? { ...track.clip, pcm: await readProjectPcm(zip, track.clip.pcm) }
           : undefined,
+        clips:
+          track.clips &&
+          (await Promise.all(
+            track.clips.map(async (clip) => ({
+              ...clip,
+              pcm: await readProjectPcm(zip, clip.pcm),
+            })),
+          )),
       })),
     ),
-    recordingTrack: {
-      ...content.recordingTrack,
-      takes: await Promise.all(
-        content.recordingTrack.takes.map(async (take) => ({
-          ...take,
-          pcm: await readProjectPcm(zip, take.pcm),
-        })),
-      ),
-    },
+    recordingTrack: content.recordingTrack
+      ? {
+          ...content.recordingTrack,
+          takes: await Promise.all(
+            content.recordingTrack.takes.map(async (take) => ({
+              ...take,
+              pcm: await readProjectPcm(zip, take.pcm),
+            })),
+          ),
+        }
+      : undefined,
   };
 }
 

--- a/src/lib/recorder/runtime.ts
+++ b/src/lib/recorder/runtime.ts
@@ -38,20 +38,12 @@ const MAX_RECORDING_SECONDS = 5 * 60;
 const MIN_TAKE_DURATION = 0.01;
 const DEFAULT_TRACK_HEIGHT = 72;
 const MIN_TRACK_HEIGHT = DEFAULT_TRACK_HEIGHT;
-const MIN_RECORDING_TRACK_HEIGHT = 116;
 const MAX_TRACK_HEIGHT = 300;
-// The recording track keeps a fixed id so its playback can live in the shared
-// track playback map while its state still lives outside audioTracks.
-const RECORDING_TRACK_ID = "__capture__";
 
 type CaptureStatus = "disabled" | "ready" | "recording" | "processing";
 
 // The ordinary-track UI currently keeps zero or one imported clip and has
 // no clip-level mute/solo controls. Imported clips initialize both flags to false.
-// Ordinary tracks leave nextTakeNumber at 1 because only the recording track
-// creates takes. The recording track uses RECORDING_TRACK_ID. Its state is still
-// stored in recordingTrack rather than audioTracks, but its playback shares
-// trackPlaybacks with ordinary tracks.
 export interface AudioTrackState {
   id: string;
   eq: MultibandEqParameters;
@@ -129,7 +121,9 @@ export interface RecorderRuntimeState {
   metronomeGain: number;
   // Tracks
   audioTracks: AudioTrackState[];
-  recordingTrack: AudioTrackState;
+  // Recording appends takes to this track, and the shared capture input
+  // monitors through its channel.
+  armedTrackId: string;
   previewClipRegions?: ClipRegion[];
   pendingRecording?: PendingRecordingState;
   // Capture
@@ -152,9 +146,9 @@ export type PersistableRecorderRuntimeState = Pick<
   | "punch"
   | "latencyCompensation"
   | "referenceVideo"
+  | "armedTrackId"
 > & {
   audioTracks: Omit<AudioTrackState, "regions">[];
-  recordingTrack: Omit<AudioTrackState, "regions">;
 };
 
 export type RecorderClipId =
@@ -171,6 +165,7 @@ export type RecorderClipTrim = Extract<RecorderClipId, { id: string }> & {
 };
 
 export function createDefaultRecorderRuntimeState(): RecorderRuntimeState {
+  const track = createAudioTrackState();
   return {
     title: "Untitled recording",
     locators: [],
@@ -184,8 +179,8 @@ export function createDefaultRecorderRuntimeState(): RecorderRuntimeState {
     punch: { enabled: false },
     masterGain: 1,
     metronomeGain: 0.5,
-    audioTracks: [],
-    recordingTrack: createRecordingTrackState(),
+    audioTracks: [track],
+    armedTrackId: track.id,
     captureStatus: "disabled",
     inputChannelCount: 0,
     selectedChannel: 0,
@@ -202,6 +197,9 @@ export class RecorderRuntime {
   private readonly transport: AudioContextTransport;
   captureInput?: CaptureInput;
   private trackPlaybacks = new Map<string, AudioTrackPlayback>();
+  // Covers the async capture start before pendingRecording exists so the
+  // armed track cannot change under a recording that is about to begin.
+  private startingRecording = false;
   private attachedYouTubePlayer?: {
     videoId: string;
     player: YouTubePlayerApi;
@@ -243,7 +241,8 @@ export class RecorderRuntime {
     const { input, channelCount } = await CaptureInput.open({
       context,
       deviceId,
-      output: this.getTrackPlayback(RECORDING_TRACK_ID).channel.input,
+      output: this.getTrackPlayback(this.store.get().armedTrackId).channel
+        .input,
       onNotification: (message) => {
         switch (message.type) {
           case "samples": {
@@ -375,7 +374,6 @@ export class RecorderRuntime {
       });
     }
     const audioTracks = state.audioTracks.map((track) => moveTrackClips(track));
-    const recordingTrack = moveTrackClips(state.recordingTrack);
     const referenceVideo = state.referenceVideo
       ? {
           ...state.referenceVideo,
@@ -385,10 +383,7 @@ export class RecorderRuntime {
     if (referenceOffset !== undefined && !referenceVideo) {
       throw new Error("Recorder clip state is missing.");
     }
-    this.store.update({ recordingTrack, audioTracks, referenceVideo });
-    if (recordingTrack !== state.recordingTrack) {
-      this.syncTrackPlayback(recordingTrack);
-    }
+    this.store.update({ audioTracks, referenceVideo });
     if (referenceOffset !== undefined) {
       this.syncYouTubePlayer();
     }
@@ -439,11 +434,7 @@ export class RecorderRuntime {
       });
     }
     const audioTracks = state.audioTracks.map((track) => updateClips(track));
-    const recordingTrack = updateClips(state.recordingTrack);
-    this.store.update({ recordingTrack, audioTracks });
-    if (recordingTrack !== state.recordingTrack) {
-      this.syncTrackPlayback(recordingTrack);
-    }
+    this.store.update({ audioTracks });
     for (const [index, track] of audioTracks.entries()) {
       if (track !== state.audioTracks[index]) {
         this.syncTrackPlayback(track);
@@ -473,15 +464,10 @@ export class RecorderRuntime {
     const audioTracks = state.audioTracks.map((track) =>
       removeTrackClips(track),
     );
-    const recordingTrack = removeTrackClips(state.recordingTrack);
     this.store.update({
-      recordingTrack,
       audioTracks,
       ...(removeReference ? { referenceVideo: undefined } : {}),
     });
-    if (recordingTrack !== state.recordingTrack) {
-      this.syncTrackPlayback(recordingTrack);
-    }
     for (const [index, track] of audioTracks.entries()) {
       if (track !== state.audioTracks[index]) {
         this.syncTrackPlayback(track);
@@ -498,17 +484,13 @@ export class RecorderRuntime {
   setTrackHeight(id: string, height: number): void {
     this.updateTrack(id, (track) => ({
       ...track,
-      // The Capture row carries input controls and needs more room.
-      height:
-        id === RECORDING_TRACK_ID
-          ? clampRecordingTrackHeight(height)
-          : clampTrackHeight(height),
+      height: clampTrackHeight(height),
     }));
   }
 
   removeAudioTrack(id: string): void {
-    if (id === RECORDING_TRACK_ID) {
-      throw new Error("The recording track cannot be removed.");
+    if (id === this.store.get().armedTrackId) {
+      throw new Error("Cannot remove the recording destination.");
     }
     this.trackPlaybacks.get(id)?.dispose();
     this.trackPlaybacks.delete(id);
@@ -525,6 +507,40 @@ export class RecorderRuntime {
     this.trackPlaybacks.get(id)?.channel.setEq(eq);
   }
 
+  setArmedTrack(id: string): void {
+    if (this.isRecordingLocked()) {
+      throw new Error(
+        "Cannot change the recording destination while recording.",
+      );
+    }
+    this.getTrack(id);
+    this.store.update({ armedTrackId: id });
+    this.syncMonitorRoute();
+  }
+
+  private isRecordingLocked(): boolean {
+    const { captureStatus } = this.store.get();
+    return (
+      this.startingRecording ||
+      captureStatus === "recording" ||
+      captureStatus === "processing"
+    );
+  }
+
+  private syncMonitorRoute(): void {
+    this.captureInput?.setMonitorOutput(
+      this.getTrackPlayback(this.store.get().armedTrackId).channel.input,
+    );
+  }
+
+  private getTrack(id: string): AudioTrackState {
+    const track = this.store.get().audioTracks.find((track) => track.id === id);
+    if (!track) {
+      throw new Error("Audio track state is missing.");
+    }
+    return track;
+  }
+
   private updateTrack(
     id: string,
     update: (track: AudioTrackState) => AudioTrackState,
@@ -533,13 +549,7 @@ export class RecorderRuntime {
       const next = update(track);
       return next.clips === track.clips ? next : resolveTrackRegions(next);
     };
-    const state = this.store.get();
-    if (id === RECORDING_TRACK_ID) {
-      const recordingTrack = apply(state.recordingTrack);
-      this.store.update({ recordingTrack });
-      return recordingTrack;
-    }
-    const audioTracks = state.audioTracks.slice();
+    const audioTracks = this.store.get().audioTracks.slice();
     const index = audioTracks.findIndex((track) => track.id === id);
     const track = audioTracks[index];
     if (!track) {
@@ -553,13 +563,7 @@ export class RecorderRuntime {
   private getTrackPlayback(id: string): AudioTrackPlayback {
     let playback = this.trackPlaybacks.get(id);
     if (!playback) {
-      const { audioTracks, recordingTrack } = this.store.get();
-      const track = [...audioTracks, recordingTrack].find(
-        (entry) => entry.id === id,
-      );
-      if (!track) {
-        throw new Error("Audio track state is missing.");
-      }
+      const track = this.getTrack(id);
       playback = new AudioTrackPlayback({
         transport: this.transport,
         output: this.masterOutput,
@@ -593,13 +597,25 @@ export class RecorderRuntime {
     if (!this.captureInput) {
       throw new Error("Enable an audio input before recording.");
     }
+    if (this.isRecordingLocked()) {
+      throw new Error("Recording is already in progress.");
+    }
+    this.startingRecording = true;
+    try {
+      await this.beginRecording(this.captureInput);
+    } finally {
+      this.startingRecording = false;
+    }
+  }
+
+  private async beginRecording(captureInput: CaptureInput): Promise<void> {
     const context = this.context;
     await context.resume();
-    const captureStartFrame = await this.captureInput.startCapture();
+    const captureStartFrame = await captureInput.startCapture();
     if (!this.store.get().isPlaying) {
       await this.play();
     }
-    this.getTrackPlayback(RECORDING_TRACK_ID).setPlaybackGain(0);
+    this.getTrackPlayback(this.store.get().armedTrackId).setPlaybackGain(0);
     // Trim samples captured during playback lead time.
     const playbackStartFrame =
       this.transport.playbackAnchor!.contextTime * context.sampleRate;
@@ -610,7 +626,7 @@ export class RecorderRuntime {
       ) - this.store.get().latencyCompensation;
     const id = crypto.randomUUID();
     const state = this.store.get();
-    const number = state.recordingTrack.nextTakeNumber;
+    const number = this.getTrack(state.armedTrackId).nextTakeNumber;
     const punchRange =
       state.punch.enabled && state.punch.range
         ? {
@@ -870,42 +886,24 @@ export class RecorderRuntime {
       playback.dispose();
     }
     this.trackPlaybacks.clear();
-    const audioTracks = project.audioTracks.map((track) =>
-      resolveTrackRegions(track),
-    );
-    for (const track of audioTracks) {
-      if (track.clips.length === 0) {
-        continue;
-      }
-      const playback = new AudioTrackPlayback({
-        transport: this.transport,
-        output: this.masterOutput,
-        eq: track.eq,
-        gain: 0,
-      });
-      playback.setSources(getClipSources(track.regions));
-      this.trackPlaybacks.set(track.id, playback);
-    }
-    // Clamp loaded external state at the runtime boundary so older projects
-    // cannot restore a Capture row too short for its current controls, and pin
-    // the recording track id that persistence does not preserve.
-    const recordingTrack = resolveTrackRegions({
-      ...project.recordingTrack,
-      id: RECORDING_TRACK_ID,
-      height: clampRecordingTrackHeight(project.recordingTrack.height),
-    });
     this.store.update({
       ...project,
-      audioTracks,
       position: 0,
-      recordingTrack,
+      audioTracks: project.audioTracks.map((track) =>
+        resolveTrackRegions({
+          ...track,
+          height: clampTrackHeight(track.height),
+        }),
+      ),
     });
-    this.syncTrackPlayback(recordingTrack);
-    // The recording playback was recreated above, so point the open input at
-    // its new channel.
-    this.captureInput?.setMonitorOutput(
-      this.getTrackPlayback(RECORDING_TRACK_ID).channel.input,
-    );
+    for (const track of this.store.get().audioTracks) {
+      if (track.clips.length > 0) {
+        this.syncTrackPlayback(track);
+      }
+    }
+    // Every playback was recreated above, so point the open input at the
+    // armed track's new channel.
+    this.syncMonitorRoute();
     this.syncYouTubePlayer();
     this.transport.seek(0);
     this.metronome.setTempo(project.tempo);
@@ -929,7 +927,7 @@ export class RecorderRuntime {
           loop: state.loop,
           punch: state.punch,
           audioTracks: state.audioTracks,
-          recordingTrack: state.recordingTrack,
+          armedTrackId: state.armedTrackId,
           latencyCompensation: state.latencyCompensation,
           referenceVideo: state.referenceVideo,
         }) satisfies PersistableRecorderRuntimeState,
@@ -940,16 +938,20 @@ export class RecorderRuntime {
 
   private syncTrackMix(): void {
     const state = this.store.get();
-    for (const [id, gain] of deriveTrackMix(state)) {
-      this.trackPlaybacks.get(id)?.channel.setGain(gain);
-    }
-    // Suppress take playback independently so channel mix edits cannot unmute it.
-    const { captureStatus } = state;
-    this.trackPlaybacks
-      .get(RECORDING_TRACK_ID)
-      ?.setPlaybackGain(
-        captureStatus === "recording" || captureStatus === "processing" ? 0 : 1,
+    const gains = deriveTrackMix(state);
+    const { captureStatus, armedTrackId } = state;
+    for (const track of state.audioTracks) {
+      const playback = this.trackPlaybacks.get(track.id);
+      playback?.channel.setGain(gains.get(track.id)!);
+      // Suppress the armed track's existing comp while it records, independent
+      // of channel mix so mix edits cannot unmute it.
+      playback?.setPlaybackGain(
+        (captureStatus === "recording" || captureStatus === "processing") &&
+          track.id === armedTrackId
+          ? 0
+          : 1,
       );
+    }
   }
 
   private syncMetronomeGain(): void {
@@ -1007,29 +1009,33 @@ export class RecorderRuntime {
     );
     takeBuffer.getChannelData(0).set(slice.samples);
     const timelineOffset = pendingRecording.timelineOffset + slice.startOffset;
-    const previousTrack = this.store.get().recordingTrack;
-    const recordingTrack = resolveTrackRegions({
-      ...previousTrack,
-      nextTakeNumber: previousTrack.nextTakeNumber + 1,
-      clips: [
-        ...previousTrack.clips,
-        {
-          ...createAudioClip({
-            id: pendingRecording.id,
-            name: pendingRecording.name,
-            buffer: takeBuffer,
+    const { armedTrackId } = this.store.get();
+    const audioTracks = this.store.get().audioTracks.map((track) =>
+      track.id !== armedTrackId
+        ? track
+        : resolveTrackRegions({
+            ...track,
+            nextTakeNumber: track.nextTakeNumber + 1,
+            clips: [
+              ...track.clips,
+              {
+                ...createAudioClip({
+                  id: pendingRecording.id,
+                  name: pendingRecording.name,
+                  buffer: takeBuffer,
+                }),
+                timelineOffset,
+              },
+            ],
           }),
-          timelineOffset,
-        },
-      ],
-    });
+    );
     this.store.update({
       captureStatus: "ready",
       pendingRecording: undefined,
       previewClipRegions: undefined,
-      recordingTrack,
+      audioTracks,
     });
-    this.syncTrackPlayback(recordingTrack);
+    this.syncTrackPlayback(this.getTrack(armedTrackId));
     this.syncTrackMix();
   }
 
@@ -1042,7 +1048,7 @@ export class RecorderRuntime {
     pendingRecording: PendingRecordingState,
   ): void {
     const previewClipRegions = deriveClipRegions([
-      ...getActiveClips(this.store.get().recordingTrack.clips),
+      ...getActiveClips(this.getTrack(this.store.get().armedTrackId).clips),
       pendingRecordingToTake(pendingRecording),
     ]);
     this.store.update({ pendingRecording, previewClipRegions });
@@ -1153,27 +1159,6 @@ function createAudioTrackState(): AudioTrackState {
   };
 }
 
-function createRecordingTrackState(): AudioTrackState {
-  return {
-    id: RECORDING_TRACK_ID,
-    eq: createDefaultMultibandEq(),
-    height: MIN_RECORDING_TRACK_HEIGHT,
-    gain: 1,
-    muted: false,
-    soloed: false,
-    clips: [],
-    regions: [],
-    nextTakeNumber: 1,
-  };
-}
-
 function clampTrackHeight(height: number): number {
   return Math.max(MIN_TRACK_HEIGHT, Math.min(MAX_TRACK_HEIGHT, height));
-}
-
-function clampRecordingTrackHeight(height: number): number {
-  return Math.max(
-    MIN_RECORDING_TRACK_HEIGHT,
-    Math.min(MAX_TRACK_HEIGHT, height),
-  );
 }


### PR DESCRIPTION
- related to https://github.com/hi-ogawa/toy-midi/issues/464
- supersedes https://github.com/hi-ogawa/toy-midi/pull/503

After https://github.com/hi-ogawa/toy-midi/pull/512 the recording track already shares the playback map, the id-keyed editing API, and the monitor reroute. What remains separate is the state itself: `recordingTrack` still lives outside `audioTracks`, addressed through a fixed id.

This PR puts every audio track in `audioTracks` and replaces the fixed id with `armedTrackId`. Recording appends its take to the armed track, `syncTrackMix` suppresses only the armed track's existing comp while recording, and `setArmedTrack` re-points the shared input's monitoring at the new destination. The armed track cannot change or be removed from the moment a recording starts until it finishes processing. Loading a project recreates every playback uniformly and points the open input at the armed track's new channel. The current Capture-row UI remains, rendering whichever track is armed, with the Arm control and append-on-import behavior left for the next step.

Projects save every track's clip array plus the armed id while keeping storage unversioned and the existing archive format. Persistence folds an older project's separate recording track into the track list and arms it, preserving PCM, mix settings, placement, trims, and take numbering. The persistence, archive, and legacy-import E2E changes are carried over from #503 unchanged; the runtime side is rewritten against the current base instead of merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbHG7BkMV3VyQCDGy7i3bt
