### PR TITLE
refactor: share recorder track rows and audio timeline lanes

### DIFF
--- a/src/components/recorder/index.tsx
+++ b/src/components/recorder/index.tsx
@@ -25,7 +25,6 @@ import { RecorderLocatorRow, useRecorderLocators } from "./recorder-locators";
 import { RecorderMixer } from "./recorder-mixer";
 import { RecorderPanel } from "./recorder-panel";
 import {
-  TakeTimelineLane,
   ReferenceTimelineRow,
   TimelineHeader,
   TimelineLane,
@@ -33,7 +32,6 @@ import {
 } from "./recorder-timeline";
 import {
   AudioTrackActions,
-  CaptureTrackRow,
   TakesDisclosureRow,
   TakeTrackRow,
   TrackRow,
@@ -362,6 +360,7 @@ export function Recorder({ projectId }: { projectId: string }) {
             {state.audioTracks.map((track, index) => (
               <TrackRow
                 key={track.id}
+                data-testid="recorder-audio-track-row"
                 title={`Audio ${index + 1}`}
                 height={track.height}
                 gain={track.gain}
@@ -396,6 +395,7 @@ export function Recorder({ projectId }: { projectId: string }) {
                   clips={track.clips}
                   regions={track.regions}
                   testId="audio"
+                  editSourceClips={false}
                   pixelsPerBeat={timeline.pixelsPerBeat}
                   beatsPerBar={timeline.beatsPerBar}
                   subdivisionsPerBeat={timeline.subdivisionsPerBeat}
@@ -431,20 +431,10 @@ export function Recorder({ projectId }: { projectId: string }) {
               </TrackRow>
             ))}
 
-            <CaptureTrackRow
-              route={input.route.label}
-              routeNeedsSetup={input.route.needsSetup}
+            <TrackRow
+              title="Capture"
               gain={state.recordingTrack.gain}
               height={state.recordingTrack.height}
-              inputActive={input.active}
-              inputAnalyser={runtime.captureInput?.analyser}
-              inputMonitoring={state.inputMonitoring}
-              inputToggleDisabled={
-                input.mutationPending ||
-                !input.initialized ||
-                flags.isRecording ||
-                (!input.active && input.route.needsSetup)
-              }
               muted={state.recordingTrack.muted}
               soloed={state.recordingTrack.soloed}
               effectsOpen={effects.openEffects.has("capture")}
@@ -452,11 +442,6 @@ export function Recorder({ projectId }: { projectId: string }) {
               onGainChange={(gain) =>
                 runtime.setTrackMix(state.recordingTrack.id, { gain })
               }
-              onInputSetup={() => setIsInputSetupOpen(true)}
-              onInputMonitoringChange={(monitoring) =>
-                runtime.setInputMonitoring(monitoring)
-              }
-              onInputToggle={input.toggle}
               onMutedChange={(muted) =>
                 runtime.setTrackMix(state.recordingTrack.id, { muted })
               }
@@ -466,15 +451,43 @@ export function Recorder({ projectId }: { projectId: string }) {
               onHeightChange={(height) =>
                 runtime.setTrackHeight(state.recordingTrack.id, height)
               }
+              input={{
+                route: input.route.label,
+                routeNeedsSetup: input.route.needsSetup,
+                inputActive: input.active,
+                inputAnalyser: runtime.captureInput?.analyser,
+                inputMonitoring: state.inputMonitoring,
+                inputToggleDisabled:
+                  input.mutationPending ||
+                  !input.initialized ||
+                  flags.isRecording ||
+                  (!input.active && input.route.needsSetup),
+                onInputSetup: () => setIsInputSetupOpen(true),
+                onInputMonitoringChange: (monitoring) =>
+                  runtime.setInputMonitoring(monitoring),
+                onInputToggle: input.toggle,
+              }}
             >
-              <TakeTimelineLane
-                takes={takes}
+              <AudioTimelineLane
+                clips={takes}
+                testId="comp"
+                editSourceClips
+                emptyLabel="Enable input, place the playhead, then record"
                 regions={
                   state.previewClipRegions ?? state.recordingTrack.regions
                 }
-                pendingRecording={state.pendingRecording}
-                captureStatus={state.captureStatus}
-                isTakeSelected={(id) =>
+                recordingPreview={
+                  state.pendingRecording
+                    ? {
+                        id: state.pendingRecording.id,
+                        label:
+                          state.captureStatus === "processing"
+                            ? "Finalizing..."
+                            : "Recording...",
+                      }
+                    : undefined
+                }
+                isClipSelected={(id) =>
                   clipInteraction.isSelected({ type: "clip", id })
                 }
                 beatsPerBar={timeline.beatsPerBar}
@@ -487,25 +500,25 @@ export function Recorder({ projectId }: { projectId: string }) {
                   clipInteraction.clear();
                   runtime.seek(position);
                 }}
-                onTakeDragStart={(id, additive) =>
+                onClipDragStart={(id, additive) =>
                   clipInteraction.startMove({
                     clip: { type: "clip", id },
                     additive,
                   })
                 }
-                onTakeClick={(id, additive) =>
+                onClipClick={(id, additive) =>
                   clipInteraction.select({ type: "clip", id }, additive)
                 }
-                onTakeDragMove={clipInteraction.move}
-                onTakeTrimStart={(id, edge) =>
+                onClipDragMove={clipInteraction.move}
+                onTrimStart={(id, edge) =>
                   clipInteraction.startTrim({
                     clip: { type: "clip", id },
                     edge,
                   })
                 }
-                onTakeTrimMove={clipInteraction.trim}
+                onTrimMove={clipInteraction.trim}
               />
-            </CaptureTrackRow>
+            </TrackRow>
             {takes.length > 0 && (
               <TakesDisclosureRow
                 expanded={takesExpanded}

--- a/src/components/recorder/recorder-timeline.tsx
+++ b/src/components/recorder/recorder-timeline.tsx
@@ -13,7 +13,6 @@ import { AudioView } from "../../lib/audio-view";
 import { clamp, snapToGrid } from "../../lib/music";
 import type { AudioClip, ClipRegion } from "../../lib/recorder/audio-clip";
 import type {
-  RecorderRuntimeState,
   RecorderLoopRange,
   RecorderLoopState,
   RecorderPunchRange,
@@ -404,137 +403,12 @@ type RecorderTimelineClip = {
 
 const TIMELINE_EPSILON = 1e-6;
 
-export function TakeTimelineLane({
-  takes,
-  regions,
-  pendingRecording,
-  captureStatus,
-  isTakeSelected,
-  beatsPerBar,
-  subdivisionsPerBeat,
-  pixelsPerBeat,
-  tempo,
-  viewportStartBeat,
-  viewportWidth,
-  onSeek,
-  onTakeDragStart,
-  onTakeClick,
-  onTakeDragMove,
-  onTakeTrimStart,
-  onTakeTrimMove,
-}: {
-  takes: RecorderRuntimeState["recordingTrack"]["clips"];
-  regions: RecorderRuntimeState["recordingTrack"]["regions"];
-  pendingRecording: RecorderRuntimeState["pendingRecording"];
-  captureStatus: RecorderRuntimeState["captureStatus"];
-  isTakeSelected: (id: string) => boolean;
-  beatsPerBar: number;
-  subdivisionsPerBeat: number;
-  pixelsPerBeat: number;
-  tempo: number;
-  viewportStartBeat: number;
-  viewportWidth: number;
-  onSeek: (position: number) => void;
-  onTakeDragStart: (id: string, additive: boolean) => RecorderClipMoveSnapshot;
-  onTakeClick: (id: string, additive: boolean) => void;
-  onTakeDragMove: (snapshot: RecorderClipMoveSnapshot, delta: number) => void;
-  onTakeTrimStart: (
-    id: string,
-    edge: "start" | "end",
-  ) => RecorderClipTrimSnapshot;
-  onTakeTrimMove: (snapshot: RecorderClipTrimSnapshot, delta: number) => void;
-}) {
-  const activeTakeIds = new Set(regions.map(({ clip: take }) => take.id));
-  const activeTakes = takes.filter((take) => activeTakeIds.has(take.id));
-
-  return (
-    <div
-      className="relative overflow-hidden bg-neutral-900"
-      {...getTimelineSurfaceProps({
-        beatsPerBar,
-        onSeek,
-        pixelsPerBeat,
-        tempo,
-        viewportStartBeat,
-        subdivisionsPerBeat,
-      })}
-    >
-      {takes.length === 0 && !pendingRecording && (
-        <div className="absolute inset-0 grid place-items-center text-xs text-neutral-600">
-          Enable input, place the playhead, then record
-        </div>
-      )}
-      <div className="pointer-events-none absolute inset-0">
-        {regions.map((region, index) => {
-          const { clip: take } = region;
-          const isPendingRecording = take.id === pendingRecording?.id;
-          const audioOffset = region.timelineStart - take.timelineOffset;
-          const previous = regions[index - 1];
-          const next = regions[index + 1];
-          const joinsPrevious =
-            previous !== undefined &&
-            Math.abs(previous.timelineEnd - region.timelineStart) <
-              TIMELINE_EPSILON;
-          const joinsNext =
-            next !== undefined &&
-            Math.abs(region.timelineEnd - next.timelineStart) <
-              TIMELINE_EPSILON;
-          return (
-            <TimelineClip
-              key={`${take.id}:${index}`}
-              clip={{
-                label: isPendingRecording
-                  ? captureStatus === "processing"
-                    ? "Finalizing..."
-                    : "Recording..."
-                  : take.name,
-                duration: region.timelineEnd - region.timelineStart,
-                offset: region.timelineStart,
-                audioOffset,
-                testId: isPendingRecording ? "recording" : "comp",
-                audioView: take.audioView,
-              }}
-              pixelsPerBeat={pixelsPerBeat}
-              viewportStartBeat={viewportStartBeat}
-              tempo={tempo}
-              viewportWidth={viewportWidth}
-              joinsPrevious={joinsPrevious}
-              joinsNext={joinsNext}
-              recording={isPendingRecording}
-            />
-          );
-        })}
-      </div>
-      {activeTakes.map((take) => (
-        <TimelineClip
-          key={take.id}
-          clip={{
-            label: take.name,
-            duration: take.trimEnd - take.trimStart,
-            offset: take.timelineOffset + take.trimStart,
-            testId: "take",
-          }}
-          pixelsPerBeat={pixelsPerBeat}
-          viewportStartBeat={viewportStartBeat}
-          tempo={tempo}
-          viewportWidth={viewportWidth}
-          onClipDragStart={(additive) => onTakeDragStart(take.id, additive)}
-          onClipClick={(additive) => onTakeClick(take.id, additive)}
-          onClipDragMove={onTakeDragMove}
-          onTrimStart={(edge) => onTakeTrimStart(take.id, edge)}
-          onTrimMove={onTakeTrimMove}
-          selected={isTakeSelected(take.id)}
-          hidePresentation
-        />
-      ))}
-    </div>
-  );
-}
-
 export function AudioTimelineLane({
   beatsPerBar,
   clips,
   regions,
+  editSourceClips,
+  recordingPreview,
   testId,
   emptyLabel,
   pixelsPerBeat,
@@ -553,6 +427,9 @@ export function AudioTimelineLane({
   beatsPerBar: number;
   clips: readonly AudioClip[];
   regions: readonly ClipRegion[];
+  // Comp editing targets complete source clips, including their covered portions.
+  editSourceClips: boolean;
+  recordingPreview?: { id: string; label: string };
   testId: RecorderTimelineClip["testId"];
   emptyLabel: string;
   pixelsPerBeat: number;
@@ -568,6 +445,8 @@ export function AudioTimelineLane({
   subdivisionsPerBeat: number;
   onSeek: (position: number) => void;
 }) {
+  const activeClipIds = new Set(regions.map(({ clip }) => clip.id));
+  const activeClips = clips.filter((clip) => activeClipIds.has(clip.id));
   return (
     <div
       className="relative overflow-hidden bg-neutral-900"
@@ -580,37 +459,87 @@ export function AudioTimelineLane({
         subdivisionsPerBeat,
       })}
     >
-      {clips.length === 0 && (
+      {clips.length === 0 && !recordingPreview && (
         <div className="absolute inset-0 grid place-items-center text-xs text-neutral-600">
           {emptyLabel}
         </div>
       )}
-      {regions.map((region, index) => {
-        const { clip } = region;
-        return (
+      <div
+        className={
+          editSourceClips ? "pointer-events-none absolute inset-0" : undefined
+        }
+      >
+        {regions.map((region, index) => {
+          const { clip } = region;
+          const isRecording = clip.id === recordingPreview?.id;
+          const previous = regions[index - 1];
+          const next = regions[index + 1];
+          return (
+            <TimelineClip
+              key={`${clip.id}:${index}`}
+              clip={{
+                label: isRecording ? recordingPreview.label : clip.name,
+                duration: region.timelineEnd - region.timelineStart,
+                offset: region.timelineStart,
+                audioOffset: region.timelineStart - clip.timelineOffset,
+                audioView: clip.audioView,
+                testId: isRecording ? "recording" : testId,
+              }}
+              pixelsPerBeat={pixelsPerBeat}
+              viewportStartBeat={viewportStartBeat}
+              tempo={tempo}
+              viewportWidth={viewportWidth}
+              recording={isRecording}
+              joinsPrevious={
+                editSourceClips &&
+                previous !== undefined &&
+                Math.abs(previous.timelineEnd - region.timelineStart) <
+                  TIMELINE_EPSILON
+              }
+              joinsNext={
+                editSourceClips &&
+                next !== undefined &&
+                Math.abs(region.timelineEnd - next.timelineStart) <
+                  TIMELINE_EPSILON
+              }
+              {...(!editSourceClips && {
+                selected: isClipSelected(clip.id),
+                onClipDragStart: (additive: boolean) =>
+                  onClipDragStart(clip.id, additive),
+                onClipClick: (additive: boolean) =>
+                  onClipClick(clip.id, additive),
+                onClipDragMove,
+                onTrimStart: (edge: "start" | "end") =>
+                  onTrimStart(clip.id, edge),
+                onTrimMove,
+              })}
+            />
+          );
+        })}
+      </div>
+      {editSourceClips &&
+        activeClips.map((clip) => (
           <TimelineClip
-            key={`${clip.id}:${index}`}
+            key={clip.id}
             clip={{
               label: clip.name,
-              duration: region.timelineEnd - region.timelineStart,
-              offset: region.timelineStart,
-              audioOffset: region.timelineStart - clip.timelineOffset,
-              audioView: clip.audioView,
-              testId,
+              duration: clip.trimEnd - clip.trimStart,
+              offset: clip.timelineOffset + clip.trimStart,
+              testId: "take",
             }}
             pixelsPerBeat={pixelsPerBeat}
             viewportStartBeat={viewportStartBeat}
             tempo={tempo}
             viewportWidth={viewportWidth}
-            selected={isClipSelected(clip.id)}
             onClipDragStart={(additive) => onClipDragStart(clip.id, additive)}
             onClipClick={(additive) => onClipClick(clip.id, additive)}
             onClipDragMove={onClipDragMove}
             onTrimStart={(edge) => onTrimStart(clip.id, edge)}
             onTrimMove={onTrimMove}
+            selected={isClipSelected(clip.id)}
+            hidePresentation
           />
-        );
-      })}
+        ))}
     </div>
   );
 }

--- a/src/components/recorder/recorder-tracks.tsx
+++ b/src/components/recorder/recorder-tracks.tsx
@@ -72,6 +72,8 @@ export function TrackRow({
   effectsOpen,
   onEffectsToggle,
   action,
+  input,
+  "data-testid": testId,
   onGainChange,
   onMutedChange,
   onSoloedChange,
@@ -85,7 +87,9 @@ export function TrackRow({
   soloed: boolean;
   effectsOpen: boolean;
   onEffectsToggle: () => void;
-  action: React.ReactNode;
+  action?: React.ReactNode;
+  input?: TrackInputControls;
+  "data-testid"?: string;
   onGainChange: (gain: number) => void;
   onMutedChange: (muted: boolean) => void;
   onSoloedChange: (soloed: boolean) => void;
@@ -103,16 +107,24 @@ export function TrackRow({
   });
   return (
     <div
-      data-testid="recorder-audio-track-row"
+      data-testid={testId}
       className="relative grid grid-cols-[15rem_1fr] border-b border-neutral-700"
       style={{ height }}
     >
-      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[1.75rem_auto] content-start gap-2 border-r border-neutral-700 bg-neutral-800 px-3 py-2">
+      <div
+        className={cn(
+          "sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] content-start gap-x-2 border-r border-neutral-700 bg-neutral-800 px-3 py-2",
+          input
+            ? "grid-rows-[1.75rem_1.5rem_0.75rem_1.5rem] gap-y-1"
+            : "grid-rows-[1.75rem_auto] gap-y-2",
+        )}
+      >
         <div className="min-w-0 self-center truncate text-xs font-semibold">
           {title}
         </div>
         <div className="flex self-center gap-1">
           {action}
+          {input && <TrackInputToggle {...input} />}
           <RecorderMixToggle
             active={muted}
             kind="mute"
@@ -134,6 +146,7 @@ export function TrackRow({
             className="size-7"
           />
         </div>
+        {input && <TrackInputRoute {...input} />}
         <label className="col-span-2 grid grid-cols-[1fr_3.5rem] items-center gap-2 text-[10px] text-neutral-400">
           <RecorderGainSlider
             label={`${title} gain`}
@@ -153,170 +166,106 @@ export function TrackRow({
   );
 }
 
-export function CaptureTrackRow({
-  route,
-  routeNeedsSetup,
-  height,
-  gain,
-  inputActive,
-  inputAnalyser,
-  inputMonitoring,
-  inputToggleDisabled,
-  muted,
-  soloed,
-  effectsOpen,
-  onEffectsToggle,
-  onGainChange,
-  onInputSetup,
-  onInputMonitoringChange,
-  onInputToggle,
-  onMutedChange,
-  onSoloedChange,
-  onHeightChange,
-  children,
-}: {
+interface TrackInputControls {
   route: string;
   routeNeedsSetup: boolean;
-  height: number;
-  gain: number;
   inputActive: boolean;
   inputAnalyser?: AudioAnalyser;
   inputMonitoring: boolean;
   inputToggleDisabled: boolean;
-  muted: boolean;
-  soloed: boolean;
-  effectsOpen: boolean;
-  onEffectsToggle: () => void;
-  onGainChange: (gain: number) => void;
   onInputSetup: () => void;
   onInputMonitoringChange: (monitoring: boolean) => void;
   onInputToggle: () => void;
-  onMutedChange: (muted: boolean) => void;
-  onSoloedChange: (soloed: boolean) => void;
-  onHeightChange: (height: number) => void;
-  children: React.ReactNode;
-}) {
-  const resizeRef = usePointerDrag({
-    onStart: (event) => {
-      event.preventDefault();
-      return { startClientY: event.clientY, startHeight: height };
-    },
-    onMove: (event, drag) => {
-      onHeightChange(drag.startHeight + event.clientY - drag.startClientY);
-    },
-  });
+}
+
+function TrackInputToggle({
+  inputActive,
+  inputToggleDisabled,
+  onInputToggle,
+}: TrackInputControls) {
   return (
-    <div className="relative grid grid-cols-[15rem_1fr]" style={{ height }}>
-      <div className="sticky left-0 z-20 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[1.75rem_1.5rem_0.75rem_1.5rem] content-start gap-x-2 gap-y-1 border-r border-neutral-700 bg-neutral-800 px-3 py-2">
-        <div className="min-w-0 self-center truncate text-xs font-semibold">
-          Capture
-        </div>
-        <div className="flex self-center gap-1">
-          <Button
-            data-testid="recorder-input-toggle"
-            disabled={inputToggleDisabled}
-            onClick={onInputToggle}
-            className={
-              inputActive
-                ? "size-7 border-neutral-600 bg-red-500/35 text-xs font-semibold text-neutral-300 hover:!bg-red-500/40 hover:!text-red-300"
-                : "size-7 border-neutral-600 text-xs font-semibold text-neutral-300 hover:bg-neutral-700"
-            }
-            title={inputActive ? "Disarm capture" : "Arm capture"}
-            aria-label={inputActive ? "Disarm capture" : "Arm capture"}
-            aria-pressed={inputActive}
-          >
-            R
-          </Button>
-          <RecorderMixToggle
-            active={muted}
-            kind="mute"
-            onClick={() => onMutedChange(!muted)}
-            className="size-7"
-            title={muted ? "Unmute Capture" : "Mute Capture"}
-          />
-          <RecorderMixToggle
-            active={soloed}
-            kind="solo"
-            onClick={() => onSoloedChange(!soloed)}
-            className="size-7"
-            title={soloed ? "Disable Capture solo" : "Solo Capture"}
-          />
-          <RecorderEffectsToggle
-            label="Capture"
-            open={effectsOpen}
-            onClick={onEffectsToggle}
-            className="size-7"
-          />
-        </div>
-        <div className="col-span-2 flex min-w-0 items-center gap-1">
-          <span
-            className={cn(
-              "min-w-0 flex-1 truncate text-[11px]",
-              routeNeedsSetup
-                ? "font-medium text-orange-300"
-                : "text-neutral-400",
-            )}
-          >
-            {route}
-          </span>
-          <button
-            type="button"
-            aria-label="Configure audio input"
-            title="Configure audio input"
-            onClick={onInputSetup}
-            className={cn(
-              "grid size-6 shrink-0 place-items-center rounded text-neutral-500 hover:bg-neutral-700 hover:text-neutral-200",
-              routeNeedsSetup && "text-orange-300 hover:text-orange-200",
-            )}
-          >
-            <Settings2Icon className="size-3.5" />
-          </button>
-          <button
-            type="button"
-            data-testid="recorder-input-monitor"
-            disabled={!inputActive}
-            aria-label={
-              inputMonitoring
+    <Button
+      data-testid="recorder-input-toggle"
+      disabled={inputToggleDisabled}
+      onClick={onInputToggle}
+      className={
+        inputActive
+          ? "size-7 border-neutral-600 bg-red-500/35 text-xs font-semibold text-neutral-300 hover:!bg-red-500/40 hover:!text-red-300"
+          : "size-7 border-neutral-600 text-xs font-semibold text-neutral-300 hover:bg-neutral-700"
+      }
+      title={inputActive ? "Disarm capture" : "Arm capture"}
+      aria-label={inputActive ? "Disarm capture" : "Arm capture"}
+      aria-pressed={inputActive}
+    >
+      R
+    </Button>
+  );
+}
+
+function TrackInputRoute({
+  route,
+  routeNeedsSetup,
+  inputActive,
+  inputAnalyser,
+  inputMonitoring,
+  onInputSetup,
+  onInputMonitoringChange,
+}: TrackInputControls) {
+  return (
+    <>
+      <div className="col-span-2 flex min-w-0 items-center gap-1">
+        <span
+          className={cn(
+            "min-w-0 flex-1 truncate text-[11px]",
+            routeNeedsSetup
+              ? "font-medium text-orange-300"
+              : "text-neutral-400",
+          )}
+        >
+          {route}
+        </span>
+        <button
+          type="button"
+          aria-label="Configure audio input"
+          title="Configure audio input"
+          onClick={onInputSetup}
+          className={cn(
+            "grid size-6 shrink-0 place-items-center rounded text-neutral-500 hover:bg-neutral-700 hover:text-neutral-200",
+            routeNeedsSetup && "text-orange-300 hover:text-orange-200",
+          )}
+        >
+          <Settings2Icon className="size-3.5" />
+        </button>
+        <button
+          type="button"
+          data-testid="recorder-input-monitor"
+          disabled={!inputActive}
+          aria-label={
+            inputMonitoring
+              ? "Disable input monitoring"
+              : "Enable input monitoring"
+          }
+          aria-pressed={inputMonitoring}
+          title={
+            inputActive
+              ? inputMonitoring
                 ? "Disable input monitoring"
-                : "Enable input monitoring"
-            }
-            aria-pressed={inputMonitoring}
-            title={
-              inputActive
-                ? inputMonitoring
-                  ? "Disable input monitoring"
-                  : "Enable input monitoring (use headphones to avoid feedback)"
-                : "Enable input first to monitor"
-            }
-            onClick={() => onInputMonitoringChange(!inputMonitoring)}
-            className={cn(
-              "grid size-6 shrink-0 place-items-center rounded text-neutral-500 hover:bg-neutral-700 hover:text-neutral-200 disabled:pointer-events-none disabled:opacity-30",
-              inputMonitoring &&
-                "bg-sky-500/25 text-sky-300 hover:bg-sky-500/35",
-            )}
-          >
-            <HeadphonesIcon className="size-3.5" />
-          </button>
-        </div>
-        <div className="col-span-2">
-          <InputMeter active={inputActive} analyser={inputAnalyser} compact />
-        </div>
-        <label className="col-span-2 grid grid-cols-[1fr_3.5rem] items-center gap-2 text-[10px] text-neutral-400">
-          <RecorderGainSlider
-            label="Capture gain"
-            gain={gain}
-            onGainChange={onGainChange}
-          />
-          <span className="text-right font-mono">{formatGainDb(gain)}</span>
-        </label>
+                : "Enable input monitoring (use headphones to avoid feedback)"
+              : "Enable input first to monitor"
+          }
+          onClick={() => onInputMonitoringChange(!inputMonitoring)}
+          className={cn(
+            "grid size-6 shrink-0 place-items-center rounded text-neutral-500 hover:bg-neutral-700 hover:text-neutral-200 disabled:pointer-events-none disabled:opacity-30",
+            inputMonitoring && "bg-sky-500/25 text-sky-300 hover:bg-sky-500/35",
+          )}
+        >
+          <HeadphonesIcon className="size-3.5" />
+        </button>
       </div>
-      {children}
-      <div
-        ref={resizeRef}
-        className="absolute inset-x-0 bottom-0 z-30 h-px cursor-ns-resize border-b border-neutral-700 after:absolute after:inset-x-0 after:-top-1 after:h-2"
-        title="Resize Capture"
-      />
-    </div>
+      <div className="col-span-2">
+        <InputMeter active={inputActive} analyser={inputAnalyser} compact />
+      </div>
+    </>
   );
 }
 


### PR DESCRIPTION
- related to https://github.com/hi-ogawa/toy-midi/issues/464

This PR shares the track control panel and audio timeline lane between imported tracks and the singleton Capture track. The common row owns mix controls, gain, effects, and resizing, with Capture supplying its input controls.

The shared lane renders resolved regions and an optional recording preview. It preserves direct region editing for imported audio and full-source hit areas over Capture’s comp, including partially covered takes. Runtime ownership, recording behavior, and take disclosure remain unchanged.
