### PR TITLE
feat: hide take disclosure on empty recorder tracks

### DIFF
--- a/e2e/fake-audio/recorder-recording.test.ts
+++ b/e2e/fake-audio/recorder-recording.test.ts
@@ -49,9 +49,16 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
     .getByTestId("recorder-clip-take-lane");
   const takeRows = page.getByTestId("recorder-take-row");
   const compRegion = page.getByTestId("recorder-clip-comp");
-  await expect(takesToggle).toHaveCount(0);
+  await expect(takesToggle).toHaveAttribute("aria-expanded", "false");
+  await expect(takesToggle).toContainText("1");
   await expect(takeRows).toHaveCount(0);
   await expect(take).toHaveCount(1);
+
+  // Reveal the sole source take, then fold it before editing the main lane.
+  await takesToggle.click();
+  await expect(takeRows).toHaveCount(1);
+  await takesToggle.click();
+  await expect(takeRows).toHaveCount(0);
   await expect(compRegion).toContainText("Take 1");
   await expect(compRegion.locator("svg")).toBeVisible();
   expect(
@@ -100,7 +107,7 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   await waitForRecordingSamples(secondRecording);
   await recordButton.click();
 
-  // The second recording reveals the disclosure while source lanes stay folded.
+  // Retain the second recording while source lanes stay folded.
   await expect(takesToggle).toHaveAttribute("aria-expanded", "false");
   await expect(takesToggle).toContainText("2");
   await expect(takeRows).toHaveCount(0);
@@ -155,14 +162,16 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   await soloTake.nth(0).click();
   await takeRows.nth(1).getByRole("button", { name: "Take 2 actions" }).click();
   await page.getByRole("menuitem", { name: "Delete take" }).click();
-  await expect(takesToggle).toHaveCount(0);
-  await expect(takeRows).toHaveCount(0);
+  await expect(takesToggle).toContainText("1");
+  await expect(takeRows).toHaveCount(1);
   await expect(take).toHaveCount(0);
 
-  // Restore the remaining source from the main lane without a hidden mute state.
-  await page
-    .getByRole("button", { name: "Take 1 · Reset take mute/solo" })
-    .click();
+  // Fold and reveal the remaining source to recover its existing mute/solo controls.
+  await takesToggle.click();
+  await expect(takeRows).toHaveCount(0);
+  await takesToggle.click();
+  await muteTake.click();
+  await soloTake.click();
   await expect(take).toHaveCount(1);
   await expect(compRegion).toContainText("Take 1");
 

--- a/e2e/fake-audio/recorder-recording.test.ts
+++ b/e2e/fake-audio/recorder-recording.test.ts
@@ -29,8 +29,7 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   const recordButton = page.getByTestId("recorder-record-button");
   const playButton = page.getByTestId("recorder-play-button");
   const takesToggle = page.getByTestId("recorder-takes-toggle");
-  await expect(takesToggle).toHaveAttribute("aria-expanded", "false");
-  await expect(takesToggle).toContainText("0");
+  await expect(takesToggle).toHaveCount(0);
   await recordButton.click();
   await expect(monitorButton).toHaveAttribute("aria-pressed", "true");
   await expect(recordButton).toHaveAttribute("aria-pressed", "true");
@@ -50,13 +49,9 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
     .getByTestId("recorder-clip-take-lane");
   const takeRows = page.getByTestId("recorder-take-row");
   const compRegion = page.getByTestId("recorder-clip-comp");
-  await expect(takesToggle).toHaveAttribute("aria-expanded", "false");
+  await expect(takesToggle).toHaveCount(0);
   await expect(takeRows).toHaveCount(0);
   await expect(take).toHaveCount(1);
-  await takesToggle.click();
-  await expect(takesToggle).toHaveAttribute("aria-expanded", "true");
-  await expect(takeLane).toHaveCount(1);
-  await expect(takeRows).toHaveCount(1);
   await expect(compRegion).toContainText("Take 1");
   await expect(compRegion.locator("svg")).toBeVisible();
   expect(
@@ -105,7 +100,11 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   await waitForRecordingSamples(secondRecording);
   await recordButton.click();
 
-  // The second recording is retained as a new source take.
+  // The second recording reveals the disclosure while source lanes stay folded.
+  await expect(takesToggle).toHaveAttribute("aria-expanded", "false");
+  await expect(takesToggle).toContainText("2");
+  await expect(takeRows).toHaveCount(0);
+  await takesToggle.click();
   await expect(take).toHaveCount(2);
   await expect(takeLane).toHaveCount(2);
   await expect(takeRows).toHaveCount(2);
@@ -151,10 +150,26 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   await page.keyboard.press("Escape");
   await expect(take.nth(0)).not.toHaveAttribute("data-selected", "true");
 
-  // Delete removes every selected source take together.
-  await take.nth(0).click();
-  await takeLane.nth(1).click({ modifiers: ["Control"] });
+  // Delete the second take while the first is muted and soloed.
+  await muteTake.nth(0).click();
+  await soloTake.nth(0).click();
+  await takeRows.nth(1).getByRole("button", { name: "Take 2 actions" }).click();
+  await page.getByRole("menuitem", { name: "Delete take" }).click();
+  await expect(takesToggle).toHaveCount(0);
+  await expect(takeRows).toHaveCount(0);
+  await expect(take).toHaveCount(0);
+
+  // Restore the remaining source from the main lane without a hidden mute state.
+  await page
+    .getByRole("button", { name: "Take 1 · Reset take mute/solo" })
+    .click();
+  await expect(take).toHaveCount(1);
+  await expect(compRegion).toContainText("Take 1");
+
+  // Delete the sole take from the main lane and keep the empty track compact.
+  await take.click();
   await page.keyboard.press("Delete");
+  await expect(takesToggle).toHaveCount(0);
   await expect(take).toHaveCount(0);
   await expect(takeRows).toHaveCount(0);
 });

--- a/e2e/fake-audio/recorder-recording.test.ts
+++ b/e2e/fake-audio/recorder-recording.test.ts
@@ -50,15 +50,12 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   const takeRows = page.getByTestId("recorder-take-row");
   const compRegion = page.getByTestId("recorder-clip-comp");
   await expect(takesToggle).toHaveAttribute("aria-expanded", "false");
-  await expect(takesToggle).toContainText("1");
   await expect(takeRows).toHaveCount(0);
   await expect(take).toHaveCount(1);
-
-  // Reveal the sole source take, then fold it before editing the main lane.
   await takesToggle.click();
+  await expect(takesToggle).toHaveAttribute("aria-expanded", "true");
+  await expect(takeLane).toHaveCount(1);
   await expect(takeRows).toHaveCount(1);
-  await takesToggle.click();
-  await expect(takeRows).toHaveCount(0);
   await expect(compRegion).toContainText("Take 1");
   await expect(compRegion.locator("svg")).toBeVisible();
   expect(
@@ -107,11 +104,7 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   await waitForRecordingSamples(secondRecording);
   await recordButton.click();
 
-  // Retain the second recording while source lanes stay folded.
-  await expect(takesToggle).toHaveAttribute("aria-expanded", "false");
-  await expect(takesToggle).toContainText("2");
-  await expect(takeRows).toHaveCount(0);
-  await takesToggle.click();
+  // The second recording is retained as a new source take.
   await expect(take).toHaveCount(2);
   await expect(takeLane).toHaveCount(2);
   await expect(takeRows).toHaveCount(2);
@@ -157,26 +150,9 @@ test("records, plays, and manages multiple takes", async ({ page }) => {
   await page.keyboard.press("Escape");
   await expect(take.nth(0)).not.toHaveAttribute("data-selected", "true");
 
-  // Delete the second take while the first is muted and soloed.
-  await muteTake.nth(0).click();
-  await soloTake.nth(0).click();
-  await takeRows.nth(1).getByRole("button", { name: "Take 2 actions" }).click();
-  await page.getByRole("menuitem", { name: "Delete take" }).click();
-  await expect(takesToggle).toContainText("1");
-  await expect(takeRows).toHaveCount(1);
-  await expect(take).toHaveCount(0);
-
-  // Fold and reveal the remaining source to recover its existing mute/solo controls.
-  await takesToggle.click();
-  await expect(takeRows).toHaveCount(0);
-  await takesToggle.click();
-  await muteTake.click();
-  await soloTake.click();
-  await expect(take).toHaveCount(1);
-  await expect(compRegion).toContainText("Take 1");
-
-  // Delete the sole take from the main lane and keep the empty track compact.
-  await take.click();
+  // Delete removes every selected source take together.
+  await take.nth(0).click();
+  await takeLane.nth(1).click({ modifiers: ["Control"] });
   await page.keyboard.press("Delete");
   await expect(takesToggle).toHaveCount(0);
   await expect(take).toHaveCount(0);

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -469,6 +469,10 @@ export function Recorder({ projectId }: { projectId: string }) {
             >
               <TakeTimelineLane
                 takes={takes}
+                onResetTakeMix={(id) => {
+                  runtime.setClipMuted({ id, muted: false });
+                  runtime.setClipSoloed({ id, soloed: false });
+                }}
                 regions={
                   state.previewClipRegions ?? state.recordingTrack.regions
                 }
@@ -506,12 +510,15 @@ export function Recorder({ projectId }: { projectId: string }) {
                 onTakeTrimMove={clipInteraction.trim}
               />
             </CaptureTrackRow>
-            <TakesDisclosureRow
-              expanded={takesExpanded}
-              takeCount={takes.length}
-              onExpandedChange={setTakesExpanded}
-            />
-            {takesExpanded &&
+            {takes.length >= 2 && (
+              <TakesDisclosureRow
+                expanded={takesExpanded}
+                takeCount={takes.length}
+                onExpandedChange={setTakesExpanded}
+              />
+            )}
+            {takes.length >= 2 &&
+              takesExpanded &&
               takes.map((take) => (
                 <TakeTrackRow
                   key={take.id}

--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -469,10 +469,6 @@ export function Recorder({ projectId }: { projectId: string }) {
             >
               <TakeTimelineLane
                 takes={takes}
-                onResetTakeMix={(id) => {
-                  runtime.setClipMuted({ id, muted: false });
-                  runtime.setClipSoloed({ id, soloed: false });
-                }}
                 regions={
                   state.previewClipRegions ?? state.recordingTrack.regions
                 }
@@ -510,14 +506,14 @@ export function Recorder({ projectId }: { projectId: string }) {
                 onTakeTrimMove={clipInteraction.trim}
               />
             </CaptureTrackRow>
-            {takes.length >= 2 && (
+            {takes.length > 0 && (
               <TakesDisclosureRow
                 expanded={takesExpanded}
                 takeCount={takes.length}
                 onExpandedChange={setTakesExpanded}
               />
             )}
-            {takes.length >= 2 &&
+            {takes.length > 0 &&
               takesExpanded &&
               takes.map((take) => (
                 <TakeTrackRow

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -406,7 +406,6 @@ const TIMELINE_EPSILON = 1e-6;
 
 export function TakeTimelineLane({
   takes,
-  onResetTakeMix,
   regions,
   pendingRecording,
   captureStatus,
@@ -425,7 +424,6 @@ export function TakeTimelineLane({
   onTakeTrimMove,
 }: {
   takes: RecorderRuntimeState["recordingTrack"]["clips"];
-  onResetTakeMix: (id: string) => void;
   regions: RecorderRuntimeState["recordingTrack"]["regions"];
   pendingRecording: RecorderRuntimeState["pendingRecording"];
   captureStatus: RecorderRuntimeState["captureStatus"];
@@ -446,7 +444,6 @@ export function TakeTimelineLane({
   ) => RecorderClipTrimSnapshot;
   onTakeTrimMove: (snapshot: RecorderClipTrimSnapshot, delta: number) => void;
 }) {
-  const singleTake = takes.length === 1 ? takes[0] : undefined;
   const activeTakeIds = new Set(regions.map(({ clip: take }) => take.id));
   const activeTakes = takes.filter((take) => activeTakeIds.has(take.id));
 
@@ -462,19 +459,6 @@ export function TakeTimelineLane({
         subdivisionsPerBeat,
       })}
     >
-      {singleTake && (singleTake.muted || singleTake.soloed) && (
-        <button
-          type="button"
-          className="absolute top-2 left-2 z-20 rounded border border-neutral-600 bg-neutral-800 px-2 py-1 text-xs text-neutral-300 hover:bg-neutral-700"
-          onPointerDown={(event) => event.stopPropagation()}
-          onClick={(event) => {
-            event.stopPropagation();
-            onResetTakeMix(singleTake.id);
-          }}
-        >
-          {singleTake.name} · Reset take mute/solo
-        </button>
-      )}
       {takes.length === 0 && !pendingRecording && (
         <div className="absolute inset-0 grid place-items-center text-xs text-neutral-600">
           Enable input, place the playhead, then record

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -406,6 +406,7 @@ const TIMELINE_EPSILON = 1e-6;
 
 export function TakeTimelineLane({
   takes,
+  onResetTakeMix,
   regions,
   pendingRecording,
   captureStatus,
@@ -424,6 +425,7 @@ export function TakeTimelineLane({
   onTakeTrimMove,
 }: {
   takes: RecorderRuntimeState["recordingTrack"]["clips"];
+  onResetTakeMix: (id: string) => void;
   regions: RecorderRuntimeState["recordingTrack"]["regions"];
   pendingRecording: RecorderRuntimeState["pendingRecording"];
   captureStatus: RecorderRuntimeState["captureStatus"];
@@ -444,6 +446,7 @@ export function TakeTimelineLane({
   ) => RecorderClipTrimSnapshot;
   onTakeTrimMove: (snapshot: RecorderClipTrimSnapshot, delta: number) => void;
 }) {
+  const singleTake = takes.length === 1 ? takes[0] : undefined;
   const activeTakeIds = new Set(regions.map(({ clip: take }) => take.id));
   const activeTakes = takes.filter((take) => activeTakeIds.has(take.id));
 
@@ -459,6 +462,19 @@ export function TakeTimelineLane({
         subdivisionsPerBeat,
       })}
     >
+      {singleTake && (singleTake.muted || singleTake.soloed) && (
+        <button
+          type="button"
+          className="absolute top-2 left-2 z-20 rounded border border-neutral-600 bg-neutral-800 px-2 py-1 text-xs text-neutral-300 hover:bg-neutral-700"
+          onPointerDown={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            event.stopPropagation();
+            onResetTakeMix(singleTake.id);
+          }}
+        >
+          {singleTake.name} · Reset take mute/solo
+        </button>
+      )}
       {takes.length === 0 && !pendingRecording && (
         <div className="absolute inset-0 grid place-items-center text-xs text-neutral-600">
           Enable input, place the playhead, then record


### PR DESCRIPTION
- related to https://github.com/hi-ogawa/toy-midi/issues/464

This PR hides the Takes disclosure when Capture has no clips. Once a clip exists, the disclosure is available with source lanes collapsed by default, so a single take stays compact while its mute, solo, and deletion controls remain accessible by expanding it.

Single takes can still be moved, trimmed, selected, and deleted directly in the main lane.
